### PR TITLE
CBEF-72 - Fix conflicting tests.

### DIFF
--- a/samples/ContosoUniversity/Data/DbInitializer.cs
+++ b/samples/ContosoUniversity/Data/DbInitializer.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Linq;
+using System.Xml;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 using ContosoUniversity.Models;
@@ -8,35 +9,46 @@ namespace ContosoUniversity.Data
 {
     public static class DbInitializer
     {
+        private static int _baseId = 0;
+        private static int ID_SPACE_SIZE = 1000;
+
+        static Student[] students = new Student[]
+        {
+            new Student { FirstMidName = "Carson",   LastName = "Alexander",
+                EnrollmentDate = DateTime.Parse("2010-09-01"), ID = 1 },
+            new Student { FirstMidName = "Meredith", LastName = "Alonso",
+                EnrollmentDate = DateTime.Parse("2012-09-01"), ID = 2 },
+            new Student { FirstMidName = "Arturo",   LastName = "Anand",
+                EnrollmentDate = DateTime.Parse("2013-09-01"), ID = 3 },
+            new Student { FirstMidName = "Gytis",    LastName = "Barzdukas",
+                EnrollmentDate = DateTime.Parse("2012-09-01"), ID = 4 },
+            new Student { FirstMidName = "Yan",      LastName = "Li",
+                EnrollmentDate = DateTime.Parse("2012-09-01"), ID = 5 },
+            new Student { FirstMidName = "Peggy",    LastName = "Justice",
+                EnrollmentDate = DateTime.Parse("2011-09-01"), ID = 6 },
+            new Student { FirstMidName = "Laura",    LastName = "Norman",
+                EnrollmentDate = DateTime.Parse("2013-09-01"), ID = 7 },
+            new Student { FirstMidName = "Nino",     LastName = "Olivetto",
+                EnrollmentDate = DateTime.Parse("2005-09-01"), ID = 8 }
+        };
+
+        public static Student[] someStudents()
+        {
+            _baseId = _baseId + ID_SPACE_SIZE;
+            return students.ToList().ConvertAll(s => new Student { FirstMidName = s.FirstMidName, LastName = s.LastName, ID = _baseId + s.ID }).ToArray();
+        }
+
         public static async Task Initialize(SchoolContext context)
         {
             //context.Database.EnsureCreated();
 
             // Look for any students.
+
             if (await context.Students.AnyAsync())
             {
                 return;   // DB has been seeded
             }
 
-            var students = new Student[]
-            {
-                new Student { FirstMidName = "Carson",   LastName = "Alexander",
-                    EnrollmentDate = DateTime.Parse("2010-09-01"), ID = 1 },
-                new Student { FirstMidName = "Meredith", LastName = "Alonso",
-                    EnrollmentDate = DateTime.Parse("2012-09-01"), ID = 2 },
-                new Student { FirstMidName = "Arturo",   LastName = "Anand",
-                    EnrollmentDate = DateTime.Parse("2013-09-01"), ID = 3 },
-                new Student { FirstMidName = "Gytis",    LastName = "Barzdukas",
-                    EnrollmentDate = DateTime.Parse("2012-09-01"), ID = 4 },
-                new Student { FirstMidName = "Yan",      LastName = "Li",
-                    EnrollmentDate = DateTime.Parse("2012-09-01"), ID = 5 },
-                new Student { FirstMidName = "Peggy",    LastName = "Justice",
-                    EnrollmentDate = DateTime.Parse("2011-09-01"), ID = 6 },
-                new Student { FirstMidName = "Laura",    LastName = "Norman",
-                    EnrollmentDate = DateTime.Parse("2013-09-01"), ID = 7 },
-                new Student { FirstMidName = "Nino",     LastName = "Olivetto",
-                    EnrollmentDate = DateTime.Parse("2005-09-01"), ID = 8 }
-            };
 
             context.Students.AddRange(students);
             await context.SaveChangesAsync();

--- a/tests/Couchbase.EntityFrameworkCore.FunctionalTests/ContosoUniversityTests/ContosoFixture.cs
+++ b/tests/Couchbase.EntityFrameworkCore.FunctionalTests/ContosoUniversityTests/ContosoFixture.cs
@@ -10,7 +10,14 @@ namespace Couchbase.EntityFrameworkCore.FunctionalTests.ContosoUniversityTests;
 
 public class ContosoFixture : IAsyncLifetime
 {
-    public ContosoContext DbContext { get; private set; }
+    public ClusterOptions ClusterOptions { get; private set; }
+    public ILogger logger { get; private set; }
+
+    public ContosoContext DbContext()
+    {
+        var contextOptions = new DbContextOptions<SchoolContext>();
+        return new ContosoContext(contextOptions, ClusterOptions);
+    }
     
     public Task InitializeAsync()
     {
@@ -19,15 +26,13 @@ public class ContosoFixture : IAsyncLifetime
             builder.AddFilter(level => level >= LogLevel.Debug);
             builder.AddFile("Logs/myapp-{Date}.txt", LogLevel.Debug);
         });
+        logger = loggerFactory.CreateLogger<ContosoFixture>();
 
-        var clusterOptions = new ClusterOptions()
+        ClusterOptions = new ClusterOptions()
             .WithConnectionString("http://127.0.0.1")
             .WithCredentials("Administrator", "password")
-            .WithLogging(loggerFactory)
-            .WithBuckets("contoso");
-
-        var contextOptions = new DbContextOptions<SchoolContext>();
-        DbContext = new ContosoContext(contextOptions, clusterOptions);
+            .WithLogging(loggerFactory);
+        
         return Task.CompletedTask;
     }
 

--- a/tests/Couchbase.EntityFrameworkCore.FunctionalTests/ContosoUniversityTests/DbInitializerTests.cs
+++ b/tests/Couchbase.EntityFrameworkCore.FunctionalTests/ContosoUniversityTests/DbInitializerTests.cs
@@ -19,6 +19,6 @@ public class DbInitializerTests
     [Fact]
     public void Test_Initialize()
     {
-        DbInitializer.Initialize(_contosoFixture.DbContext);
+       DbInitializer.Initialize(_contosoFixture.DbContext());
     }
 }

--- a/tests/Couchbase.EntityFrameworkCore.FunctionalTests/ContosoUniversityTests/StudentTests.cs
+++ b/tests/Couchbase.EntityFrameworkCore.FunctionalTests/ContosoUniversityTests/StudentTests.cs
@@ -1,11 +1,10 @@
 using ContosoUniversity;
+using ContosoUniversity.Data;
 using ContosoUniversity.Models;
-using Couchbase.EntityFrameworkCore.FunctionalTests.Fixtures;
 using Microsoft.EntityFrameworkCore;
-using Microsoft.EntityFrameworkCore.TestModels.UpdatesModel;
+using Microsoft.Extensions.Logging;
 using Xunit;
 using Xunit.Abstractions;
-using Person = Microsoft.EntityFrameworkCore.TestModels.UpdatesModel.Person;
 
 namespace Couchbase.EntityFrameworkCore.FunctionalTests.ContosoUniversityTests;
 
@@ -28,127 +27,173 @@ public class StudentTests : IAsyncDisposable, IDisposable
         string searchString,
         int? pageNumber)
     {
-        if (searchString != null)
+        ContosoContext context = _contosoFixture.DbContext();
+        try
         {
-            pageNumber = 1;
-        }
-        else
-        {
-            searchString = currentFilter;
-        }
-        var students = from s in _contosoFixture.DbContext.Students
-            select s;
-        if (!String.IsNullOrEmpty(searchString))
-        {
-            students = students.Where(s => s.LastName.Contains(searchString)
-                                           || s.FirstMidName.Contains(searchString));
-        }
-        switch (sortOrder)
-        {
-            case "name_desc":
-                students = students.OrderByDescending(s => s.LastName);
-                break;
-            case "Date":
-                students = students.OrderBy(s => s.EnrollmentDate);
-                break;
-            case "date_desc":
-                students = students.OrderByDescending(s => s.EnrollmentDate);
-                break;
-            default:
-                students = students.OrderBy(s => s.LastName);
-                break;
-        }
+            if (searchString != null)
+            {
+                pageNumber = 1;
+            }
+            else
+            {
+                searchString = currentFilter;
+            }
 
-        int pageSize = 3;
-        var paginatedList =
-            await PaginatedList<Student>.CreateAsync(students.AsNoTracking(), pageNumber ?? 1, pageSize);
-        
-        Assert.Equal(8, paginatedList.Count);
+            var students = from s in context.Students
+                select s;
+            if (!String.IsNullOrEmpty(searchString))
+            {
+                students = students.Where(s => s.LastName.Contains(searchString)
+                                               || s.FirstMidName.Contains(searchString));
+            }
+
+            switch (sortOrder)
+            {
+                case "name_desc":
+                    students = students.OrderByDescending(s => s.LastName);
+                    break;
+                case "Date":
+                    students = students.OrderBy(s => s.EnrollmentDate);
+                    break;
+                case "date_desc":
+                    students = students.OrderByDescending(s => s.EnrollmentDate);
+                    break;
+                default:
+                    students = students.OrderBy(s => s.LastName);
+                    break;
+            }
+
+            int pageSize = 3;
+            var paginatedList =
+                await PaginatedList<Student>.CreateAsync(students.AsNoTracking(), pageNumber ?? 1,
+                    pageSize);
+
+            Assert.Equal(8, paginatedList.Count);
+        }
+        finally
+        {
+            if (context != null)
+            {
+                context.Dispose();
+            }
+        }
     }
 
     [Fact]
     public async Task Test_PersonStudent_AddRange()
     {
-        var context = _contosoFixture.DbContext;
-        context.Students.AddRange(_students);
+        var context = _contosoFixture.DbContext();
+        try
+        {
+            var students = DbInitializer.someStudents();
+            await CleanUp(students);
 
-        var count = await context.SaveChangesAsync();
-        Assert.Equal(8, count);
+            context.Students.AddRange(students);
+            var count = await context.SaveChangesAsync();
+            Assert.Equal(8, count);
+
+            context.Students.RemoveRange(students);
+            var count1 = await context.SaveChangesAsync();
+            Assert.Equal(8, count1);
+
+            Assert.Equal(0, await context.Students.CountAsync());
+        }
+        finally
+        {
+            if (context != null)
+            {
+                context.Dispose();
+            }
+        }
     }
 
     [Fact]
     public async Task Test_PersonStudent_RemoveRange()
     {
-        var context = _contosoFixture.DbContext;
-        context.Students.AddRange(_students);
+        var context = _contosoFixture.DbContext();
+        try
+        {
+            var students = DbInitializer.someStudents();
+            await CleanUp(students);
 
-        var count = await context.SaveChangesAsync();
-        Assert.Equal(8, count);
+            context.Students.AddRange(students);
+            var count = await context.SaveChangesAsync();
+            Assert.Equal(8, count);
 
-        context.Students.RemoveRange(_students);
-        var count1 = await context.SaveChangesAsync();
+            context.Students.RemoveRange(students);
+            var count1 = await context.SaveChangesAsync();
+            Assert.Equal(8, count1);
 
-        Assert.Equal(8, count1);
-        Assert.Equal(0, await context.Students.CountAsync());
+            Assert.Equal(0, await context.Students.CountAsync());
+        }
+        finally
+        {
+            if (context != null)
+            {
+                context.Dispose();
+            }
+        }
     }
-    
+
     [Fact]
     public async Task Test_PersonStudent_UpdateRange()
     {
-        var context = _contosoFixture.DbContext;
-        context.Students.AddRange(_students);
-
-        var count = await context.SaveChangesAsync();
-      //  Assert.Equal(8, count);
-
-        var results = await context.Students.ToListAsync();
-
-        context.Students.RemoveRange(_students);
-        var count1 = await context.SaveChangesAsync();
-
-        Assert.Equal(8, count1);
-    }
-
-    #region Data
-    
-    Student[] _students =
-    [
-        new Student { FirstMidName = "Carson",   LastName = "Alexander",
-            EnrollmentDate = DateTime.Parse("2010-09-01"), ID = 8 },
-        new Student { FirstMidName = "Meredith", LastName = "Alonso",
-            EnrollmentDate = DateTime.Parse("2012-09-01"), ID = 1 },
-        new Student { FirstMidName = "Arturo",   LastName = "Anand",
-            EnrollmentDate = DateTime.Parse("2013-09-01"), ID = 2 },
-        new Student { FirstMidName = "Gytis",    LastName = "Barzdukas",
-            EnrollmentDate = DateTime.Parse("2012-09-01"), ID = 3 },
-        new Student { FirstMidName = "Yan",      LastName = "Li",
-            EnrollmentDate = DateTime.Parse("2012-09-01"), ID = 4 },
-        new Student { FirstMidName = "Peggy",    LastName = "Justice",
-            EnrollmentDate = DateTime.Parse("2011-09-01"), ID = 5 },
-        new Student { FirstMidName = "Laura",    LastName = "Norman",
-            EnrollmentDate = DateTime.Parse("2013-09-01"), ID = 6 },
-        new Student { FirstMidName = "Nino",     LastName = "Olivetto",
-            EnrollmentDate = DateTime.Parse("2005-09-01"), ID = 7 }
-    ];
-
-    #endregion
-
-    public async ValueTask DisposeAsync()
-    {
+        var context = _contosoFixture.DbContext();
         try
         {
-            var context = _contosoFixture.DbContext;
-            context.Students.RemoveRange(_students);
-            await context.SaveChangesAsync();
+            var students = DbInitializer.someStudents();
+            await CleanUp(students);
+
+            context.Students.AddRange(students);
+            var count = await context.SaveChangesAsync();
+            Assert.Equal(8, count);
+
+            context.Students.UpdateRange(students);
+            var count1 = await context.SaveChangesAsync();
+            Assert.Equal(8, count1);
+
+            context.Students.RemoveRange(students);
+            var count2 = await context.SaveChangesAsync();
+            Assert.Equal(8, count2);
+
+            Assert.Equal(0, await context.Students.CountAsync());
         }
-        catch (Exception e)
+        finally
         {
-            _outputHelper.WriteLine(e.Message);
+            if (context != null)
+            {
+                context.Dispose();
+            }
         }
+    }
+    
+    public async ValueTask DisposeAsync()
+    {
     }
 
     public void Dispose()
     {
         DisposeAsync().GetAwaiter().GetResult();
+    }
+
+    public async ValueTask CleanUp(Student[] students)
+    {
+        var context = _contosoFixture.DbContext();
+        try
+        {
+            context.Students.RemoveRange(students);
+            await context.SaveChangesAsync();
+        }
+        catch (Exception e)
+        {
+            _contosoFixture.logger.LogDebug(e.Message);
+        }
+        finally
+        {
+            if (context != null)
+            {
+                context.Dispose();
+            }
+        }
     }
 }

--- a/tests/Couchbase.EntityFrameworkCore.FunctionalTests/QueryTests.cs
+++ b/tests/Couchbase.EntityFrameworkCore.FunctionalTests/QueryTests.cs
@@ -102,28 +102,31 @@ public class QueryTests
             .WithConnectionString("couchbase://localhost")
             .WithCredentials("Administrator", "password"));
 
-        context.Add(new Session
+        var s1 = new Session
         {
             Category = "disabled",
             SessionId = 1,
             TenantId = "1"
-        });
-        context.Add(new Session
+        };
+        context.Add(s1);
+
+        var s2 = new Session
         {
             Category = "xydisabled",
             SessionId = 2,
             TenantId = "2"
-        });
+        };
+        context.Add(s2);
 
         var count = await context.SaveChangesAsync();
 
-        var position = 2;
+        var position = 1;
         var nextPage = await context.Sessions
-            .OrderBy(s => s.Id)
+            .OrderBy(s => s.Category)
             .Skip(position)
             .Take(10)
             .ToListAsync();
-        _outputHelper.WriteLine(nextPage.First().Category);
+        Assert.Equal(s2.Category, nextPage.First().Category);
     }
 
     [Fact]


### PR DESCRIPTION
CBEF-72 - Fix conflicting tests

Motivation
==========
The tests run concurrently so the context and documentIds used cannot clash.

Changes
=======
DbContext creates a new context.
Each test uses a list of unique students.

Change-Id: I21d0cba2e1098fc71540bb599e902c746cf11f97