### PR TITLE
CBEF-85 - Run Query tests in async mode only.

### DIFF
--- a/tests/Couchbase.EntityFrameworkCore.FunctionalTests/Query/CouchbaseNorthwindAsTrackingTestBase.cs
+++ b/tests/Couchbase.EntityFrameworkCore.FunctionalTests/Query/CouchbaseNorthwindAsTrackingTestBase.cs
@@ -12,6 +12,9 @@ namespace Couchbase.EntityFrameworkCore.FunctionalTests.Query;
 public abstract class CouchbaseNorthwindAsTrackingQueryTestBase<TFixture> : IClassFixture<TFixture>
     where TFixture : NorthwindQueryCouchbaseFixture<NoopModelCustomizer>, new()
 {
+
+    public static IEnumerable<object[]> IsAsyncData = new[] { new object[] { true } };
+
     protected CouchbaseNorthwindAsTrackingQueryTestBase(TFixture fixture)
     {
         Fixture = fixture;

--- a/tests/Couchbase.EntityFrameworkCore.FunctionalTests/Query/CouchbaseNorthwindChangeTrackingQueryTestBase.cs
+++ b/tests/Couchbase.EntityFrameworkCore.FunctionalTests/Query/CouchbaseNorthwindChangeTrackingQueryTestBase.cs
@@ -13,6 +13,9 @@ using Microsoft.EntityFrameworkCore.TestModels.Northwind;
 public abstract class CouchbaseNorthwindChangeTrackingQueryTestBase<TFixture> : IClassFixture<TFixture>
     where TFixture :  NorthwindQueryCouchbaseFixture<NoopModelCustomizer>, new()
 {
+
+    public static IEnumerable<object[]> IsAsyncData = new[] { new object[] { true } };
+
     protected CouchbaseNorthwindChangeTrackingQueryTestBase(TFixture fixture)
     {
         Fixture = fixture;

--- a/tests/Couchbase.EntityFrameworkCore.FunctionalTests/Query/CouchbaseNorthwindCompiledQueryTestBase.cs
+++ b/tests/Couchbase.EntityFrameworkCore.FunctionalTests/Query/CouchbaseNorthwindCompiledQueryTestBase.cs
@@ -16,6 +16,9 @@ namespace Couchbase.EntityFrameworkCore.FunctionalTests.Query;
 public abstract class CouchbaseNorthwindCompiledQueryTestBase<TFixture> : IClassFixture<TFixture>
     where TFixture : CouchbaseNorthwindQueryFixtureBase<NoopModelCustomizer>, new()
 {
+
+    public static IEnumerable<object[]> IsAsyncData = new[] {new object[] { true } };
+
     protected CouchbaseNorthwindCompiledQueryTestBase(TFixture fixture)
     {
         Fixture = fixture;
@@ -528,7 +531,7 @@ public abstract class CouchbaseNorthwindCompiledQueryTestBase<TFixture> : IClass
             Assert.True(query(context, "ALFKI"));
         }
     }
-    
+
     [ConditionalFact]
     public virtual async Task Compiled_query_with_max_parameters()
     {
@@ -841,6 +844,4 @@ public abstract class CouchbaseNorthwindCompiledQueryTestBase<TFixture> : IClass
 
     protected NorthwindContext CreateContext()
         => Fixture.CreateContext();
-
-    public static IEnumerable<object[]> IsAsyncData = new[] { new object[] { false }, new object[] { true } };
 }

--- a/tests/Couchbase.EntityFrameworkCore.FunctionalTests/Query/CouchbaseNorthwindFunctionsQueryTestBase.cs
+++ b/tests/Couchbase.EntityFrameworkCore.FunctionalTests/Query/CouchbaseNorthwindFunctionsQueryTestBase.cs
@@ -26,12 +26,13 @@ namespace Couchbase.EntityFrameworkCore.FunctionalTests.Query;
 public abstract class CouchbaseNorthwindFunctionsQueryTestBase<TFixture> : QueryTestBase<TFixture>
     where TFixture : NorthwindQueryFixtureBase<NoopModelCustomizer>, new()
 {
+
+    public new static IEnumerable<object[]> IsAsyncData = new[] { new object[] { true } };
+
     protected CouchbaseNorthwindFunctionsQueryTestBase(TFixture fixture)
         : base(fixture)
     {
     }
-    
-    public new static IEnumerable<object[]> IsAsyncData = new[] { new object[] { true } };
 
     protected NorthwindContext CreateContext()
         => Fixture.CreateContext();

--- a/tests/Couchbase.EntityFrameworkCore.FunctionalTests/Query/CouchbaseNorthwindQueryFixtureBase.cs
+++ b/tests/Couchbase.EntityFrameworkCore.FunctionalTests/Query/CouchbaseNorthwindQueryFixtureBase.cs
@@ -11,9 +11,12 @@ using Xunit;
 
 namespace Couchbase.EntityFrameworkCore.FunctionalTests.Query;
 
-public abstract class CouchbaseNorthwindQueryFixtureBase<TModelCustomizer> : SharedStoreFixtureBase<NorthwindContext>, IFilteredQueryFixtureBase
+public abstract class CouchbaseNorthwindQueryFixtureBase<TModelCustomizer> : NorthwindQueryRelationalFixture<TModelCustomizer>, IFilteredQueryFixtureBase
     where TModelCustomizer : IModelCustomizer, new()
 {
+
+    public static IEnumerable<object[]> IsAsyncData = new[] { new object[] { true } };
+
     public Func<DbContext> GetContextCreator()
         => () => CreateContext();
 

--- a/tests/Couchbase.EntityFrameworkCore.FunctionalTests/Query/CouchbaseNorthwindWhereQueryTestBase.cs
+++ b/tests/Couchbase.EntityFrameworkCore.FunctionalTests/Query/CouchbaseNorthwindWhereQueryTestBase.cs
@@ -18,6 +18,9 @@ namespace Couchbase.EntityFrameworkCore.FunctionalTests.Query;
 public abstract class CouchbaseNorthwindWhereQueryTestBase<TFixture> : CouchbaseQueryTestBase<TFixture>
     where TFixture : NorthwindQueryFixtureBase<NoopModelCustomizer>, new()
 {
+
+    public static IEnumerable<object[]> IsAsyncData = new[] { new object[] { true } };
+
     protected CouchbaseNorthwindWhereQueryTestBase(TFixture fixture)
         : base(fixture)
     {
@@ -1656,6 +1659,7 @@ public abstract class CouchbaseNorthwindWhereQueryTestBase<TFixture> : Couchbase
             async,
             ss => ss.Set<Order>().Select(o => o.OrderDate.Value.TimeOfDay));
 
+    /* TODO: MSR has compile error
     [ConditionalTheory]
     [MemberData(nameof(IsAsyncData))]
     public virtual Task TypeBinary_short_circuit(bool async)
@@ -1669,7 +1673,7 @@ public abstract class CouchbaseNorthwindWhereQueryTestBase<TFixture> : Couchbase
 #pragma warning restore CS0184 // 'is' expression's given expression is never of the provided type
             assertEmpty: true);
     }
-
+*/
     [ConditionalTheory]
     [MemberData(nameof(IsAsyncData))]
     public virtual Task Decimal_cast_to_double_works(bool async)

--- a/tests/Couchbase.EntityFrameworkCore.FunctionalTests/Query/NorthwindGroupByQueryCouchbaseTest.cs
+++ b/tests/Couchbase.EntityFrameworkCore.FunctionalTests/Query/NorthwindGroupByQueryCouchbaseTest.cs
@@ -19,6 +19,8 @@ public class NorthwindGroupByQueryCouchbaseTest : NorthwindGroupByQueryRelationa
         Fixture.TestSqlLoggerFactory.SetTestOutputHelper(testOutputHelper);
     }
 
+    public static IEnumerable<object[]> IsAsyncData = new[] { new object[] { true } };
+
     public override Task Select_uncorrelated_collection_with_groupby_multiple_collections_work(bool async)
         => AssertApplyNotSupported(() => base.Select_uncorrelated_collection_with_groupby_multiple_collections_work(async));
 

--- a/tests/Couchbase.EntityFrameworkCore.FunctionalTests/Query/NorthwindIncludeNoTrackingQueryCouchbaseTest.cs
+++ b/tests/Couchbase.EntityFrameworkCore.FunctionalTests/Query/NorthwindIncludeNoTrackingQueryCouchbaseTest.cs
@@ -13,6 +13,9 @@ namespace Couchbase.EntityFrameworkCore.FunctionalTests.Query;
 public class NorthwindIncludeNoTrackingQueryCouchbaseTest : NorthwindIncludeNoTrackingQueryTestBase<
     NorthwindQueryCouchbaseFixture<NoopModelCustomizer>>
 {
+
+    public static IEnumerable<object[]> IsAsyncData = new[] { new object[] { true } };
+
     public NorthwindIncludeNoTrackingQueryCouchbaseTest(
         NorthwindQueryCouchbaseFixture<NoopModelCustomizer> fixture,
         ITestOutputHelper testOutputHelper)

--- a/tests/Couchbase.EntityFrameworkCore.FunctionalTests/Query/NorthwindJoinQueryCouchbaseTest.cs
+++ b/tests/Couchbase.EntityFrameworkCore.FunctionalTests/Query/NorthwindJoinQueryCouchbaseTest.cs
@@ -11,6 +11,9 @@ namespace Couchbase.EntityFrameworkCore.FunctionalTests.Query;
 
 public class NorthwindJoinQueryCouchbaseTest : NorthwindJoinQueryRelationalTestBase<NorthwindQueryCouchbaseFixture<NoopModelCustomizer>>
 {
+
+    public static IEnumerable<object[]> IsAsyncData = new[] { new object[] { true } };
+
     public NorthwindJoinQueryCouchbaseTest(NorthwindQueryCouchbaseFixture<NoopModelCustomizer> fixture, ITestOutputHelper testOutputHelper)
         : base(fixture)
     {

--- a/tests/Couchbase.EntityFrameworkCore.FunctionalTests/Query/NorthwindKeylessEntitiesQueryCouchbaseTest.cs
+++ b/tests/Couchbase.EntityFrameworkCore.FunctionalTests/Query/NorthwindKeylessEntitiesQueryCouchbaseTest.cs
@@ -11,6 +11,9 @@ namespace Couchbase.EntityFrameworkCore.FunctionalTests.Query;
 public class NorthwindKeylessEntitiesQueryCouchbaseTest : NorthwindKeylessEntitiesQueryRelationalTestBase<
     NorthwindQueryCouchbaseFixture<NoopModelCustomizer>>
 {
+
+    public static IEnumerable<object[]> IsAsyncData = new[] { new object[] { true } };
+
     public NorthwindKeylessEntitiesQueryCouchbaseTest(
         NorthwindQueryCouchbaseFixture<NoopModelCustomizer> fixture,
         ITestOutputHelper testOutputHelper)

--- a/tests/Couchbase.EntityFrameworkCore.FunctionalTests/Query/NorthwindMiscellaneousQueryCouchbaseTest.cs
+++ b/tests/Couchbase.EntityFrameworkCore.FunctionalTests/Query/NorthwindMiscellaneousQueryCouchbaseTest.cs
@@ -15,6 +15,9 @@ namespace Couchbase.EntityFrameworkCore.FunctionalTests.Query;
 public class NorthwindMiscellaneousQueryCouchbaseTest : NorthwindMiscellaneousQueryRelationalTestBase<
     NorthwindQueryCouchbaseFixture<NoopModelCustomizer>>
 {
+
+    public static IEnumerable<object[]> IsAsyncData = new[] { new object[] { true } };
+
     public NorthwindMiscellaneousQueryCouchbaseTest(
         NorthwindQueryCouchbaseFixture<NoopModelCustomizer> fixture,
         ITestOutputHelper testOutputHelper)

--- a/tests/Couchbase.EntityFrameworkCore.FunctionalTests/Query/NorthwindNavigationsQueryCouchbaseTest.cs
+++ b/tests/Couchbase.EntityFrameworkCore.FunctionalTests/Query/NorthwindNavigationsQueryCouchbaseTest.cs
@@ -9,6 +9,9 @@ namespace Couchbase.EntityFrameworkCore.FunctionalTests.Query;
 public class NorthwindNavigationsQueryCouchbaseTest : NorthwindNavigationsQueryRelationalTestBase<
     NorthwindQueryCouchbaseFixture<NoopModelCustomizer>>
 {
+
+    public static IEnumerable<object[]> IsAsyncData = new[] { new object[] { true } };
+
     public NorthwindNavigationsQueryCouchbaseTest(NorthwindQueryCouchbaseFixture<NoopModelCustomizer> fixture)
         : base(fixture)
     {

--- a/tests/Couchbase.EntityFrameworkCore.FunctionalTests/Query/NorthwindQueryCouchbaseFixture.cs
+++ b/tests/Couchbase.EntityFrameworkCore.FunctionalTests/Query/NorthwindQueryCouchbaseFixture.cs
@@ -10,10 +10,12 @@ using Microsoft.Extensions.Logging;
 using TestSqlLoggerFactory = Microsoft.EntityFrameworkCore.TestUtilities.TestSqlLoggerFactory;
 
 namespace Couchbase.EntityFrameworkCore.FunctionalTests.Query;
-
-public class NorthwindQueryCouchbaseFixture<TModelCustomizer> : NorthwindQueryRelationalFixture<TModelCustomizer>
+public class NorthwindQueryCouchbaseFixture<TModelCustomizer> :CouchbaseNorthwindQueryFixtureBase<TModelCustomizer>
     where TModelCustomizer : IModelCustomizer, new()
 {
+
+    public static IEnumerable<object[]> IsAsyncData = new[] { new object[] { true } };
+
     public NorthwindQueryCouchbaseFixture()
     {
     }
@@ -51,4 +53,7 @@ public class NorthwindQueryCouchbaseFixture<TModelCustomizer> : NorthwindQueryRe
 
         modelBuilder.ConfigureToCouchbase(context);
     }
+
+    protected override void Seed(NorthwindContext context)
+        => base.Seed(context);
 }


### PR DESCRIPTION
Motivation
==========
Because sync is not supported, run tests in async
mode only.

Changes
======
Define IsAsyncData in test classes.

Change-Id: I645030f4bc7fada3fa4c655f56f033230e313b4c