### PR TITLE
Completely implement CouchbaseCommand

### DIFF
--- a/src/Couchbase.EntityFrameworkCore/Infrastructure/Internal/CouchbaseOptionsExtension.cs
+++ b/src/Couchbase.EntityFrameworkCore/Infrastructure/Internal/CouchbaseOptionsExtension.cs
@@ -6,6 +6,7 @@ using Couchbase;
 using Couchbase.EntityFrameworkCore.Extensions;
 using Couchbase.Extensions.DependencyInjection;
 using Couchbase.EntityFrameworkCore.Utils;
+using Couchbase.Core.IO.Serializers;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 
 namespace Couchbase.EntityFrameworkCore.Infrastructure.Internal;
@@ -39,6 +40,7 @@ public class CouchbaseOptionsExtension: RelationalOptionsExtension
         {
             options.WithLogging(_couchbaseDbContextOptionsBuilder.ClusterOptions.Logging);
             options.WithConnectionString(_couchbaseDbContextOptionsBuilder.ClusterOptions.ConnectionString);
+            options.WithSerializer(SystemTextJsonSerializer.Create());
             if (_couchbaseDbContextOptionsBuilder.ClusterOptions.Authenticator == null)
             {
                 options.WithCredentials(_couchbaseDbContextOptionsBuilder.ClusterOptions.UserName, _couchbaseDbContextOptionsBuilder.ClusterOptions.Password);

--- a/src/Couchbase.EntityFrameworkCore/Storage/Internal/CouchbaseCommand.cs
+++ b/src/Couchbase.EntityFrameworkCore/Storage/Internal/CouchbaseCommand.cs
@@ -1,5 +1,6 @@
 using System.Data;
 using System.Data.Common;
+using System.Text.Json;
 using Couchbase.Query;
 using Couchbase.EntityFrameworkCore.Internal;
 
@@ -7,52 +8,152 @@ namespace Couchbase.EntityFrameworkCore.Storage.Internal;
 
 public class CouchbaseCommand : DbCommand
 {
+    private CancellationTokenSource? _cancellationTokenSource;
+    private string _commandText = string.Empty;
+
     public new virtual CouchbaseParameterCollection Parameters
         => field ??= new CouchbaseParameterCollection();
 
-    internal ICluster Cluster { get; set; }
+    internal ICluster? Cluster { get; set; }
+
+    public override string CommandText
+    {
+        get => _commandText;
+        set => _commandText = value ?? string.Empty;
+    }
+
+    public override int CommandTimeout { get; set; }
+
+    public override CommandType CommandType { get; set; } = CommandType.Text;
+
+    public override UpdateRowSource UpdatedRowSource { get; set; } = UpdateRowSource.None;
+
+    protected override DbConnection? DbConnection { get; set; }
+
+    protected override DbParameterCollection DbParameterCollection => Parameters;
+
+    protected override DbTransaction? DbTransaction { get; set; }
+
+    public override bool DesignTimeVisible { get; set; }
 
     public override void Cancel()
     {
-        throw new NotImplementedException();
-    }
-
-    public override int ExecuteNonQuery()
-    {
-        return AsyncHelper.RunSync(async ValueTask<int> (state) =>
-            {
-                var options = new QueryOptions();
-                foreach (var dbParameter in state.Parameters)
-                {
-                    if (dbParameter is CouchbaseParameter parameter)
-                    {
-                        options.Parameter(parameter.ParameterName, parameter.Value!);
-                    }
-                }
-
-                var result = await state.Cluster.QueryAsync<int>(state.CommandText, options).ConfigureAwait(false);
-                return await result.Rows.CountAsync(CancellationToken.None).ConfigureAwait(false);
-            }, this);
-    }
-
-    public override object? ExecuteScalar()
-    {
-        throw new NotImplementedException();
+        _cancellationTokenSource?.Cancel();
     }
 
     public override void Prepare()
     {
-        throw new NotImplementedException();
+        // No-op: Couchbase N1QL auto-prepares queries.
+        // The ADO.NET contract treats Prepare as a hint, not a requirement.
     }
 
-    public override string CommandText { get; set; }
-    public override int CommandTimeout { get; set; }
-    public override CommandType CommandType { get; set; }
-    public override UpdateRowSource UpdatedRowSource { get; set; }
-    protected override DbConnection? DbConnection { get; set; }
-    protected override DbParameterCollection DbParameterCollection => Parameters;
-    protected override DbTransaction? DbTransaction { get; set; }
-    public override bool DesignTimeVisible { get; set; }
+    public override Task PrepareAsync(CancellationToken cancellationToken = default)
+    {
+        // No-op for Couchbase
+        return Task.CompletedTask;
+    }
+
+    public override int ExecuteNonQuery()
+    {
+        return AsyncHelper.RunSync(
+            static state => state.ExecuteNonQueryAsync(CancellationToken.None),
+            this);
+    }
+
+    public override async Task<int> ExecuteNonQueryAsync(CancellationToken cancellationToken)
+    {
+        using var linkedCts = CreateLinkedTokenSource(cancellationToken);
+        var options = BuildQueryOptions(linkedCts.Token);
+
+        var cluster = ResolveCluster();
+        var result = await cluster.QueryAsync<object>(CommandText, options).ConfigureAwait(false);
+
+        // Drain all rows to ensure query completes
+        await foreach (var _ in result.Rows.WithCancellation(linkedCts.Token).ConfigureAwait(false))
+        {
+        }
+
+        // Return mutation count from metrics if available, otherwise -1
+        var metrics = result.MetaData?.Metrics;
+        if (metrics != null)
+        {
+            return (int)metrics.MutationCount;
+        }
+
+        return -1;
+    }
+
+    public override object? ExecuteScalar()
+    {
+        return AsyncHelper.RunSync(
+            static state => state.ExecuteScalarAsync(CancellationToken.None),
+            this);
+    }
+
+    public override async Task<object?> ExecuteScalarAsync(CancellationToken cancellationToken)
+    {
+        using var linkedCts = CreateLinkedTokenSource(cancellationToken);
+        var options = BuildQueryOptions(linkedCts.Token);
+
+        var cluster = ResolveCluster();
+        var result = await cluster.QueryAsync<JsonElement>(CommandText, options).ConfigureAwait(false);
+
+        await foreach (var row in result.Rows.WithCancellation(linkedCts.Token).ConfigureAwait(false))
+        {
+            return ExtractScalarValue(row);
+        }
+
+        return null;
+    }
+
+    private static object? ExtractScalarValue(JsonElement element)
+    {
+        switch (element.ValueKind)
+        {
+            case JsonValueKind.Null:
+            case JsonValueKind.Undefined:
+                return DBNull.Value;
+
+            case JsonValueKind.True:
+                return true;
+
+            case JsonValueKind.False:
+                return false;
+
+            case JsonValueKind.String:
+                return element.GetString();
+
+            case JsonValueKind.Number:
+                if (element.TryGetInt64(out var longVal))
+                    return longVal;
+                return element.GetDouble();
+
+            case JsonValueKind.Object:
+                // SELECT col AS x -> extract first property value
+                using (var enumerator = element.EnumerateObject())
+                {
+                    if (enumerator.MoveNext())
+                    {
+                        return ExtractScalarValue(enumerator.Current.Value);
+                    }
+                }
+                return null;
+
+            case JsonValueKind.Array:
+                // Return first element if array
+                using (var enumerator = element.EnumerateArray())
+                {
+                    if (enumerator.MoveNext())
+                    {
+                        return ExtractScalarValue(enumerator.Current);
+                    }
+                }
+                return null;
+
+            default:
+                return null;
+        }
+    }
 
     protected override DbParameter CreateDbParameter()
     {
@@ -61,15 +162,87 @@ public class CouchbaseCommand : DbCommand
 
     protected override DbDataReader ExecuteDbDataReader(CommandBehavior behavior)
     {
-        var options = new QueryOptions();
-        foreach (var dbParameter in Parameters)
+        return AsyncHelper.RunSync(
+            static state => state.Command.ExecuteDbDataReaderAsync(state.Behavior, CancellationToken.None),
+            (Command: this, Behavior: behavior));
+    }
+
+    protected override async Task<DbDataReader> ExecuteDbDataReaderAsync(
+        CommandBehavior behavior,
+        CancellationToken cancellationToken)
+    {
+        using var linkedCts = CreateLinkedTokenSource(cancellationToken);
+        var options = BuildQueryOptions(linkedCts.Token);
+
+        var cluster = ResolveCluster();
+        var queryResult = await cluster.QueryAsync<object>(CommandText, options).ConfigureAwait(false);
+
+        return new CouchbaseDbDataReader<object>(queryResult);
+    }
+
+    protected override void Dispose(bool disposing)
+    {
+        if (disposing)
         {
-            var parameter = (CouchbaseParameter)dbParameter;
-            options.Parameter(parameter.ParameterName, parameter.Value);
+            _cancellationTokenSource?.Dispose();
+            _cancellationTokenSource = null;
         }
 
-        var queryResult = Cluster.QueryAsync<object>(CommandText, options).GetAwaiter().GetResult();
-        return new CouchbaseDbDataReader<object>(queryResult);
+        base.Dispose(disposing);
+    }
+
+    public override async ValueTask DisposeAsync()
+    {
+        _cancellationTokenSource?.Dispose();
+        _cancellationTokenSource = null;
+
+        await base.DisposeAsync().ConfigureAwait(false);
+    }
+
+    private ICluster ResolveCluster()
+    {
+        if (Cluster != null)
+        {
+            return Cluster;
+        }
+
+        if (DbConnection is CouchbaseConnection couchbaseConnection && couchbaseConnection.Cluster != null)
+        {
+            return couchbaseConnection.Cluster;
+        }
+
+        throw new InvalidOperationException(
+            "No Couchbase cluster is available. Ensure the connection is open or the Cluster property is set.");
+    }
+
+    private QueryOptions BuildQueryOptions(CancellationToken cancellationToken)
+    {
+        var options = new QueryOptions().CancellationToken(cancellationToken);
+
+        if (CommandTimeout > 0)
+        {
+            options.Timeout(TimeSpan.FromSeconds(CommandTimeout));
+        }
+
+        foreach (var dbParameter in Parameters)
+        {
+            if (dbParameter is CouchbaseParameter parameter)
+            {
+                options.Parameter(parameter.ParameterName, parameter.Value!);
+            }
+        }
+
+        return options;
+    }
+
+    private CancellationTokenSource CreateLinkedTokenSource(CancellationToken externalToken)
+    {
+        _cancellationTokenSource?.Dispose();
+        _cancellationTokenSource = new CancellationTokenSource();
+
+        return externalToken.CanBeCanceled
+            ? CancellationTokenSource.CreateLinkedTokenSource(_cancellationTokenSource.Token, externalToken)
+            : _cancellationTokenSource;
     }
 }
 

--- a/src/Couchbase.EntityFrameworkCore/Storage/Internal/CouchbaseParameterCollection.cs
+++ b/src/Couchbase.EntityFrameworkCore/Storage/Internal/CouchbaseParameterCollection.cs
@@ -3,14 +3,14 @@ using System.Data.Common;
 
 namespace Couchbase.EntityFrameworkCore.Storage.Internal;
 
-public class CouchbaseParameterCollection : DbParameterCollection
+public sealed class CouchbaseParameterCollection : DbParameterCollection
 {
     private readonly List<CouchbaseParameter> _parameters = new();
 
-    public virtual CouchbaseParameter AddWithValue(string? parameterName, object? value)
+    public CouchbaseParameter AddWithValue(string? parameterName, object? value)
         => Add(new CouchbaseParameter(parameterName, value));
 
-    public virtual CouchbaseParameter Add(CouchbaseParameter value)
+    public CouchbaseParameter Add(CouchbaseParameter value)
     {
         _parameters.Add(value);
 
@@ -78,7 +78,8 @@ public class CouchbaseParameterCollection : DbParameterCollection
         throw new NotImplementedException();
     }
 
-    public override int Count { get; }
+    public override int Count => _parameters.Count;
+
     public override object SyncRoot { get; }
 
     public override int IndexOf(string parameterName)

--- a/tests/Couchbase.EntityFrameworkCore.IntegrationTests/Tests/CouchbaseCommandTests.cs
+++ b/tests/Couchbase.EntityFrameworkCore.IntegrationTests/Tests/CouchbaseCommandTests.cs
@@ -1,0 +1,460 @@
+using System.Data;
+using Couchbase.EntityFrameworkCode.IntegrationTests.Fixtures;
+using Couchbase.EntityFrameworkCore.Storage.Internal;
+using Microsoft.EntityFrameworkCore;
+using Xunit.Abstractions;
+
+namespace Couchbase.EntityFrameworkCode.IntegrationTests.Tests;
+
+[Collection(CouchbaseTestingCollection.Name)]
+public class CouchbaseCommandTests(
+    BloggingFixture bloggingFixture,
+    ITestOutputHelper outputHelper)
+{
+    [Fact]
+    public async Task CreateCommand_ReturnsValidCouchbaseCommand()
+    {
+        await using var context = bloggingFixture.GetDbContext();
+        var connection = context.Database.GetDbConnection();
+        await connection.OpenAsync();
+
+        using var command = connection.CreateCommand();
+
+        Assert.NotNull(command);
+        Assert.IsType<CouchbaseCommand>(command);
+    }
+
+    [Fact]
+    public async Task CommandText_CanBeSetAndRetrieved()
+    {
+        await using var context = bloggingFixture.GetDbContext();
+        var connection = context.Database.GetDbConnection();
+        await connection.OpenAsync();
+
+        using var command = connection.CreateCommand();
+        command.CommandText = "SELECT 1";
+
+        Assert.Equal("SELECT 1", command.CommandText);
+    }
+
+    [Fact]
+    public async Task CommandTimeout_CanBeSetAndRetrieved()
+    {
+        await using var context = bloggingFixture.GetDbContext();
+        var connection = context.Database.GetDbConnection();
+        await connection.OpenAsync();
+
+        using var command = connection.CreateCommand();
+        command.CommandTimeout = 60;
+
+        Assert.Equal(60, command.CommandTimeout);
+    }
+
+    [Fact]
+    public async Task CreateParameter_ReturnsCouchbaseParameter()
+    {
+        await using var context = bloggingFixture.GetDbContext();
+        var connection = context.Database.GetDbConnection();
+        await connection.OpenAsync();
+
+        using var command = connection.CreateCommand();
+        var parameter = command.CreateParameter();
+
+        Assert.NotNull(parameter);
+        Assert.IsType<CouchbaseParameter>(parameter);
+    }
+
+    [Fact]
+    public async Task Parameters_CanAddAndRetrieve()
+    {
+        await using var context = bloggingFixture.GetDbContext();
+        var connection = context.Database.GetDbConnection();
+        await connection.OpenAsync();
+
+        using var command = (CouchbaseCommand)connection.CreateCommand();
+        command.Parameters.AddWithValue("$param1", "value1");
+        command.Parameters.AddWithValue("$param2", 42);
+
+        Assert.Equal(2, command.Parameters.Count);
+    }
+
+    [Fact]
+    public async Task Prepare_DoesNotThrow()
+    {
+        await using var context = bloggingFixture.GetDbContext();
+        var connection = context.Database.GetDbConnection();
+        await connection.OpenAsync();
+
+        using var command = connection.CreateCommand();
+        command.CommandText = "SELECT * FROM `default`.`blogs`.`blog`";
+
+        var exception = Record.Exception(() => command.Prepare());
+
+        Assert.Null(exception);
+    }
+
+    [Fact]
+    public async Task PrepareAsync_DoesNotThrow()
+    {
+        await using var context = bloggingFixture.GetDbContext();
+        var connection = context.Database.GetDbConnection();
+        await connection.OpenAsync();
+
+        using var command = connection.CreateCommand();
+        command.CommandText = "SELECT * FROM `default`.`blogs`.`blog`";
+
+        var exception = await Record.ExceptionAsync(() => command.PrepareAsync());
+
+        Assert.Null(exception);
+    }
+
+    [Fact]
+    public async Task ExecuteNonQueryAsync_WithSelectQuery_ReturnsResult()
+    {
+        await using var context = bloggingFixture.GetDbContext();
+        var connection = context.Database.GetDbConnection();
+        await connection.OpenAsync();
+
+        using var command = connection.CreateCommand();
+        command.CommandText = "SELECT RAW 1";
+
+        var result = await command.ExecuteNonQueryAsync(CancellationToken.None);
+
+        // SELECT queries don't mutate, so result should be 0 or -1
+        outputHelper.WriteLine($"ExecuteNonQueryAsync result: {result}");
+    }
+
+    [Fact]
+    public async Task ExecuteNonQuery_WithSelectQuery_ReturnsResult()
+    {
+        await using var context = bloggingFixture.GetDbContext();
+        var connection = context.Database.GetDbConnection();
+        await connection.OpenAsync();
+
+        using var command = connection.CreateCommand();
+        command.CommandText = "SELECT RAW 1";
+
+        var result = command.ExecuteNonQuery();
+
+        outputHelper.WriteLine($"ExecuteNonQuery result: {result}");
+    }
+
+    [Fact]
+    public async Task ExecuteScalarAsync_WithSimpleQuery_ReturnsValue()
+    {
+        await using var context = bloggingFixture.GetDbContext();
+        var connection = context.Database.GetDbConnection();
+        await connection.OpenAsync();
+
+        using var command = connection.CreateCommand();
+        command.CommandText = "SELECT RAW 42";
+
+        var result = await command.ExecuteScalarAsync(CancellationToken.None);
+
+        Assert.NotNull(result);
+        Assert.Equal(42L, result);
+        outputHelper.WriteLine($"ExecuteScalarAsync result: {result} (type: {result?.GetType().Name})");
+    }
+
+    [Fact]
+    public async Task ExecuteScalar_WithSimpleQuery_ReturnsValue()
+    {
+        await using var context = bloggingFixture.GetDbContext();
+        var connection = context.Database.GetDbConnection();
+        await connection.OpenAsync();
+
+        using var command = connection.CreateCommand();
+        command.CommandText = "SELECT 'hello' AS greeting";
+
+        var result = command.ExecuteScalar();
+
+        Assert.NotNull(result);
+        Assert.Equal("hello", result);
+        outputHelper.WriteLine($"ExecuteScalar result: {result}");
+    }
+
+    [Fact]
+    public async Task ExecuteScalarAsync_WithCountQuery_ReturnsCount()
+    {
+        await using var context = bloggingFixture.GetDbContext();
+        var connection = context.Database.GetDbConnection();
+        await connection.OpenAsync();
+
+        using var command = connection.CreateCommand();
+        command.CommandText = "SELECT COUNT(*) AS cnt FROM `default`.`blogs`.`blog`";
+
+        var result = await command.ExecuteScalarAsync(CancellationToken.None);
+
+        Assert.NotNull(result);
+        outputHelper.WriteLine($"Blog count: {result}");
+    }
+
+    [Fact]
+    public async Task ExecuteScalarAsync_WithNoResults_ReturnsNull()
+    {
+        await using var context = bloggingFixture.GetDbContext();
+        var connection = context.Database.GetDbConnection();
+        await connection.OpenAsync();
+
+        using var command = connection.CreateCommand();
+        command.CommandText = "SELECT b.ID  FROM `default`.`blogs`.`blog` as b WHERE blogId = -99999";
+
+        var result = await command.ExecuteScalarAsync(CancellationToken.None);
+
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public async Task ExecuteReaderAsync_WithSelectQuery_ReturnsDataReader()
+    {
+        await using var context = bloggingFixture.GetDbContext();
+        var connection = context.Database.GetDbConnection();
+        await connection.OpenAsync();
+
+        using var command = connection.CreateCommand();
+        command.CommandText = "SELECT * FROM `default`.`blogs`.`blog` LIMIT 5";
+
+        await using var reader = await command.ExecuteReaderAsync(CancellationToken.None);
+
+        Assert.NotNull(reader);
+        Assert.IsType<CouchbaseDbDataReader<object>>(reader);
+    }
+
+    [Fact]
+    public async Task ExecuteReader_WithSelectQuery_ReturnsDataReader()
+    {
+        await using var context = bloggingFixture.GetDbContext();
+        var connection = context.Database.GetDbConnection();
+        await connection.OpenAsync();
+
+        using var command = connection.CreateCommand();
+        command.CommandText = "SELECT * FROM `default`.`blogs`.`blog` LIMIT 5";
+
+        using var reader = command.ExecuteReader();
+
+        Assert.NotNull(reader);
+        Assert.IsType<CouchbaseDbDataReader<object>>(reader);
+    }
+
+    [Fact]
+    public async Task ExecuteReaderAsync_HasRows_ReturnsTrue()
+    {
+        await using var context = bloggingFixture.GetDbContext();
+        var connection = context.Database.GetDbConnection();
+        await connection.OpenAsync();
+
+        using var command = connection.CreateCommand();
+        command.CommandText = "SELECT * FROM `default`.`blogs`.`blog` LIMIT 1";
+
+        await using var reader = await command.ExecuteReaderAsync(CancellationToken.None);
+
+        Assert.True(reader.HasRows);
+    }
+
+    [Fact]
+    public async Task ExecuteScalarAsync_WithParameters_UsesParameterValues()
+    {
+        await using var context = bloggingFixture.GetDbContext();
+        var connection = context.Database.GetDbConnection();
+        await connection.OpenAsync();
+
+        using var command = (CouchbaseCommand)connection.CreateCommand();
+        command.CommandText = "SELECT $value AS result";
+        command.Parameters.AddWithValue("$value", 123);
+
+        var result = await command.ExecuteScalarAsync(CancellationToken.None);
+
+        Assert.NotNull(result);
+        Assert.Equal(123L, result);
+    }
+
+    [Fact]
+    public async Task ExecuteScalarAsync_WithMultipleParameters_UsesAllParameters()
+    {
+        await using var context = bloggingFixture.GetDbContext();
+        var connection = context.Database.GetDbConnection();
+        await connection.OpenAsync();
+
+        using var command = (CouchbaseCommand)connection.CreateCommand();
+        command.CommandText = "SELECT $a + $b AS sum";
+        command.Parameters.AddWithValue("$a", 10);
+        command.Parameters.AddWithValue("$b", 20);
+
+        var result = await command.ExecuteScalarAsync(CancellationToken.None);
+
+        Assert.NotNull(result);
+        Assert.Equal(30L, result);
+    }
+
+    [Fact]
+    public async Task Cancel_DuringExecution_DoesNotThrowImmediately()
+    {
+        await using var context = bloggingFixture.GetDbContext();
+        var connection = context.Database.GetDbConnection();
+        await connection.OpenAsync();
+
+        using var command = connection.CreateCommand();
+        command.CommandText = "SELECT 1";
+
+        // Cancel should not throw even if called before execution
+        var exception = Record.Exception(() => command.Cancel());
+
+        Assert.Null(exception);
+    }
+
+    [Fact]
+    public async Task CommandType_DefaultsToText()
+    {
+        await using var context = bloggingFixture.GetDbContext();
+        var connection = context.Database.GetDbConnection();
+        await connection.OpenAsync();
+
+        using var command = connection.CreateCommand();
+
+        Assert.Equal(CommandType.Text, command.CommandType);
+    }
+
+    [Fact]
+    public async Task Connection_IsSetCorrectly()
+    {
+        await using var context = bloggingFixture.GetDbContext();
+        var connection = context.Database.GetDbConnection();
+        await connection.OpenAsync();
+
+        using var command = connection.CreateCommand();
+
+        Assert.Same(connection, command.Connection);
+    }
+
+    [Fact]
+    public async Task Dispose_CanBeCalledMultipleTimes()
+    {
+        await using var context = bloggingFixture.GetDbContext();
+        var connection = context.Database.GetDbConnection();
+        await connection.OpenAsync();
+
+        var command = connection.CreateCommand();
+
+        var exception = Record.Exception(() =>
+        {
+            command.Dispose();
+            command.Dispose();
+        });
+
+        Assert.Null(exception);
+    }
+
+    [Fact]
+    public async Task DisposeAsync_CanBeCalledMultipleTimes()
+    {
+        await using var context = bloggingFixture.GetDbContext();
+        var connection = context.Database.GetDbConnection();
+        await connection.OpenAsync();
+
+        var command = connection.CreateCommand();
+
+        var exception = await Record.ExceptionAsync(async () =>
+        {
+            await command.DisposeAsync();
+            await command.DisposeAsync();
+        });
+
+        Assert.Null(exception);
+    }
+
+    [Fact]
+    public async Task ExecuteNonQueryAsync_WithTimeout_DoesNotThrowForFastQuery()
+    {
+        await using var context = bloggingFixture.GetDbContext();
+        var connection = context.Database.GetDbConnection();
+        await connection.OpenAsync();
+
+        using var command = connection.CreateCommand();
+        command.CommandText = "SELECT 1";
+        command.CommandTimeout = 30;
+
+        var exception = await Record.ExceptionAsync(() => command.ExecuteNonQueryAsync(CancellationToken.None));
+
+        Assert.Null(exception);
+    }
+
+    [Fact]
+    public async Task ExecuteScalarAsync_WithNullResult_ReturnsDBNull()
+    {
+        await using var context = bloggingFixture.GetDbContext();
+        var connection = context.Database.GetDbConnection();
+        await connection.OpenAsync();
+
+        using var command = connection.CreateCommand();
+        command.CommandText = "SELECT NULL AS nullValue";
+
+        var result = await command.ExecuteScalarAsync(CancellationToken.None);
+
+        Assert.Equal(DBNull.Value, result);
+    }
+
+    [Fact]
+    public async Task ExecuteScalarAsync_WithBooleanResult_ReturnsBoolean()
+    {
+        await using var context = bloggingFixture.GetDbContext();
+        var connection = context.Database.GetDbConnection();
+        await connection.OpenAsync();
+
+        using var command = connection.CreateCommand();
+        command.CommandText = "SELECT TRUE AS boolValue";
+
+        var result = await command.ExecuteScalarAsync(CancellationToken.None);
+
+        Assert.NotNull(result);
+        Assert.True((bool)result);
+    }
+
+    [Fact]
+    public async Task ExecuteScalarAsync_WithStringResult_ReturnsString()
+    {
+        await using var context = bloggingFixture.GetDbContext();
+        var connection = context.Database.GetDbConnection();
+        await connection.OpenAsync();
+
+        using var command = connection.CreateCommand();
+        command.CommandText = "SELECT 'test string' AS strValue";
+
+        var result = await command.ExecuteScalarAsync(CancellationToken.None);
+
+        Assert.NotNull(result);
+        Assert.Equal("test string", result);
+    }
+
+    [Fact]
+    public async Task ExecuteScalarAsync_WithDecimalResult_ReturnsNumber()
+    {
+        await using var context = bloggingFixture.GetDbContext();
+        var connection = context.Database.GetDbConnection();
+        await connection.OpenAsync();
+
+        using var command = connection.CreateCommand();
+        command.CommandText = "SELECT 3.14159 AS piValue";
+
+        var result = await command.ExecuteScalarAsync(CancellationToken.None);
+
+        Assert.NotNull(result);
+        Assert.Equal(3.14159, Convert.ToDouble(result), 5);
+    }
+
+    [Fact]
+    public async Task ExecuteReaderAsync_CanReadRows()
+    {
+        await using var context = bloggingFixture.GetDbContext();
+        var connection = context.Database.GetDbConnection();
+        await connection.OpenAsync();
+
+        using var command = connection.CreateCommand();
+        command.CommandText = "SELECT blogId, url FROM `default`.`blogs`.`blog` LIMIT 2";
+
+        await using var reader = await command.ExecuteReaderAsync(CancellationToken.None);
+
+        var hasRows = reader.Read();
+        Assert.True(hasRows);
+        outputHelper.WriteLine("Successfully read first row from reader");
+    }
+}

--- a/tests/Couchbase.EntityFrameworkCore.UnitTests/Couchbase/EntityFrameworkCore/Storage/Internal/CouchbaseCommandTests.cs
+++ b/tests/Couchbase.EntityFrameworkCore.UnitTests/Couchbase/EntityFrameworkCore/Storage/Internal/CouchbaseCommandTests.cs
@@ -1,0 +1,485 @@
+using System.Data;
+using System.Data.Common;
+using System.Text.Json;
+using Couchbase.EntityFrameworkCore.Infrastructure;
+using Couchbase.EntityFrameworkCore.Storage.Internal;
+using Couchbase.Extensions.DependencyInjection;
+using Couchbase.Query;
+using Moq;
+using Xunit;
+
+namespace Couchbase.EntityFrameworkCore.UnitTests.Couchbase.EntityFrameworkCore.Storage.Internal;
+
+public class CouchbaseCommandTests
+{
+    private readonly Mock<IBucketProvider> _mockBucketProvider;
+    private readonly Mock<ICouchbaseDbContextOptionsBuilder> _mockOptions;
+    private readonly Mock<IBucket> _mockBucket;
+    private readonly Mock<ICluster> _mockCluster;
+
+    public CouchbaseCommandTests()
+    {
+        _mockBucketProvider = new Mock<IBucketProvider>();
+        _mockOptions = new Mock<ICouchbaseDbContextOptionsBuilder>();
+        _mockBucket = new Mock<IBucket>();
+        _mockCluster = new Mock<ICluster>();
+
+        _mockOptions.Setup(o => o.Bucket).Returns("test-bucket");
+        _mockOptions.Setup(o => o.ConnectionString).Returns("couchbase://localhost");
+        _mockOptions.Setup(o => o.ClusterOptions).Returns(new ClusterOptions().WithConnectionString("couchbase://localhost"));
+
+        _mockBucket.Setup(b => b.Cluster).Returns(_mockCluster.Object);
+        _mockBucketProvider.Setup(p => p.GetBucketAsync("test-bucket"))
+            .ReturnsAsync(_mockBucket.Object);
+    }
+
+    [Fact]
+    public void Constructor_DefaultValues_AreCorrect()
+    {
+        var command = new CouchbaseCommand();
+
+        Assert.Equal(string.Empty, command.CommandText);
+        Assert.Equal(0, command.CommandTimeout);
+        Assert.Equal(CommandType.Text, command.CommandType);
+        Assert.Equal(UpdateRowSource.None, command.UpdatedRowSource);
+        Assert.False(command.DesignTimeVisible);
+        Assert.Null(command.Connection);
+        Assert.Null(command.Transaction);
+    }
+
+    [Fact]
+    public void CommandText_SetNull_ReturnsEmptyString()
+    {
+        var command = new CouchbaseCommand();
+
+        command.CommandText = null!;
+
+        Assert.Equal(string.Empty, command.CommandText);
+    }
+
+    [Fact]
+    public void CommandText_SetValue_ReturnsValue()
+    {
+        var command = new CouchbaseCommand();
+
+        command.CommandText = "SELECT * FROM bucket";
+
+        Assert.Equal("SELECT * FROM bucket", command.CommandText);
+    }
+
+    [Fact]
+    public void CommandTimeout_SetValue_ReturnsValue()
+    {
+        var command = new CouchbaseCommand();
+
+        command.CommandTimeout = 30;
+
+        Assert.Equal(30, command.CommandTimeout);
+    }
+
+    [Fact]
+    public void CommandType_SetValue_ReturnsValue()
+    {
+        var command = new CouchbaseCommand();
+
+        command.CommandType = CommandType.StoredProcedure;
+
+        Assert.Equal(CommandType.StoredProcedure, command.CommandType);
+    }
+
+    [Fact]
+    public void UpdatedRowSource_SetValue_ReturnsValue()
+    {
+        var command = new CouchbaseCommand();
+
+        command.UpdatedRowSource = UpdateRowSource.FirstReturnedRecord;
+
+        Assert.Equal(UpdateRowSource.FirstReturnedRecord, command.UpdatedRowSource);
+    }
+
+    [Fact]
+    public void DesignTimeVisible_SetValue_ReturnsValue()
+    {
+        var command = new CouchbaseCommand();
+
+        command.DesignTimeVisible = true;
+
+        Assert.True(command.DesignTimeVisible);
+    }
+
+    [Fact]
+    public void Parameters_ReturnsNonNullCollection()
+    {
+        var command = new CouchbaseCommand();
+
+        Assert.NotNull(command.Parameters);
+        Assert.IsType<CouchbaseParameterCollection>(command.Parameters);
+    }
+
+    [Fact]
+    public void Parameters_ReturnsSameInstance()
+    {
+        var command = new CouchbaseCommand();
+
+        var params1 = command.Parameters;
+        var params2 = command.Parameters;
+
+        Assert.Same(params1, params2);
+    }
+
+    [Fact]
+    public void CreateParameter_ReturnsCouchbaseParameter()
+    {
+        var command = new CouchbaseCommand();
+
+        var parameter = command.CreateParameter();
+
+        Assert.NotNull(parameter);
+        Assert.IsType<CouchbaseParameter>(parameter);
+    }
+
+    [Fact]
+    public void Prepare_DoesNotThrow()
+    {
+        var command = new CouchbaseCommand();
+
+        var exception = Record.Exception(() => command.Prepare());
+
+        Assert.Null(exception);
+    }
+
+    [Fact]
+    public async Task PrepareAsync_DoesNotThrow()
+    {
+        var command = new CouchbaseCommand();
+
+        var exception = await Record.ExceptionAsync(() => command.PrepareAsync());
+
+        Assert.Null(exception);
+    }
+
+    [Fact]
+    public void Cancel_WhenNoCancellationToken_DoesNotThrow()
+    {
+        var command = new CouchbaseCommand();
+
+        var exception = Record.Exception(() => command.Cancel());
+
+        Assert.Null(exception);
+    }
+
+    [Fact]
+    public void Connection_SetAndGet_Works()
+    {
+        var command = new CouchbaseCommand();
+        var connection = new CouchbaseConnection(_mockBucketProvider.Object, _mockOptions.Object);
+
+        command.Connection = connection;
+
+        Assert.Same(connection, command.Connection);
+    }
+
+    [Fact]
+    public void Transaction_SetAndGet_Works()
+    {
+        var command = new CouchbaseCommand();
+        var mockTransaction = new Mock<DbTransaction>();
+
+        command.Transaction = mockTransaction.Object;
+
+        Assert.Same(mockTransaction.Object, command.Transaction);
+    }
+
+    [Fact]
+    public void ResolveCluster_WithExplicitCluster_ReturnsExplicitCluster()
+    {
+        var command = new CouchbaseCommand { Cluster = _mockCluster.Object };
+
+        // Indirectly test via ExecuteNonQueryAsync which calls ResolveCluster
+        // If ResolveCluster fails, it throws InvalidOperationException
+        Assert.NotNull(command.Cluster);
+        Assert.Same(_mockCluster.Object, command.Cluster);
+    }
+
+    [Fact]
+    public void ResolveCluster_WithNoClusterAndNoConnection_ThrowsInvalidOperationException()
+    {
+        var command = new CouchbaseCommand
+        {
+            CommandText = "SELECT 1"
+        };
+
+        Assert.Throws<InvalidOperationException>(() => command.ExecuteNonQuery());
+    }
+
+    [Fact]
+    public async Task ResolveCluster_WithNoClusterAndNoConnection_ThrowsInvalidOperationExceptionAsync()
+    {
+        var command = new CouchbaseCommand
+        {
+            CommandText = "SELECT 1"
+        };
+
+        await Assert.ThrowsAsync<InvalidOperationException>(() => command.ExecuteNonQueryAsync(CancellationToken.None));
+    }
+
+    [Fact]
+    public async Task ResolveCluster_WithConnectionButNoCluster_ThrowsInvalidOperationException()
+    {
+        var connection = new CouchbaseConnection(_mockBucketProvider.Object, _mockOptions.Object);
+        // Connection is not opened, so Cluster is null
+        var command = new CouchbaseCommand
+        {
+            Connection = connection,
+            CommandText = "SELECT 1"
+        };
+
+        await Assert.ThrowsAsync<InvalidOperationException>(() => command.ExecuteNonQueryAsync(CancellationToken.None));
+    }
+
+    [Fact]
+    public async Task ExecuteNonQueryAsync_WithValidCluster_CallsQueryAsync()
+    {
+        var mockQueryResult = CreateMockQueryResultWithRows<object>(new List<object>());
+        _mockCluster.Setup(c => c.QueryAsync<object>(It.IsAny<string>(), It.IsAny<QueryOptions>()))
+            .ReturnsAsync(mockQueryResult);
+
+        var command = new CouchbaseCommand
+        {
+            Cluster = _mockCluster.Object,
+            CommandText = "UPDATE bucket SET x = 1"
+        };
+
+        var result = await command.ExecuteNonQueryAsync(CancellationToken.None);
+
+        _mockCluster.Verify(c => c.QueryAsync<object>("UPDATE bucket SET x = 1", It.IsAny<QueryOptions>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task ExecuteScalarAsync_WithRows_ReturnsFirstColumnOfFirstRow()
+    {
+        var rows = new List<JsonElement> { JsonDocument.Parse("{\"result\": 42}").RootElement };
+        var mockQueryResult = CreateMockQueryResultWithRows(rows);
+        _mockCluster.Setup(c => c.QueryAsync<JsonElement>(It.IsAny<string>(), It.IsAny<QueryOptions>()))
+            .ReturnsAsync(mockQueryResult);
+
+        var command = new CouchbaseCommand
+        {
+            Cluster = _mockCluster.Object,
+            CommandText = "SELECT COUNT(*) as result FROM bucket"
+        };
+
+        var result = await command.ExecuteScalarAsync(CancellationToken.None);
+
+        Assert.Equal(42L, result);
+    }
+
+    [Fact]
+    public async Task ExecuteScalarAsync_WithNoRows_ReturnsNull()
+    {
+        var rows = new List<JsonElement>();
+        var mockQueryResult = CreateMockQueryResultWithRows(rows);
+        _mockCluster.Setup(c => c.QueryAsync<JsonElement>(It.IsAny<string>(), It.IsAny<QueryOptions>()))
+            .ReturnsAsync(mockQueryResult);
+
+        var command = new CouchbaseCommand
+        {
+            Cluster = _mockCluster.Object,
+            CommandText = "SELECT * FROM bucket WHERE 1=0"
+        };
+
+        var result = await command.ExecuteScalarAsync(CancellationToken.None);
+
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public async Task ExecuteScalarAsync_WithNullJsonValue_ReturnsDBNull()
+    {
+        var rows = new List<JsonElement> { JsonDocument.Parse("null").RootElement };
+        var mockQueryResult = CreateMockQueryResultWithRows(rows);
+        _mockCluster.Setup(c => c.QueryAsync<JsonElement>(It.IsAny<string>(), It.IsAny<QueryOptions>()))
+            .ReturnsAsync(mockQueryResult);
+
+        var command = new CouchbaseCommand
+        {
+            Cluster = _mockCluster.Object,
+            CommandText = "SELECT RAW NULL"
+        };
+
+        var result = await command.ExecuteScalarAsync(CancellationToken.None);
+
+        Assert.Equal(DBNull.Value, result);
+    }
+
+    [Fact]
+    public async Task ExecuteScalarAsync_WithEmptyObject_ReturnsNull()
+    {
+        var rows = new List<JsonElement> { JsonDocument.Parse("{}").RootElement };
+        var mockQueryResult = CreateMockQueryResultWithRows(rows);
+        _mockCluster.Setup(c => c.QueryAsync<JsonElement>(It.IsAny<string>(), It.IsAny<QueryOptions>()))
+            .ReturnsAsync(mockQueryResult);
+
+        var command = new CouchbaseCommand
+        {
+            Cluster = _mockCluster.Object,
+            CommandText = "SELECT"
+        };
+
+        var result = await command.ExecuteScalarAsync(CancellationToken.None);
+
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public async Task ExecuteScalarAsync_WithNullPropertyValue_ReturnsDBNull()
+    {
+        var rows = new List<JsonElement> { JsonDocument.Parse("{\"result\": null}").RootElement };
+        var mockQueryResult = CreateMockQueryResultWithRows(rows);
+        _mockCluster.Setup(c => c.QueryAsync<JsonElement>(It.IsAny<string>(), It.IsAny<QueryOptions>()))
+            .ReturnsAsync(mockQueryResult);
+
+        var command = new CouchbaseCommand
+        {
+            Cluster = _mockCluster.Object,
+            CommandText = "SELECT NULL as result"
+        };
+
+        var result = await command.ExecuteScalarAsync(CancellationToken.None);
+
+        Assert.Equal(DBNull.Value, result);
+    }
+
+    [Fact]
+    public async Task ExecuteScalarAsync_WithRawScalar_ReturnsValue()
+    {
+        var rows = new List<JsonElement> { JsonDocument.Parse("42").RootElement };
+        var mockQueryResult = CreateMockQueryResultWithRows(rows);
+        _mockCluster.Setup(c => c.QueryAsync<JsonElement>(It.IsAny<string>(), It.IsAny<QueryOptions>()))
+            .ReturnsAsync(mockQueryResult);
+
+        var command = new CouchbaseCommand
+        {
+            Cluster = _mockCluster.Object,
+            CommandText = "SELECT RAW 42"
+        };
+
+        var result = await command.ExecuteScalarAsync(CancellationToken.None);
+
+        Assert.Equal(42L, result);
+    }
+
+    [Fact]
+    public async Task ExecuteScalarAsync_WithStringValue_ReturnsString()
+    {
+        var rows = new List<JsonElement> { JsonDocument.Parse("{\"result\": \"hello\"}").RootElement };
+        var mockQueryResult = CreateMockQueryResultWithRows(rows);
+        _mockCluster.Setup(c => c.QueryAsync<JsonElement>(It.IsAny<string>(), It.IsAny<QueryOptions>()))
+            .ReturnsAsync(mockQueryResult);
+
+        var command = new CouchbaseCommand
+        {
+            Cluster = _mockCluster.Object,
+            CommandText = "SELECT 'hello' as result"
+        };
+
+        var result = await command.ExecuteScalarAsync(CancellationToken.None);
+
+        Assert.Equal("hello", result);
+    }
+
+    [Fact]
+    public async Task ExecuteScalarAsync_WithBooleanValue_ReturnsBoolean()
+    {
+        var rows = new List<JsonElement> { JsonDocument.Parse("{\"result\": true}").RootElement };
+        var mockQueryResult = CreateMockQueryResultWithRows(rows);
+        _mockCluster.Setup(c => c.QueryAsync<JsonElement>(It.IsAny<string>(), It.IsAny<QueryOptions>()))
+            .ReturnsAsync(mockQueryResult);
+
+        var command = new CouchbaseCommand
+        {
+            Cluster = _mockCluster.Object,
+            CommandText = "SELECT TRUE as result"
+        };
+
+        var result = await command.ExecuteScalarAsync(CancellationToken.None);
+
+        Assert.True((bool)result!);
+    }
+
+    [Fact]
+    public async Task ExecuteDbDataReaderAsync_ReturnsDataReader()
+    {
+        var mockQueryResult = CreateMockQueryResultWithRows<object>(new List<object>());
+        _mockCluster.Setup(c => c.QueryAsync<object>(It.IsAny<string>(), It.IsAny<QueryOptions>()))
+            .ReturnsAsync(mockQueryResult);
+
+        var command = new CouchbaseCommand
+        {
+            Cluster = _mockCluster.Object,
+            CommandText = "SELECT * FROM bucket"
+        };
+
+        var reader = await command.ExecuteReaderAsync(CancellationToken.None);
+
+        Assert.NotNull(reader);
+        Assert.IsType<CouchbaseDbDataReader<object>>(reader);
+    }
+
+    [Fact]
+    public async Task ExecuteNonQueryAsync_WithParameters_CallsQueryAsyncWithCommandText()
+    {
+        var mockQueryResult = CreateMockQueryResultWithRows<object>(new List<object>());
+        _mockCluster.Setup(c => c.QueryAsync<object>(It.IsAny<string>(), It.IsAny<QueryOptions>()))
+            .ReturnsAsync(mockQueryResult);
+
+        var command = new CouchbaseCommand
+        {
+            Cluster = _mockCluster.Object,
+            CommandText = "UPDATE bucket SET x = $value WHERE id = $id"
+        };
+        command.Parameters.AddWithValue("$value", 100);
+        command.Parameters.AddWithValue("$id", "doc1");
+
+        await command.ExecuteNonQueryAsync(CancellationToken.None);
+
+        _mockCluster.Verify(c => c.QueryAsync<object>("UPDATE bucket SET x = $value WHERE id = $id", It.IsAny<QueryOptions>()), Times.Once);
+    }
+
+    [Fact]
+    public void Dispose_CanBeCalledMultipleTimes()
+    {
+        var command = new CouchbaseCommand();
+
+        var exception = Record.Exception(() =>
+        {
+            command.Dispose();
+            command.Dispose();
+        });
+
+        Assert.Null(exception);
+    }
+
+    [Fact]
+    public async Task DisposeAsync_CanBeCalledMultipleTimes()
+    {
+        var command = new CouchbaseCommand();
+
+        var exception = await Record.ExceptionAsync(async () =>
+        {
+            await command.DisposeAsync();
+            await command.DisposeAsync();
+        });
+
+        Assert.Null(exception);
+    }
+
+    private static IQueryResult<T> CreateMockQueryResultWithRows<T>(List<T> rows)
+    {
+        var mockResult = new Mock<IQueryResult<T>>();
+        mockResult.Setup(r => r.Rows).Returns(rows.ToAsyncEnumerable());
+        mockResult.Setup(r => r.MetaData).Returns((QueryMetaData?)null);
+
+        return mockResult.Object;
+    }
+}


### PR DESCRIPTION
- CouchbaseCommand was only partially implemented so implement it completely
- Default the serializer to System.Text.Json so that we do not need to use NewtonSoft in ExecuteScalarAsync
- Add unit and integration tests