### PR TITLE
Fully implement CouchbaseTypeMappingSource with tests

### DIFF
--- a/src/Couchbase.EntityFrameworkCore/Storage/Internal/CouchbaseBoolTypeMapping.cs
+++ b/src/Couchbase.EntityFrameworkCore/Storage/Internal/CouchbaseBoolTypeMapping.cs
@@ -1,0 +1,42 @@
+using Microsoft.EntityFrameworkCore.Storage;
+
+namespace Couchbase.EntityFrameworkCore.Storage.Internal;
+
+/// <summary>
+/// Type mapping for boolean values in Couchbase SQL++.
+/// </summary>
+/// <remarks>
+/// Couchbase SQL++ uses TRUE/FALSE literals for booleans, not 1/0.
+/// </remarks>
+public class CouchbaseBoolTypeMapping : BoolTypeMapping
+{
+    /// <summary>
+    /// Creates a new instance of <see cref="CouchbaseBoolTypeMapping"/>.
+    /// </summary>
+    public CouchbaseBoolTypeMapping()
+        : base("BOOLEAN")
+    {
+    }
+
+    /// <summary>
+    /// Creates a new instance from existing parameters (used for cloning).
+    /// </summary>
+    protected CouchbaseBoolTypeMapping(RelationalTypeMappingParameters parameters)
+        : base(parameters)
+    {
+    }
+
+    /// <inheritdoc />
+    protected override RelationalTypeMapping Clone(RelationalTypeMappingParameters parameters)
+    {
+        return new CouchbaseBoolTypeMapping(parameters);
+    }
+
+    /// <summary>
+    /// Generates a SQL++ boolean literal (TRUE or FALSE).
+    /// </summary>
+    protected override string GenerateNonNullSqlLiteral(object value)
+    {
+        return (bool)value ? "TRUE" : "FALSE";
+    }
+}

--- a/src/Couchbase.EntityFrameworkCore/Storage/Internal/CouchbaseByteArrayTypeMapping.cs
+++ b/src/Couchbase.EntityFrameworkCore/Storage/Internal/CouchbaseByteArrayTypeMapping.cs
@@ -1,0 +1,76 @@
+using System.Collections;
+using Microsoft.EntityFrameworkCore.ChangeTracking;
+using Microsoft.EntityFrameworkCore.Storage;
+using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
+
+namespace Couchbase.EntityFrameworkCore.Storage.Internal;
+
+/// <summary>
+/// Type mapping for byte arrays in Couchbase, stored as Base64-encoded strings.
+/// </summary>
+/// <remarks>
+/// Couchbase JSON documents store binary data as Base64 strings.
+/// This mapping ensures SQL++ literals and parameters are correctly formatted as Base64.
+/// </remarks>
+public class CouchbaseByteArrayTypeMapping : RelationalTypeMapping
+{
+    private static readonly ValueConverter<byte[], string> Base64Converter =
+        new(
+            bytes => Convert.ToBase64String(bytes),
+            base64 => Convert.FromBase64String(base64));
+
+    /// <summary>
+    /// Creates a new instance of <see cref="CouchbaseByteArrayTypeMapping"/>.
+    /// </summary>
+    public CouchbaseByteArrayTypeMapping()
+        : base(new RelationalTypeMappingParameters(
+            new CoreTypeMappingParameters(
+                typeof(byte[]),
+                Base64Converter,
+                new ValueComparer<byte[]>(
+                    (a, b) => StructuralComparisons.StructuralEqualityComparer.Equals(a, b),
+                    v => StructuralComparisons.StructuralEqualityComparer.GetHashCode(v),
+                    v => v.ToArray())),
+            "STRING"))
+    {
+    }
+
+    /// <summary>
+    /// Creates a new instance from existing parameters (used for cloning).
+    /// </summary>
+    protected CouchbaseByteArrayTypeMapping(RelationalTypeMappingParameters parameters)
+        : base(parameters)
+    {
+    }
+
+    /// <inheritdoc />
+    protected override RelationalTypeMapping Clone(RelationalTypeMappingParameters parameters)
+    {
+        return new CouchbaseByteArrayTypeMapping(parameters);
+    }
+
+    /// <summary>
+    /// Generates a SQL++ string literal containing the Base64-encoded byte array.
+    /// </summary>
+    protected override string GenerateNonNullSqlLiteral(object value)
+    {
+        // The value may already be converted to a Base64 string by the ValueConverter,
+        // or it may be the original byte[]
+        string base64;
+        if (value is byte[] bytes)
+        {
+            base64 = Convert.ToBase64String(bytes);
+        }
+        else if (value is string str)
+        {
+            base64 = str;
+        }
+        else
+        {
+            throw new InvalidOperationException($"Cannot generate SQL literal for type {value.GetType()}");
+        }
+        
+        // SQL++ string literals use single quotes
+        return $"'{base64}'";
+    }
+}

--- a/src/Couchbase.EntityFrameworkCore/Storage/Internal/CouchbaseTypeMapping.cs
+++ b/src/Couchbase.EntityFrameworkCore/Storage/Internal/CouchbaseTypeMapping.cs
@@ -5,45 +5,60 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 namespace Couchbase.EntityFrameworkCore.Storage.Internal;
 
+/// <summary>
+/// Type mapping for Couchbase JSON types (OBJECT and ARRAY).
+/// </summary>
 public class CouchbaseTypeMapping : RelationalTypeMapping
 {
-    private readonly Type _clrType;
-    private readonly ValueComparer? _comparer;
-    private readonly ValueComparer? _keyComparer;
-    private readonly JsonValueReaderWriter? _jsonValueReaderWriter;
-
-    protected CouchbaseTypeMapping(RelationalTypeMappingParameters relationalParameters) : base(relationalParameters)
+    /// <summary>
+    /// Creates a new instance from existing parameters (used for cloning).
+    /// </summary>
+    protected CouchbaseTypeMapping(RelationalTypeMappingParameters parameters)
+        : base(parameters)
     {
     }
-    
-   public CouchbaseTypeMapping(
+
+    /// <summary>
+    /// Creates a new Couchbase type mapping.
+    /// </summary>
+    /// <param name="clrType">The CLR type being mapped.</param>
+    /// <param name="storeType">The Couchbase store type (e.g., "OBJECT", "ARRAY").</param>
+    /// <param name="comparer">Optional value comparer.</param>
+    /// <param name="keyComparer">Optional key comparer.</param>
+    /// <param name="jsonValueReaderWriter">Optional JSON reader/writer.</param>
+    public CouchbaseTypeMapping(
         Type clrType,
+        string storeType,
         ValueComparer? comparer = null,
         ValueComparer? keyComparer = null,
-        JsonValueReaderWriter? jsonValueReaderWriter = null) 
-       : base(new RelationalTypeMappingParameters(new CoreTypeMappingParameters(clrType), "couchbase"))
-   {
-       _clrType = clrType;
-       _comparer = comparer;
-       _keyComparer = keyComparer;
-       _jsonValueReaderWriter = jsonValueReaderWriter;
-   }
+        JsonValueReaderWriter? jsonValueReaderWriter = null)
+        : base(new RelationalTypeMappingParameters(
+            new CoreTypeMappingParameters(clrType)
+                .WithComposedConverter(null, comparer, keyComparer, null, jsonValueReaderWriter),
+            storeType))
+    {
+    }
 
+    /// <inheritdoc />
     protected override RelationalTypeMapping Clone(RelationalTypeMappingParameters parameters)
     {
         return new CouchbaseTypeMapping(parameters);
     }
 
-    public override CoreTypeMapping WithComposedConverter(ValueConverter? converter, ValueComparer? comparer = null,
-        ValueComparer? keyComparer = null, CoreTypeMapping? elementMapping = null,
+    /// <inheritdoc />
+    public override CoreTypeMapping WithComposedConverter(
+        ValueConverter? converter,
+        ValueComparer? comparer = null,
+        ValueComparer? keyComparer = null,
+        CoreTypeMapping? elementMapping = null,
         JsonValueReaderWriter? jsonValueReaderWriter = null)
     {
-        return new CouchbaseTypeMapping(Parameters.WithComposedConverter(converter, comparer, keyComparer,
-            elementMapping, jsonValueReaderWriter));
+        return new CouchbaseTypeMapping(
+            Parameters.WithComposedConverter(converter, comparer, keyComparer, elementMapping, jsonValueReaderWriter));
     }
 
     /// <summary>
-    /// SQL++ requires that that discriminator values are encased in quotation marks. This may break other things...
+    /// SQL++ requires string literals to be enclosed in double quotes.
     /// </summary>
     protected override string SqlLiteralFormatString => "\"{0}\"";
 }

--- a/src/Couchbase.EntityFrameworkCore/Storage/Internal/CouchbaseTypeMapping.cs
+++ b/src/Couchbase.EntityFrameworkCore/Storage/Internal/CouchbaseTypeMapping.cs
@@ -1,3 +1,5 @@
+using System.Text;
+using System.Text.Json.Nodes;
 using Microsoft.EntityFrameworkCore.ChangeTracking;
 using Microsoft.EntityFrameworkCore.Storage;
 using Microsoft.EntityFrameworkCore.Storage.Json;
@@ -8,6 +10,10 @@ namespace Couchbase.EntityFrameworkCore.Storage.Internal;
 /// <summary>
 /// Type mapping for Couchbase JSON types (OBJECT and ARRAY).
 /// </summary>
+/// <remarks>
+/// This mapping handles <see cref="JsonObject"/> and <see cref="JsonArray"/> types,
+/// generating valid SQL++ literals (raw JSON without string quoting).
+/// </remarks>
 public class CouchbaseTypeMapping : RelationalTypeMapping
 {
     /// <summary>
@@ -58,9 +64,21 @@ public class CouchbaseTypeMapping : RelationalTypeMapping
     }
 
     /// <summary>
-    /// SQL++ requires string literals to be enclosed in double quotes.
+    /// Generates a SQL++ literal for the given value.
     /// </summary>
-    protected override string SqlLiteralFormatString => "\"{0}\"";
+    /// <remarks>
+    /// For <see cref="JsonObject"/> and <see cref="JsonArray"/>, emits raw JSON (valid SQL++ object/array literals).
+    /// For other types, falls back to base implementation.
+    /// </remarks>
+    protected override string GenerateNonNullSqlLiteral(object value)
+    {
+        return value switch
+        {
+            JsonObject jsonObject => jsonObject.ToJsonString(),
+            JsonArray jsonArray => jsonArray.ToJsonString(),
+            _ => base.GenerateNonNullSqlLiteral(value)
+        };
+    }
 }
 
 /* ************************************************************

--- a/src/Couchbase.EntityFrameworkCore/Storage/Internal/CouchbaseTypeMapping.cs
+++ b/src/Couchbase.EntityFrameworkCore/Storage/Internal/CouchbaseTypeMapping.cs
@@ -1,4 +1,3 @@
-using System.Text;
 using System.Text.Json.Nodes;
 using Microsoft.EntityFrameworkCore.ChangeTracking;
 using Microsoft.EntityFrameworkCore.Storage;

--- a/src/Couchbase.EntityFrameworkCore/Storage/Internal/CouchbaseTypeMappingSource.cs
+++ b/src/Couchbase.EntityFrameworkCore/Storage/Internal/CouchbaseTypeMappingSource.cs
@@ -58,7 +58,7 @@ public class CouchbaseTypeMappingSource : RelationalTypeMappingSource
 
             // Other types -> STRING
             { typeof(Guid), new GuidTypeMapping("STRING", DbType.Guid) },
-            { typeof(byte[]), new ByteArrayTypeMapping("STRING", DbType.Binary) },
+            { typeof(byte[]), new CouchbaseByteArrayTypeMapping() },
 
             // JSON types
             {

--- a/src/Couchbase.EntityFrameworkCore/Storage/Internal/CouchbaseTypeMappingSource.cs
+++ b/src/Couchbase.EntityFrameworkCore/Storage/Internal/CouchbaseTypeMappingSource.cs
@@ -42,8 +42,8 @@ public class CouchbaseTypeMappingSource : RelationalTypeMappingSource
             { typeof(double), new DoubleTypeMapping("NUMBER") },
             { typeof(decimal), new DecimalTypeMapping("NUMBER") },
 
-            // Boolean -> BOOLEAN
-            { typeof(bool), new BoolTypeMapping("BOOLEAN") },
+            // Boolean -> BOOLEAN (uses TRUE/FALSE literals, not 1/0)
+            { typeof(bool), new CouchbaseBoolTypeMapping() },
 
             // String types -> STRING
             { typeof(string), new StringTypeMapping("STRING", DbType.String) },

--- a/src/Couchbase.EntityFrameworkCore/Storage/Internal/CouchbaseTypeMappingSource.cs
+++ b/src/Couchbase.EntityFrameworkCore/Storage/Internal/CouchbaseTypeMappingSource.cs
@@ -4,40 +4,78 @@ using System.Text.Json.Nodes;
 
 namespace Couchbase.EntityFrameworkCore.Storage.Internal;
 
-public class CouchbaseTypeMappingSource: RelationalTypeMappingSource
+/// <summary>
+/// Provides type mappings between .NET CLR types and Couchbase JSON types.
+/// </summary>
+/// <remarks>
+/// Couchbase stores documents as JSON, which supports the following types:
+/// <list type="bullet">
+/// <item><description>NUMBER - All numeric types (integers, decimals, floats)</description></item>
+/// <item><description>STRING - Text, dates (ISO 8601), GUIDs, Base64 binary</description></item>
+/// <item><description>BOOLEAN - true/false</description></item>
+/// <item><description>OBJECT - Nested documents</description></item>
+/// <item><description>ARRAY - Lists and arrays</description></item>
+/// <item><description>NULL - null values</description></item>
+/// </list>
+/// </remarks>
+public class CouchbaseTypeMappingSource : RelationalTypeMappingSource
 {
     private readonly Dictionary<Type, RelationalTypeMapping> _clrTypeMappings;
-    
-    public CouchbaseTypeMappingSource(TypeMappingSourceDependencies dependencies, RelationalTypeMappingSourceDependencies relationalDependencies) 
+
+    public CouchbaseTypeMappingSource(
+        TypeMappingSourceDependencies dependencies,
+        RelationalTypeMappingSourceDependencies relationalDependencies)
         : base(dependencies, relationalDependencies)
     {
-        _clrTypeMappings
-            = new Dictionary<Type, RelationalTypeMapping>
+        _clrTypeMappings = new Dictionary<Type, RelationalTypeMapping>
+        {
+            // Numeric types -> NUMBER
+            { typeof(int), new IntTypeMapping("NUMBER") },
+            { typeof(uint), new UIntTypeMapping("NUMBER") },
+            { typeof(long), new LongTypeMapping("NUMBER") },
+            { typeof(ulong), new ULongTypeMapping("NUMBER") },
+            { typeof(short), new ShortTypeMapping("NUMBER") },
+            { typeof(ushort), new UShortTypeMapping("NUMBER") },
+            { typeof(byte), new ByteTypeMapping("NUMBER") },
+            { typeof(sbyte), new SByteTypeMapping("NUMBER") },
+            { typeof(float), new FloatTypeMapping("NUMBER") },
+            { typeof(double), new DoubleTypeMapping("NUMBER") },
+            { typeof(decimal), new DecimalTypeMapping("NUMBER") },
+
+            // Boolean -> BOOLEAN
+            { typeof(bool), new BoolTypeMapping("BOOLEAN") },
+
+            // String types -> STRING
+            { typeof(string), new StringTypeMapping("STRING", DbType.String) },
+            { typeof(char), new CharTypeMapping("STRING", DbType.StringFixedLength) },
+
+            // Date/time types -> STRING (ISO 8601 format)
+            { typeof(DateTime), new DateTimeTypeMapping("STRING", DbType.DateTime) },
+            { typeof(DateTimeOffset), new DateTimeOffsetTypeMapping("STRING", DbType.DateTimeOffset) },
+            { typeof(DateOnly), new DateOnlyTypeMapping("STRING") },
+            { typeof(TimeOnly), new TimeOnlyTypeMapping("STRING") },
+            { typeof(TimeSpan), new TimeSpanTypeMapping("STRING") },
+
+            // Other types -> STRING
+            { typeof(Guid), new GuidTypeMapping("STRING", DbType.Guid) },
+            { typeof(byte[]), new ByteArrayTypeMapping("STRING", DbType.Binary) },
+
+            // JSON types
             {
-                {
-                    typeof(JsonObject), new CouchbaseTypeMapping(
-                        typeof(JsonObject), jsonValueReaderWriter: dependencies.JsonValueReaderWriterSource.FindReaderWriter(typeof(JsonObject)))
-                },
-                {
-                    typeof(int), new IntTypeMapping("NUMBER")
-                },
-                {
-                    typeof(uint), new UIntTypeMapping("NUMBER")
-                },
-                {
-                    typeof(double), new DoubleTypeMapping("NUMBER")
-                },
-                {
-                    typeof(long), new LongTypeMapping("NUMBER")
-                },
-                {
-                    typeof(bool), new BoolTypeMapping("BOOLEAN")
-                }
-                ,
-                {
-                    typeof(string), new StringTypeMapping("STRING", DbType.String)
-                }
-            };
+                typeof(JsonObject),
+                new CouchbaseTypeMapping(
+                    typeof(JsonObject),
+                    "OBJECT",
+                    jsonValueReaderWriter: dependencies.JsonValueReaderWriterSource.FindReaderWriter(typeof(JsonObject)))
+            },
+            {
+                typeof(JsonArray),
+                new CouchbaseTypeMapping(
+                    typeof(JsonArray),
+                    "ARRAY",
+                    jsonValueReaderWriter: dependencies.JsonValueReaderWriterSource.FindReaderWriter(typeof(JsonArray)))
+            }
+        };
     }
 
     protected override RelationalTypeMapping? FindMapping(in RelationalTypeMappingInfo mappingInfo)

--- a/src/Couchbase.EntityFrameworkCore/Storage/Internal/CouchbaseTypeMappingSource.cs
+++ b/src/Couchbase.EntityFrameworkCore/Storage/Internal/CouchbaseTypeMappingSource.cs
@@ -80,13 +80,15 @@ public class CouchbaseTypeMappingSource : RelationalTypeMappingSource
 
     protected override RelationalTypeMapping? FindMapping(in RelationalTypeMappingInfo mappingInfo)
     {
-       var clrType = mappingInfo.ClrType;
-       if (clrType == null)
-       {
-           throw new InvalidOperationException($"Cannot map type {clrType}");
-       }
+        var clrType = mappingInfo.ClrType;
 
-       return _clrTypeMappings.TryGetValue(clrType, out var mapping) ? mapping : base.FindMapping(in mappingInfo);
+        // ClrType may be null when EF requests a mapping by store type (e.g., during scaffolding/migrations)
+        if (clrType == null)
+        {
+            return base.FindMapping(in mappingInfo);
+        }
+
+        return _clrTypeMappings.TryGetValue(clrType, out var mapping) ? mapping : base.FindMapping(in mappingInfo);
     }
 }
 

--- a/tests/Couchbase.EntityFrameworkCore.UnitTests/Couchbase/EntityFrameworkCore/Storage/Internal/CouchbaseBoolTypeMappingTests.cs
+++ b/tests/Couchbase.EntityFrameworkCore.UnitTests/Couchbase/EntityFrameworkCore/Storage/Internal/CouchbaseBoolTypeMappingTests.cs
@@ -1,0 +1,119 @@
+using Couchbase.EntityFrameworkCore.Storage.Internal;
+using Microsoft.EntityFrameworkCore.Storage;
+using Xunit;
+
+namespace Couchbase.EntityFrameworkCore.UnitTests.Couchbase.EntityFrameworkCore.Storage.Internal;
+
+public class CouchbaseBoolTypeMappingTests
+{
+    [Fact]
+    public void Constructor_SetsStoreTypeToBoolean()
+    {
+        // Act
+        var mapping = new CouchbaseBoolTypeMapping();
+
+        // Assert
+        Assert.Equal("BOOLEAN", mapping.StoreType);
+    }
+
+    [Fact]
+    public void Constructor_SetsClrTypeToBool()
+    {
+        // Act
+        var mapping = new CouchbaseBoolTypeMapping();
+
+        // Assert
+        Assert.Equal(typeof(bool), mapping.ClrType);
+    }
+
+    [Fact]
+    public void GenerateSqlLiteral_WithTrue_ReturnsTRUE()
+    {
+        // Arrange
+        var mapping = new CouchbaseBoolTypeMapping();
+
+        // Act
+        var literal = mapping.GenerateSqlLiteral(true);
+
+        // Assert
+        Assert.Equal("TRUE", literal);
+    }
+
+    [Fact]
+    public void GenerateSqlLiteral_WithFalse_ReturnsFALSE()
+    {
+        // Arrange
+        var mapping = new CouchbaseBoolTypeMapping();
+
+        // Act
+        var literal = mapping.GenerateSqlLiteral(false);
+
+        // Assert
+        Assert.Equal("FALSE", literal);
+    }
+
+    [Fact]
+    public void GenerateSqlLiteral_WithNull_ReturnsNULL()
+    {
+        // Arrange
+        var mapping = new CouchbaseBoolTypeMapping();
+
+        // Act
+        var literal = mapping.GenerateSqlLiteral(null);
+
+        // Assert
+        Assert.Equal("NULL", literal);
+    }
+
+    [Fact]
+    public void Clone_PreservesStoreType()
+    {
+        // Arrange
+        var original = new CouchbaseBoolTypeMapping();
+
+        // Act - Clone is called internally through WithComposedConverter
+        var cloned = original.WithComposedConverter(null);
+
+        // Assert
+        Assert.Equal("BOOLEAN", ((RelationalTypeMapping)cloned).StoreType);
+    }
+
+    [Fact]
+    public void Clone_ReturnsCouchbaseBoolTypeMapping()
+    {
+        // Arrange
+        var original = new CouchbaseBoolTypeMapping();
+
+        // Act
+        var cloned = original.WithComposedConverter(null);
+
+        // Assert
+        Assert.IsType<CouchbaseBoolTypeMapping>(cloned);
+    }
+
+    [Fact]
+    public void ClonedMapping_GenerateSqlLiteral_StillReturnsTrueFalse()
+    {
+        // Arrange
+        var original = new CouchbaseBoolTypeMapping();
+        var cloned = (CouchbaseBoolTypeMapping)original.WithComposedConverter(null);
+
+        // Act
+        var trueLiteral = cloned.GenerateSqlLiteral(true);
+        var falseLiteral = cloned.GenerateSqlLiteral(false);
+
+        // Assert
+        Assert.Equal("TRUE", trueLiteral);
+        Assert.Equal("FALSE", falseLiteral);
+    }
+
+    [Fact]
+    public void Mapping_InheritsBoolTypeMapping()
+    {
+        // Act
+        var mapping = new CouchbaseBoolTypeMapping();
+
+        // Assert
+        Assert.IsAssignableFrom<BoolTypeMapping>(mapping);
+    }
+}

--- a/tests/Couchbase.EntityFrameworkCore.UnitTests/Couchbase/EntityFrameworkCore/Storage/Internal/CouchbaseByteArrayTypeMappingTests.cs
+++ b/tests/Couchbase.EntityFrameworkCore.UnitTests/Couchbase/EntityFrameworkCore/Storage/Internal/CouchbaseByteArrayTypeMappingTests.cs
@@ -1,0 +1,162 @@
+using Couchbase.EntityFrameworkCore.Storage.Internal;
+using Microsoft.EntityFrameworkCore.Storage;
+using Xunit;
+
+namespace Couchbase.EntityFrameworkCore.UnitTests.Couchbase.EntityFrameworkCore.Storage.Internal;
+
+public class CouchbaseByteArrayTypeMappingTests
+{
+    [Fact]
+    public void Constructor_SetsStoreTypeToString()
+    {
+        // Act
+        var mapping = new CouchbaseByteArrayTypeMapping();
+
+        // Assert
+        Assert.Equal("STRING", mapping.StoreType);
+    }
+
+    [Fact]
+    public void Constructor_SetsClrTypeToByteArray()
+    {
+        // Act
+        var mapping = new CouchbaseByteArrayTypeMapping();
+
+        // Assert
+        Assert.Equal(typeof(byte[]), mapping.ClrType);
+    }
+
+    [Fact]
+    public void GenerateSqlLiteral_WithByteArray_ReturnsBase64String()
+    {
+        // Arrange
+        var mapping = new CouchbaseByteArrayTypeMapping();
+        var bytes = new byte[] { 0x48, 0x65, 0x6C, 0x6C, 0x6F }; // "Hello" in ASCII
+
+        // Act
+        var literal = mapping.GenerateSqlLiteral(bytes);
+
+        // Assert - Should be Base64 encoded in single quotes
+        Assert.Equal("'SGVsbG8='", literal);
+    }
+
+    [Fact]
+    public void GenerateSqlLiteral_WithEmptyByteArray_ReturnsEmptyBase64()
+    {
+        // Arrange
+        var mapping = new CouchbaseByteArrayTypeMapping();
+        var bytes = Array.Empty<byte>();
+
+        // Act
+        var literal = mapping.GenerateSqlLiteral(bytes);
+
+        // Assert
+        Assert.Equal("''", literal);
+    }
+
+    [Fact]
+    public void GenerateSqlLiteral_WithNull_ReturnsNULL()
+    {
+        // Arrange
+        var mapping = new CouchbaseByteArrayTypeMapping();
+
+        // Act
+        var literal = mapping.GenerateSqlLiteral(null);
+
+        // Assert
+        Assert.Equal("NULL", literal);
+    }
+
+    [Fact]
+    public void GenerateSqlLiteral_WithBinaryData_ProducesValidBase64()
+    {
+        // Arrange
+        var mapping = new CouchbaseByteArrayTypeMapping();
+        var bytes = new byte[] { 0x00, 0xFF, 0x7F, 0x80, 0xAB, 0xCD };
+
+        // Act
+        var literal = mapping.GenerateSqlLiteral(bytes);
+
+        // Assert - Verify it's a valid Base64 string in single quotes
+        Assert.StartsWith("'", literal);
+        Assert.EndsWith("'", literal);
+        
+        // Extract and decode to verify round-trip
+        var base64 = literal.Trim('\'');
+        var decoded = Convert.FromBase64String(base64);
+        Assert.Equal(bytes, decoded);
+    }
+
+    [Fact]
+    public void GenerateSqlLiteral_IsValidSqlPlusPlus_UsesSingleQuotes()
+    {
+        // Arrange
+        var mapping = new CouchbaseByteArrayTypeMapping();
+        var bytes = new byte[] { 1, 2, 3 };
+
+        // Act
+        var literal = mapping.GenerateSqlLiteral(bytes);
+
+        // Assert - SQL++ string literals use single quotes, not hex format
+        Assert.StartsWith("'", literal);
+        Assert.EndsWith("'", literal);
+        Assert.DoesNotContain("0x", literal); // Not hex format
+    }
+
+    [Fact]
+    public void Clone_PreservesStoreType()
+    {
+        // Arrange
+        var original = new CouchbaseByteArrayTypeMapping();
+
+        // Act - Clone is called internally through WithComposedConverter
+        var cloned = original.WithComposedConverter(null);
+
+        // Assert
+        Assert.Equal("STRING", ((RelationalTypeMapping)cloned).StoreType);
+    }
+
+    [Fact]
+    public void Clone_ReturnsCouchbaseByteArrayTypeMapping()
+    {
+        // Arrange
+        var original = new CouchbaseByteArrayTypeMapping();
+
+        // Act
+        var cloned = original.WithComposedConverter(null);
+
+        // Assert
+        Assert.IsType<CouchbaseByteArrayTypeMapping>(cloned);
+    }
+
+    [Fact]
+    public void Mapping_InheritsRelationalTypeMapping()
+    {
+        // Act
+        var mapping = new CouchbaseByteArrayTypeMapping();
+
+        // Assert
+        Assert.IsAssignableFrom<RelationalTypeMapping>(mapping);
+    }
+
+    [Fact]
+    public void GenerateSqlLiteral_WithLargeByteArray_ProducesValidBase64()
+    {
+        // Arrange
+        var mapping = new CouchbaseByteArrayTypeMapping();
+        var bytes = new byte[1000];
+        new Random(42).NextBytes(bytes);
+
+        // Act
+        var literal = mapping.GenerateSqlLiteral(bytes);
+
+        // Assert
+        Assert.StartsWith("'", literal);
+        Assert.EndsWith("'", literal);
+        
+        // Verify round-trip
+        var base64 = literal.Trim('\'');
+        var decoded = Convert.FromBase64String(base64);
+        Assert.Equal(bytes, decoded);
+    }
+}

--- a/tests/Couchbase.EntityFrameworkCore.UnitTests/Couchbase/EntityFrameworkCore/Storage/Internal/CouchbaseTypeMappingSourceTests.cs
+++ b/tests/Couchbase.EntityFrameworkCore.UnitTests/Couchbase/EntityFrameworkCore/Storage/Internal/CouchbaseTypeMappingSourceTests.cs
@@ -1,0 +1,372 @@
+using System.Text.Json.Nodes;
+using Couchbase.EntityFrameworkCore.Storage.Internal;
+using Microsoft.EntityFrameworkCore.Storage;
+using Microsoft.EntityFrameworkCore.Storage.Json;
+using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
+using Moq;
+using Xunit;
+
+namespace Couchbase.EntityFrameworkCore.UnitTests.Couchbase.EntityFrameworkCore.Storage.Internal;
+
+public class CouchbaseTypeMappingSourceTests
+{
+    private readonly CouchbaseTypeMappingSource _typeMappingSource;
+
+    public CouchbaseTypeMappingSourceTests()
+    {
+        var mockJsonReaderWriterSource = new Mock<IJsonValueReaderWriterSource>();
+        mockJsonReaderWriterSource
+            .Setup(x => x.FindReaderWriter(It.IsAny<Type>()))
+            .Returns((JsonValueReaderWriter?)null);
+
+        var mockValueConverterSelector = new Mock<IValueConverterSelector>();
+
+        var dependencies = new TypeMappingSourceDependencies(
+            mockValueConverterSelector.Object,
+            mockJsonReaderWriterSource.Object,
+            Array.Empty<ITypeMappingSourcePlugin>());
+
+        var relationalDependencies = new RelationalTypeMappingSourceDependencies(
+            Array.Empty<IRelationalTypeMappingSourcePlugin>());
+
+        _typeMappingSource = new CouchbaseTypeMappingSource(dependencies, relationalDependencies);
+    }
+
+    #region Numeric Types -> NUMBER
+
+    [Fact]
+    public void FindMapping_Int_ReturnsNumberType()
+    {
+        var mapping = _typeMappingSource.FindMapping(typeof(int));
+
+        Assert.NotNull(mapping);
+        Assert.Equal("NUMBER", mapping.StoreType);
+        Assert.Equal(typeof(int), mapping.ClrType);
+    }
+
+    [Fact]
+    public void FindMapping_UInt_ReturnsNumberType()
+    {
+        var mapping = _typeMappingSource.FindMapping(typeof(uint));
+
+        Assert.NotNull(mapping);
+        Assert.Equal("NUMBER", mapping.StoreType);
+        Assert.Equal(typeof(uint), mapping.ClrType);
+    }
+
+    [Fact]
+    public void FindMapping_Long_ReturnsNumberType()
+    {
+        var mapping = _typeMappingSource.FindMapping(typeof(long));
+
+        Assert.NotNull(mapping);
+        Assert.Equal("NUMBER", mapping.StoreType);
+        Assert.Equal(typeof(long), mapping.ClrType);
+    }
+
+    [Fact]
+    public void FindMapping_ULong_ReturnsNumberType()
+    {
+        var mapping = _typeMappingSource.FindMapping(typeof(ulong));
+
+        Assert.NotNull(mapping);
+        Assert.Equal("NUMBER", mapping.StoreType);
+        Assert.Equal(typeof(ulong), mapping.ClrType);
+    }
+
+    [Fact]
+    public void FindMapping_Short_ReturnsNumberType()
+    {
+        var mapping = _typeMappingSource.FindMapping(typeof(short));
+
+        Assert.NotNull(mapping);
+        Assert.Equal("NUMBER", mapping.StoreType);
+        Assert.Equal(typeof(short), mapping.ClrType);
+    }
+
+    [Fact]
+    public void FindMapping_UShort_ReturnsNumberType()
+    {
+        var mapping = _typeMappingSource.FindMapping(typeof(ushort));
+
+        Assert.NotNull(mapping);
+        Assert.Equal("NUMBER", mapping.StoreType);
+        Assert.Equal(typeof(ushort), mapping.ClrType);
+    }
+
+    [Fact]
+    public void FindMapping_Byte_ReturnsNumberType()
+    {
+        var mapping = _typeMappingSource.FindMapping(typeof(byte));
+
+        Assert.NotNull(mapping);
+        Assert.Equal("NUMBER", mapping.StoreType);
+        Assert.Equal(typeof(byte), mapping.ClrType);
+    }
+
+    [Fact]
+    public void FindMapping_SByte_ReturnsNumberType()
+    {
+        var mapping = _typeMappingSource.FindMapping(typeof(sbyte));
+
+        Assert.NotNull(mapping);
+        Assert.Equal("NUMBER", mapping.StoreType);
+        Assert.Equal(typeof(sbyte), mapping.ClrType);
+    }
+
+    [Fact]
+    public void FindMapping_Float_ReturnsNumberType()
+    {
+        var mapping = _typeMappingSource.FindMapping(typeof(float));
+
+        Assert.NotNull(mapping);
+        Assert.Equal("NUMBER", mapping.StoreType);
+        Assert.Equal(typeof(float), mapping.ClrType);
+    }
+
+    [Fact]
+    public void FindMapping_Double_ReturnsNumberType()
+    {
+        var mapping = _typeMappingSource.FindMapping(typeof(double));
+
+        Assert.NotNull(mapping);
+        Assert.Equal("NUMBER", mapping.StoreType);
+        Assert.Equal(typeof(double), mapping.ClrType);
+    }
+
+    [Fact]
+    public void FindMapping_Decimal_ReturnsNumberType()
+    {
+        var mapping = _typeMappingSource.FindMapping(typeof(decimal));
+
+        Assert.NotNull(mapping);
+        Assert.Equal("NUMBER", mapping.StoreType);
+        Assert.Equal(typeof(decimal), mapping.ClrType);
+    }
+
+    #endregion
+
+    #region Boolean -> BOOLEAN
+
+    [Fact]
+    public void FindMapping_Bool_ReturnsBooleanType()
+    {
+        var mapping = _typeMappingSource.FindMapping(typeof(bool));
+
+        Assert.NotNull(mapping);
+        Assert.Equal("BOOLEAN", mapping.StoreType);
+        Assert.Equal(typeof(bool), mapping.ClrType);
+    }
+
+    #endregion
+
+    #region String Types -> STRING
+
+    [Fact]
+    public void FindMapping_String_ReturnsStringType()
+    {
+        var mapping = _typeMappingSource.FindMapping(typeof(string));
+
+        Assert.NotNull(mapping);
+        Assert.Equal("STRING", mapping.StoreType);
+        Assert.Equal(typeof(string), mapping.ClrType);
+    }
+
+    [Fact]
+    public void FindMapping_Char_ReturnsStringType()
+    {
+        var mapping = _typeMappingSource.FindMapping(typeof(char));
+
+        Assert.NotNull(mapping);
+        Assert.Equal("STRING", mapping.StoreType);
+        Assert.Equal(typeof(char), mapping.ClrType);
+    }
+
+    #endregion
+
+    #region Date/Time Types -> STRING
+
+    [Fact]
+    public void FindMapping_DateTime_ReturnsStringType()
+    {
+        var mapping = _typeMappingSource.FindMapping(typeof(DateTime));
+
+        Assert.NotNull(mapping);
+        Assert.Equal("STRING", mapping.StoreType);
+        Assert.Equal(typeof(DateTime), mapping.ClrType);
+    }
+
+    [Fact]
+    public void FindMapping_DateTimeOffset_ReturnsStringType()
+    {
+        var mapping = _typeMappingSource.FindMapping(typeof(DateTimeOffset));
+
+        Assert.NotNull(mapping);
+        Assert.Equal("STRING", mapping.StoreType);
+        Assert.Equal(typeof(DateTimeOffset), mapping.ClrType);
+    }
+
+    [Fact]
+    public void FindMapping_DateOnly_ReturnsStringType()
+    {
+        var mapping = _typeMappingSource.FindMapping(typeof(DateOnly));
+
+        Assert.NotNull(mapping);
+        Assert.Equal("STRING", mapping.StoreType);
+        Assert.Equal(typeof(DateOnly), mapping.ClrType);
+    }
+
+    [Fact]
+    public void FindMapping_TimeOnly_ReturnsStringType()
+    {
+        var mapping = _typeMappingSource.FindMapping(typeof(TimeOnly));
+
+        Assert.NotNull(mapping);
+        Assert.Equal("STRING", mapping.StoreType);
+        Assert.Equal(typeof(TimeOnly), mapping.ClrType);
+    }
+
+    [Fact]
+    public void FindMapping_TimeSpan_ReturnsStringType()
+    {
+        var mapping = _typeMappingSource.FindMapping(typeof(TimeSpan));
+
+        Assert.NotNull(mapping);
+        Assert.Equal("STRING", mapping.StoreType);
+        Assert.Equal(typeof(TimeSpan), mapping.ClrType);
+    }
+
+    #endregion
+
+    #region Other Types -> STRING
+
+    [Fact]
+    public void FindMapping_Guid_ReturnsStringType()
+    {
+        var mapping = _typeMappingSource.FindMapping(typeof(Guid));
+
+        Assert.NotNull(mapping);
+        Assert.Equal("STRING", mapping.StoreType);
+        Assert.Equal(typeof(Guid), mapping.ClrType);
+    }
+
+    [Fact]
+    public void FindMapping_ByteArray_ReturnsStringType()
+    {
+        var mapping = _typeMappingSource.FindMapping(typeof(byte[]));
+
+        Assert.NotNull(mapping);
+        Assert.Equal("STRING", mapping.StoreType);
+        Assert.Equal(typeof(byte[]), mapping.ClrType);
+    }
+
+    #endregion
+
+    #region JSON Types
+
+    [Fact]
+    public void FindMapping_JsonObject_ReturnsObjectType()
+    {
+        var mapping = _typeMappingSource.FindMapping(typeof(JsonObject));
+
+        Assert.NotNull(mapping);
+        Assert.Equal(typeof(JsonObject), mapping.ClrType);
+        Assert.Equal("OBJECT", mapping.StoreType);
+        Assert.IsType<CouchbaseTypeMapping>(mapping);
+    }
+
+    [Fact]
+    public void FindMapping_JsonArray_ReturnsArrayType()
+    {
+        var mapping = _typeMappingSource.FindMapping(typeof(JsonArray));
+
+        Assert.NotNull(mapping);
+        Assert.Equal(typeof(JsonArray), mapping.ClrType);
+        Assert.Equal("ARRAY", mapping.StoreType);
+        Assert.IsType<CouchbaseTypeMapping>(mapping);
+    }
+
+    #endregion
+
+    #region Nullable Types
+
+    [Fact]
+    public void FindMapping_NullableInt_ReturnsNumberType()
+    {
+        var mapping = _typeMappingSource.FindMapping(typeof(int?));
+
+        Assert.NotNull(mapping);
+        Assert.Equal("NUMBER", mapping.StoreType);
+    }
+
+    [Fact]
+    public void FindMapping_NullableBool_ReturnsBooleanType()
+    {
+        var mapping = _typeMappingSource.FindMapping(typeof(bool?));
+
+        Assert.NotNull(mapping);
+        Assert.Equal("BOOLEAN", mapping.StoreType);
+    }
+
+    [Fact]
+    public void FindMapping_NullableDateTime_ReturnsStringType()
+    {
+        var mapping = _typeMappingSource.FindMapping(typeof(DateTime?));
+
+        Assert.NotNull(mapping);
+        Assert.Equal("STRING", mapping.StoreType);
+    }
+
+    [Fact]
+    public void FindMapping_NullableGuid_ReturnsStringType()
+    {
+        var mapping = _typeMappingSource.FindMapping(typeof(Guid?));
+
+        Assert.NotNull(mapping);
+        Assert.Equal("STRING", mapping.StoreType);
+    }
+
+    #endregion
+
+    #region Theory Tests for All Numeric Types
+
+    [Theory]
+    [InlineData(typeof(int))]
+    [InlineData(typeof(uint))]
+    [InlineData(typeof(long))]
+    [InlineData(typeof(ulong))]
+    [InlineData(typeof(short))]
+    [InlineData(typeof(ushort))]
+    [InlineData(typeof(byte))]
+    [InlineData(typeof(sbyte))]
+    [InlineData(typeof(float))]
+    [InlineData(typeof(double))]
+    [InlineData(typeof(decimal))]
+    public void FindMapping_NumericTypes_AllMapToNumber(Type clrType)
+    {
+        var mapping = _typeMappingSource.FindMapping(clrType);
+
+        Assert.NotNull(mapping);
+        Assert.Equal("NUMBER", mapping.StoreType);
+    }
+
+    [Theory]
+    [InlineData(typeof(DateTime))]
+    [InlineData(typeof(DateTimeOffset))]
+    [InlineData(typeof(DateOnly))]
+    [InlineData(typeof(TimeOnly))]
+    [InlineData(typeof(TimeSpan))]
+    [InlineData(typeof(Guid))]
+    [InlineData(typeof(string))]
+    [InlineData(typeof(char))]
+    [InlineData(typeof(byte[]))]
+    public void FindMapping_StringSerializedTypes_AllMapToString(Type clrType)
+    {
+        var mapping = _typeMappingSource.FindMapping(clrType);
+
+        Assert.NotNull(mapping);
+        Assert.Equal("STRING", mapping.StoreType);
+    }
+
+    #endregion
+}

--- a/tests/Couchbase.EntityFrameworkCore.UnitTests/Couchbase/EntityFrameworkCore/Storage/Internal/CouchbaseTypeMappingSourceTests.cs
+++ b/tests/Couchbase.EntityFrameworkCore.UnitTests/Couchbase/EntityFrameworkCore/Storage/Internal/CouchbaseTypeMappingSourceTests.cs
@@ -369,4 +369,103 @@ public class CouchbaseTypeMappingSourceTests
     }
 
     #endregion
+
+    #region SQL Literal Generation Tests
+
+    [Fact]
+    public void StringMapping_GenerateSqlLiteral_ProducesSingleQuotedLiteral()
+    {
+        // Arrange - Get the actual mapping used by the provider for strings
+        var mapping = _typeMappingSource.FindMapping(typeof(string));
+
+        // Act
+        var literal = mapping!.GenerateSqlLiteral("MyDiscriminator");
+
+        // Assert - EF Core's StringTypeMapping uses single quotes for SQL
+        Assert.Equal("'MyDiscriminator'", literal);
+    }
+
+    [Fact]
+    public void StringMapping_GenerateSqlLiteral_EscapesSingleQuotes()
+    {
+        // Arrange
+        var mapping = _typeMappingSource.FindMapping(typeof(string));
+
+        // Act
+        var literal = mapping!.GenerateSqlLiteral("It's a test");
+
+        // Assert - Single quotes should be escaped by doubling
+        Assert.Equal("'It''s a test'", literal);
+    }
+
+    [Fact]
+    public void StringMapping_GenerateSqlLiteral_WithNull_ReturnsNull()
+    {
+        // Arrange
+        var mapping = _typeMappingSource.FindMapping(typeof(string));
+
+        // Act
+        var literal = mapping!.GenerateSqlLiteral(null);
+
+        // Assert
+        Assert.Equal("NULL", literal);
+    }
+
+    [Fact]
+    public void BoolMapping_GenerateSqlLiteral_ProducesCorrectLiteral()
+    {
+        // Arrange
+        var mapping = _typeMappingSource.FindMapping(typeof(bool));
+
+        // Act
+        var trueLiteral = mapping!.GenerateSqlLiteral(true);
+        var falseLiteral = mapping!.GenerateSqlLiteral(false);
+
+        // Assert
+        Assert.Equal("1", trueLiteral);
+        Assert.Equal("0", falseLiteral);
+    }
+
+    [Fact]
+    public void IntMapping_GenerateSqlLiteral_ProducesUnquotedNumber()
+    {
+        // Arrange
+        var mapping = _typeMappingSource.FindMapping(typeof(int));
+
+        // Act
+        var literal = mapping!.GenerateSqlLiteral(42);
+
+        // Assert
+        Assert.Equal("42", literal);
+    }
+
+    [Fact]
+    public void JsonObjectMapping_GenerateSqlLiteral_ProducesRawJson()
+    {
+        // Arrange
+        var mapping = _typeMappingSource.FindMapping(typeof(JsonObject));
+        var jsonObject = new JsonObject { ["key"] = "value" };
+
+        // Act
+        var literal = mapping!.GenerateSqlLiteral(jsonObject);
+
+        // Assert - Should be raw JSON, not quoted
+        Assert.Equal("{\"key\":\"value\"}", literal);
+    }
+
+    [Fact]
+    public void JsonArrayMapping_GenerateSqlLiteral_ProducesRawJson()
+    {
+        // Arrange
+        var mapping = _typeMappingSource.FindMapping(typeof(JsonArray));
+        var jsonArray = new JsonArray { 1, 2, 3 };
+
+        // Act
+        var literal = mapping!.GenerateSqlLiteral(jsonArray);
+
+        // Assert - Should be raw JSON array, not quoted
+        Assert.Equal("[1,2,3]", literal);
+    }
+
+    #endregion
 }

--- a/tests/Couchbase.EntityFrameworkCore.UnitTests/Couchbase/EntityFrameworkCore/Storage/Internal/CouchbaseTypeMappingSourceTests.cs
+++ b/tests/Couchbase.EntityFrameworkCore.UnitTests/Couchbase/EntityFrameworkCore/Storage/Internal/CouchbaseTypeMappingSourceTests.cs
@@ -609,6 +609,7 @@ public class CouchbaseTypeMappingSourceTests
         var boolMapping = _typeMappingSource.FindMapping(typeof(bool));
         var jsonObjMapping = _typeMappingSource.FindMapping(typeof(JsonObject));
         var jsonArrMapping = _typeMappingSource.FindMapping(typeof(JsonArray));
+        var byteArrMapping = _typeMappingSource.FindMapping(typeof(byte[]));
 
         // Build a WHERE clause with all types
         var stringLit = stringMapping!.GenerateSqlLiteral("test");
@@ -616,13 +617,60 @@ public class CouchbaseTypeMappingSourceTests
         var boolLit = boolMapping!.GenerateSqlLiteral(true);
         var jsonObjLit = jsonObjMapping!.GenerateSqlLiteral(new JsonObject { ["x"] = 1 });
         var jsonArrLit = jsonArrMapping!.GenerateSqlLiteral(new JsonArray { 1, 2 });
+        var byteArrLit = byteArrMapping!.GenerateSqlLiteral(new byte[] { 1, 2, 3 });
 
         // Assert each follows SQL++ grammar
-        Assert.Equal("'test'", stringLit);      // Single-quoted string
-        Assert.Equal("42", intLit);              // Unquoted number
-        Assert.Equal("TRUE", boolLit);           // TRUE keyword
-        Assert.Equal("{\"x\":1}", jsonObjLit);   // Raw JSON object
-        Assert.Equal("[1,2]", jsonArrLit);       // Raw JSON array
+        Assert.Equal("'test'", stringLit);       // Single-quoted string
+        Assert.Equal("42", intLit);               // Unquoted number
+        Assert.Equal("TRUE", boolLit);            // TRUE keyword
+        Assert.Equal("{\"x\":1}", jsonObjLit);    // Raw JSON object
+        Assert.Equal("[1,2]", jsonArrLit);        // Raw JSON array
+        Assert.Equal("'AQID'", byteArrLit);       // Base64 encoded in single quotes
+    }
+
+    [Fact]
+    public void ByteArrayMapping_ReturnsCouchbaseByteArrayTypeMapping()
+    {
+        // Arrange & Act
+        var mapping = _typeMappingSource.FindMapping(typeof(byte[]));
+
+        // Assert
+        Assert.IsType<CouchbaseByteArrayTypeMapping>(mapping);
+    }
+
+    [Fact]
+    public void ByteArrayLiteral_IsValidSqlPlusPlus_UsesBase64NotHex()
+    {
+        // Arrange
+        var mapping = _typeMappingSource.FindMapping(typeof(byte[]));
+        var bytes = new byte[] { 0x48, 0x65, 0x6C, 0x6C, 0x6F }; // "Hello"
+
+        // Act
+        var literal = mapping!.GenerateSqlLiteral(bytes);
+
+        // Assert - Should be Base64 in single quotes, NOT hex format
+        // Valid SQL++: 'SGVsbG8=' (Base64)
+        // Invalid: 0x48656C6C6F (hex - not valid SQL++ string)
+        Assert.Equal("'SGVsbG8='", literal);
+        Assert.DoesNotContain("0x", literal);
+        Assert.StartsWith("'", literal);
+        Assert.EndsWith("'", literal);
+    }
+
+    [Fact]
+    public void ByteArrayLiteral_RoundTripsCorrectly()
+    {
+        // Arrange
+        var mapping = _typeMappingSource.FindMapping(typeof(byte[]));
+        var originalBytes = new byte[] { 0x00, 0xFF, 0x7F, 0x80 };
+
+        // Act
+        var literal = mapping!.GenerateSqlLiteral(originalBytes);
+
+        // Assert - Verify the Base64 can be decoded back
+        var base64 = literal.Trim('\'');
+        var decodedBytes = Convert.FromBase64String(base64);
+        Assert.Equal(originalBytes, decodedBytes);
     }
 
     #endregion

--- a/tests/Couchbase.EntityFrameworkCore.UnitTests/Couchbase/EntityFrameworkCore/Storage/Internal/CouchbaseTypeMappingSourceTests.cs
+++ b/tests/Couchbase.EntityFrameworkCore.UnitTests/Couchbase/EntityFrameworkCore/Storage/Internal/CouchbaseTypeMappingSourceTests.cs
@@ -485,11 +485,44 @@ public class CouchbaseTypeMappingSourceTests
     public void FindMapping_WithStoreTypeOnly_DoesNotThrow()
     {
         // When EF requests a mapping by store type only (e.g., during scaffolding),
-        // ClrType is null. The provider should fall back to base implementation.
-        // We test this indirectly by verifying that mappings work correctly.
+        // ClrType is null. The provider should fall back to base implementation
+        // rather than throwing an exception.
 
-        // Act & Assert - Should not throw for any valid type
-        var exception = Record.Exception(() => _typeMappingSource.FindMapping(typeof(string)));
+        // Act - Call FindMapping with store type name only (no CLR type)
+        // This exercises the null ClrType code path in FindMapping(in RelationalTypeMappingInfo)
+        var exception = Record.Exception(() => _typeMappingSource.FindMapping("STRING"));
+
+        // Assert - Should not throw
+        Assert.Null(exception);
+    }
+
+    [Fact]
+    public void FindMapping_WithStoreTypeOnly_ReturnsMapping()
+    {
+        // When EF requests a mapping by store type only,
+        // it falls back to base implementation which may return a mapping
+
+        // Act
+        var mapping = _typeMappingSource.FindMapping("NUMBER");
+
+        // Assert - May return null or a mapping, but should not throw
+        // The base implementation handles store-type-only lookups
+        Assert.True(mapping == null || mapping.StoreType == "NUMBER");
+    }
+
+    [Theory]
+    [InlineData("STRING")]
+    [InlineData("NUMBER")]
+    [InlineData("BOOLEAN")]
+    [InlineData("OBJECT")]
+    [InlineData("ARRAY")]
+    [InlineData("UNKNOWN_TYPE")]
+    public void FindMapping_WithVariousStoreTypes_DoesNotThrow(string storeType)
+    {
+        // The null ClrType code path should gracefully handle any store type
+
+        // Act & Assert - Should not throw for any store type
+        var exception = Record.Exception(() => _typeMappingSource.FindMapping(storeType));
         Assert.Null(exception);
     }
 

--- a/tests/Couchbase.EntityFrameworkCore.UnitTests/Couchbase/EntityFrameworkCore/Storage/Internal/CouchbaseTypeMappingSourceTests.cs
+++ b/tests/Couchbase.EntityFrameworkCore.UnitTests/Couchbase/EntityFrameworkCore/Storage/Internal/CouchbaseTypeMappingSourceTests.cs
@@ -478,4 +478,19 @@ public class CouchbaseTypeMappingSourceTests
     }
 
     #endregion
+
+    #region Null ClrType Handling
+
+    [Fact]
+    public void FindMapping_WithNullClrType_DoesNotThrow()
+    {
+        // Arrange - Create mapping info with null ClrType (e.g., when EF requests by store type)
+        var mappingInfo = new RelationalTypeMappingInfo(storeTypeName: "STRING");
+
+        // Act & Assert - Should not throw, should fall back to base implementation
+        var exception = Record.Exception(() => _typeMappingSource.FindMapping(mappingInfo));
+        Assert.Null(exception);
+    }
+
+    #endregion
 }

--- a/tests/Couchbase.EntityFrameworkCore.UnitTests/Couchbase/EntityFrameworkCore/Storage/Internal/CouchbaseTypeMappingSourceTests.cs
+++ b/tests/Couchbase.EntityFrameworkCore.UnitTests/Couchbase/EntityFrameworkCore/Storage/Internal/CouchbaseTypeMappingSourceTests.cs
@@ -482,14 +482,147 @@ public class CouchbaseTypeMappingSourceTests
     #region Null ClrType Handling
 
     [Fact]
-    public void FindMapping_WithNullClrType_DoesNotThrow()
+    public void FindMapping_WithStoreTypeOnly_DoesNotThrow()
     {
-        // Arrange - Create mapping info with null ClrType (e.g., when EF requests by store type)
-        var mappingInfo = new RelationalTypeMappingInfo(storeTypeName: "STRING");
+        // When EF requests a mapping by store type only (e.g., during scaffolding),
+        // ClrType is null. The provider should fall back to base implementation.
+        // We test this indirectly by verifying that mappings work correctly.
 
-        // Act & Assert - Should not throw, should fall back to base implementation
-        var exception = Record.Exception(() => _typeMappingSource.FindMapping(mappingInfo));
+        // Act & Assert - Should not throw for any valid type
+        var exception = Record.Exception(() => _typeMappingSource.FindMapping(typeof(string)));
         Assert.Null(exception);
+    }
+
+    #endregion
+
+    #region SQL++ Literal Format Validation
+
+    [Fact]
+    public void JsonObjectLiteral_IsValidSqlPlusPlus_NotWrappedInQuotes()
+    {
+        // Arrange
+        var mapping = _typeMappingSource.FindMapping(typeof(JsonObject));
+        var jsonObject = new JsonObject { ["name"] = "test" };
+
+        // Act
+        var literal = mapping!.GenerateSqlLiteral(jsonObject);
+
+        // Assert - SQL++ JSON object literals must NOT be wrapped in quotes
+        // Valid SQL++: {"name":"test"}
+        // Invalid SQL++: "{"name":"test"}" or '{"name":"test"}'
+        Assert.StartsWith("{", literal);
+        Assert.EndsWith("}", literal);
+        Assert.DoesNotMatch("^[\"'].*[\"']$", literal); // Not wrapped in quotes
+    }
+
+    [Fact]
+    public void JsonArrayLiteral_IsValidSqlPlusPlus_NotWrappedInQuotes()
+    {
+        // Arrange
+        var mapping = _typeMappingSource.FindMapping(typeof(JsonArray));
+        var jsonArray = new JsonArray { "a", "b" };
+
+        // Act
+        var literal = mapping!.GenerateSqlLiteral(jsonArray);
+
+        // Assert - SQL++ JSON array literals must NOT be wrapped in quotes
+        // Valid SQL++: ["a","b"]
+        // Invalid SQL++: "["a","b"]" or '["a","b"]'
+        Assert.StartsWith("[", literal);
+        Assert.EndsWith("]", literal);
+        Assert.DoesNotMatch("^[\"'].*[\"']$", literal); // Not wrapped in quotes
+    }
+
+    [Fact]
+    public void StringLiteral_IsValidSqlPlusPlus_UsesSingleQuotes()
+    {
+        // Arrange
+        var mapping = _typeMappingSource.FindMapping(typeof(string));
+
+        // Act
+        var literal = mapping!.GenerateSqlLiteral("MyDiscriminator");
+
+        // Assert - SQL++ string literals use single quotes
+        // Valid SQL++: 'MyDiscriminator'
+        // NOT double quotes: "MyDiscriminator"
+        Assert.StartsWith("'", literal);
+        Assert.EndsWith("'", literal);
+        Assert.Equal("'MyDiscriminator'", literal);
+    }
+
+    [Fact]
+    public void StringLiteral_WithEmbeddedQuotes_EscapesCorrectly()
+    {
+        // Arrange
+        var mapping = _typeMappingSource.FindMapping(typeof(string));
+
+        // Act
+        var literal = mapping!.GenerateSqlLiteral("It's a \"test\"");
+
+        // Assert - Single quotes escaped by doubling, double quotes pass through
+        Assert.StartsWith("'", literal);
+        Assert.EndsWith("'", literal);
+        Assert.Contains("''", literal); // Escaped single quote
+    }
+
+    [Fact]
+    public void JsonObjectLiteral_CanBeUsedInSelectStatement()
+    {
+        // This test demonstrates the literal format is valid for SQL++ SELECT
+        // Example: SELECT {"key": "value"} AS obj FROM bucket
+        var mapping = _typeMappingSource.FindMapping(typeof(JsonObject));
+        var jsonObject = new JsonObject { ["status"] = "active", ["count"] = 42 };
+
+        var literal = mapping!.GenerateSqlLiteral(jsonObject);
+
+        // The literal should be directly usable in SQL++ without additional escaping
+        var sqlFragment = $"SELECT {literal} AS obj";
+
+        // Valid SQL++: SELECT {"status":"active","count":42} AS obj
+        Assert.Contains("{\"status\":\"active\",\"count\":42}", sqlFragment);
+        Assert.DoesNotContain("\"{\\'", sqlFragment); // No double-escaping
+    }
+
+    [Fact]
+    public void BooleanLiteral_IsValidSqlPlusPlus_UsesTrueFalse()
+    {
+        // Arrange
+        var mapping = _typeMappingSource.FindMapping(typeof(bool));
+
+        // Act
+        var trueLiteral = mapping!.GenerateSqlLiteral(true);
+        var falseLiteral = mapping!.GenerateSqlLiteral(false);
+
+        // Assert - SQL++ uses TRUE/FALSE keywords, not 1/0
+        // Valid SQL++: SELECT * FROM bucket WHERE active = TRUE
+        // Invalid for Couchbase: WHERE active = 1 (works but not idiomatic)
+        Assert.Equal("TRUE", trueLiteral);
+        Assert.Equal("FALSE", falseLiteral);
+    }
+
+    [Fact]
+    public void AllLiteralFormats_AreConsistentWithSqlPlusPlusGrammar()
+    {
+        // Comprehensive test verifying all literal types produce valid SQL++ syntax
+        var stringMapping = _typeMappingSource.FindMapping(typeof(string));
+        var intMapping = _typeMappingSource.FindMapping(typeof(int));
+        var boolMapping = _typeMappingSource.FindMapping(typeof(bool));
+        var jsonObjMapping = _typeMappingSource.FindMapping(typeof(JsonObject));
+        var jsonArrMapping = _typeMappingSource.FindMapping(typeof(JsonArray));
+
+        // Build a WHERE clause with all types
+        var stringLit = stringMapping!.GenerateSqlLiteral("test");
+        var intLit = intMapping!.GenerateSqlLiteral(42);
+        var boolLit = boolMapping!.GenerateSqlLiteral(true);
+        var jsonObjLit = jsonObjMapping!.GenerateSqlLiteral(new JsonObject { ["x"] = 1 });
+        var jsonArrLit = jsonArrMapping!.GenerateSqlLiteral(new JsonArray { 1, 2 });
+
+        // Assert each follows SQL++ grammar
+        Assert.Equal("'test'", stringLit);      // Single-quoted string
+        Assert.Equal("42", intLit);              // Unquoted number
+        Assert.Equal("TRUE", boolLit);           // TRUE keyword
+        Assert.Equal("{\"x\":1}", jsonObjLit);   // Raw JSON object
+        Assert.Equal("[1,2]", jsonArrLit);       // Raw JSON array
     }
 
     #endregion

--- a/tests/Couchbase.EntityFrameworkCore.UnitTests/Couchbase/EntityFrameworkCore/Storage/Internal/CouchbaseTypeMappingSourceTests.cs
+++ b/tests/Couchbase.EntityFrameworkCore.UnitTests/Couchbase/EntityFrameworkCore/Storage/Internal/CouchbaseTypeMappingSourceTests.cs
@@ -412,7 +412,7 @@ public class CouchbaseTypeMappingSourceTests
     }
 
     [Fact]
-    public void BoolMapping_GenerateSqlLiteral_ProducesCorrectLiteral()
+    public void BoolMapping_GenerateSqlLiteral_ProducesTrueFalseLiterals()
     {
         // Arrange
         var mapping = _typeMappingSource.FindMapping(typeof(bool));
@@ -421,9 +421,19 @@ public class CouchbaseTypeMappingSourceTests
         var trueLiteral = mapping!.GenerateSqlLiteral(true);
         var falseLiteral = mapping!.GenerateSqlLiteral(false);
 
+        // Assert - Couchbase SQL++ uses TRUE/FALSE, not 1/0
+        Assert.Equal("TRUE", trueLiteral);
+        Assert.Equal("FALSE", falseLiteral);
+    }
+
+    [Fact]
+    public void BoolMapping_ReturnsCouchbaseBoolTypeMapping()
+    {
+        // Arrange & Act
+        var mapping = _typeMappingSource.FindMapping(typeof(bool));
+
         // Assert
-        Assert.Equal("1", trueLiteral);
-        Assert.Equal("0", falseLiteral);
+        Assert.IsType<CouchbaseBoolTypeMapping>(mapping);
     }
 
     [Fact]

--- a/tests/Couchbase.EntityFrameworkCore.UnitTests/Couchbase/EntityFrameworkCore/Storage/Internal/CouchbaseTypeMappingTests.cs
+++ b/tests/Couchbase.EntityFrameworkCore.UnitTests/Couchbase/EntityFrameworkCore/Storage/Internal/CouchbaseTypeMappingTests.cs
@@ -1,0 +1,189 @@
+using System.Text.Json.Nodes;
+using Couchbase.EntityFrameworkCore.Storage.Internal;
+using Microsoft.EntityFrameworkCore.ChangeTracking;
+using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
+using Xunit;
+
+namespace Couchbase.EntityFrameworkCore.UnitTests.Couchbase.EntityFrameworkCore.Storage.Internal;
+
+public class CouchbaseTypeMappingTests
+{
+    #region Constructor Tests
+
+    [Fact]
+    public void Constructor_WithClrTypeAndStoreType_SetsProperties()
+    {
+        // Act
+        var mapping = new CouchbaseTypeMapping(typeof(JsonObject), "OBJECT");
+
+        // Assert
+        Assert.Equal(typeof(JsonObject), mapping.ClrType);
+        Assert.Equal("OBJECT", mapping.StoreType);
+    }
+
+    [Fact]
+    public void Constructor_WithArrayStoreType_SetsStoreType()
+    {
+        // Act
+        var mapping = new CouchbaseTypeMapping(typeof(JsonArray), "ARRAY");
+
+        // Assert
+        Assert.Equal(typeof(JsonArray), mapping.ClrType);
+        Assert.Equal("ARRAY", mapping.StoreType);
+    }
+
+    [Theory]
+    [InlineData(typeof(JsonObject), "OBJECT")]
+    [InlineData(typeof(JsonArray), "ARRAY")]
+    [InlineData(typeof(object), "CUSTOM")]
+    public void Constructor_WithVariousTypes_SetsCorrectStoreType(Type clrType, string storeType)
+    {
+        // Act
+        var mapping = new CouchbaseTypeMapping(clrType, storeType);
+
+        // Assert
+        Assert.Equal(clrType, mapping.ClrType);
+        Assert.Equal(storeType, mapping.StoreType);
+    }
+
+    #endregion
+
+    #region Clone Tests
+
+    [Fact]
+    public void Clone_PreservesClrType()
+    {
+        // Arrange
+        var original = new CouchbaseTypeMapping(typeof(JsonObject), "OBJECT");
+
+        // Act - Clone is called internally through WithComposedConverter
+        var cloned = original.WithComposedConverter(null);
+
+        // Assert
+        Assert.Equal(typeof(JsonObject), cloned.ClrType);
+        Assert.IsType<CouchbaseTypeMapping>(cloned);
+    }
+
+    [Fact]
+    public void Clone_PreservesStoreType()
+    {
+        // Arrange
+        var original = new CouchbaseTypeMapping(typeof(JsonArray), "ARRAY");
+
+        // Act
+        var cloned = original.WithComposedConverter(null);
+
+        // Assert
+        Assert.Equal("ARRAY", ((CouchbaseTypeMapping)cloned).StoreType);
+    }
+
+    #endregion
+
+    #region WithComposedConverter Tests
+
+    [Fact]
+    public void WithComposedConverter_WithNullConverter_ReturnsCouchbaseTypeMapping()
+    {
+        // Arrange
+        var mapping = new CouchbaseTypeMapping(typeof(JsonObject), "OBJECT");
+
+        // Act
+        var result = mapping.WithComposedConverter(null);
+
+        // Assert
+        Assert.IsType<CouchbaseTypeMapping>(result);
+    }
+
+    [Fact]
+    public void WithComposedConverter_WithConverter_ReturnsNewInstance()
+    {
+        // Arrange
+        var mapping = new CouchbaseTypeMapping(typeof(JsonObject), "OBJECT");
+        var converter = new ValueConverter<JsonObject, string>(
+            v => v.ToJsonString(),
+            v => JsonNode.Parse(v)!.AsObject());
+
+        // Act
+        var result = mapping.WithComposedConverter(converter);
+
+        // Assert
+        Assert.IsType<CouchbaseTypeMapping>(result);
+        Assert.NotSame(mapping, result);
+    }
+
+    [Fact]
+    public void WithComposedConverter_PreservesStoreType()
+    {
+        // Arrange
+        var mapping = new CouchbaseTypeMapping(typeof(JsonObject), "OBJECT");
+
+        // Act
+        var result = mapping.WithComposedConverter(null);
+
+        // Assert
+        Assert.Equal("OBJECT", ((CouchbaseTypeMapping)result).StoreType);
+    }
+
+    #endregion
+
+    #region SqlLiteralFormatString Tests
+
+    [Fact]
+    public void GenerateSqlLiteral_FormatsWithDoubleQuotes()
+    {
+        // Arrange
+        var mapping = new CouchbaseTypeMapping(typeof(string), "STRING");
+
+        // Act
+        var literal = mapping.GenerateSqlLiteral("test");
+
+        // Assert
+        Assert.Equal("\"test\"", literal);
+    }
+
+    [Fact]
+    public void GenerateSqlLiteral_WithDiscriminatorValue_FormatsCorrectly()
+    {
+        // Arrange
+        var mapping = new CouchbaseTypeMapping(typeof(string), "STRING");
+
+        // Act
+        var literal = mapping.GenerateSqlLiteral("MyEntityType");
+
+        // Assert
+        Assert.Equal("\"MyEntityType\"", literal);
+    }
+
+    #endregion
+
+    #region Type Preservation Tests
+
+    [Fact]
+    public void Mapping_IsRelationalTypeMapping()
+    {
+        // Arrange & Act
+        var mapping = new CouchbaseTypeMapping(typeof(JsonObject), "OBJECT");
+
+        // Assert
+        Assert.IsAssignableFrom<Microsoft.EntityFrameworkCore.Storage.RelationalTypeMapping>(mapping);
+    }
+
+    [Fact]
+    public void MultipleClones_AllReturnCouchbaseTypeMapping()
+    {
+        // Arrange
+        var original = new CouchbaseTypeMapping(typeof(JsonObject), "OBJECT");
+
+        // Act
+        var clone1 = original.WithComposedConverter(null);
+        var clone2 = clone1.WithComposedConverter(null);
+        var clone3 = clone2.WithComposedConverter(null);
+
+        // Assert
+        Assert.IsType<CouchbaseTypeMapping>(clone1);
+        Assert.IsType<CouchbaseTypeMapping>(clone2);
+        Assert.IsType<CouchbaseTypeMapping>(clone3);
+    }
+
+    #endregion
+}

--- a/tests/Couchbase.EntityFrameworkCore.UnitTests/Couchbase/EntityFrameworkCore/Storage/Internal/CouchbaseTypeMappingTests.cs
+++ b/tests/Couchbase.EntityFrameworkCore.UnitTests/Couchbase/EntityFrameworkCore/Storage/Internal/CouchbaseTypeMappingTests.cs
@@ -141,9 +141,11 @@ public class CouchbaseTypeMappingTests
         // Act
         var literal = mapping.GenerateSqlLiteral(jsonObject);
 
-        // Assert - Should be raw JSON, not quoted
+        // Assert - Should be raw JSON, not wrapped in outer quotes
         Assert.Equal("{\"name\":\"test\",\"value\":42}", literal);
-        Assert.DoesNotContain("\"{\\'", literal); // Not double-escaped
+        // Verify it's not string-wrapped (would start with ' or " before the brace)
+        Assert.StartsWith("{", literal);
+        Assert.EndsWith("}", literal);
     }
 
     [Fact]

--- a/tests/Couchbase.EntityFrameworkCore.UnitTests/Couchbase/EntityFrameworkCore/Storage/Internal/CouchbaseTypeMappingTests.cs
+++ b/tests/Couchbase.EntityFrameworkCore.UnitTests/Couchbase/EntityFrameworkCore/Storage/Internal/CouchbaseTypeMappingTests.cs
@@ -126,32 +126,139 @@ public class CouchbaseTypeMappingTests
 
     #endregion
 
-    #region SqlLiteralFormatString Tests
+    #region GenerateNonNullSqlLiteral Tests
 
     [Fact]
-    public void GenerateSqlLiteral_FormatsWithDoubleQuotes()
+    public void GenerateSqlLiteral_WithJsonObject_EmitsRawJson()
     {
         // Arrange
-        var mapping = new CouchbaseTypeMapping(typeof(string), "STRING");
+        var mapping = new CouchbaseTypeMapping(typeof(JsonObject), "OBJECT");
+        var jsonObject = new JsonObject
+        {
+            ["name"] = "test",
+            ["value"] = 42
+        };
 
         // Act
-        var literal = mapping.GenerateSqlLiteral("test");
+        var literal = mapping.GenerateSqlLiteral(jsonObject);
 
-        // Assert
-        Assert.Equal("\"test\"", literal);
+        // Assert - Should be raw JSON, not quoted
+        Assert.Equal("{\"name\":\"test\",\"value\":42}", literal);
+        Assert.DoesNotContain("\"{\\'", literal); // Not double-escaped
     }
 
     [Fact]
-    public void GenerateSqlLiteral_WithDiscriminatorValue_FormatsCorrectly()
+    public void GenerateSqlLiteral_WithJsonArray_EmitsRawJson()
     {
         // Arrange
-        var mapping = new CouchbaseTypeMapping(typeof(string), "STRING");
+        var mapping = new CouchbaseTypeMapping(typeof(JsonArray), "ARRAY");
+        var jsonArray = new JsonArray { 1, 2, 3 };
 
         // Act
-        var literal = mapping.GenerateSqlLiteral("MyEntityType");
+        var literal = mapping.GenerateSqlLiteral(jsonArray);
+
+        // Assert - Should be raw JSON array, not quoted
+        Assert.Equal("[1,2,3]", literal);
+    }
+
+    [Fact]
+    public void GenerateSqlLiteral_WithEmptyJsonObject_EmitsEmptyObject()
+    {
+        // Arrange
+        var mapping = new CouchbaseTypeMapping(typeof(JsonObject), "OBJECT");
+        var jsonObject = new JsonObject();
+
+        // Act
+        var literal = mapping.GenerateSqlLiteral(jsonObject);
 
         // Assert
-        Assert.Equal("\"MyEntityType\"", literal);
+        Assert.Equal("{}", literal);
+    }
+
+    [Fact]
+    public void GenerateSqlLiteral_WithEmptyJsonArray_EmitsEmptyArray()
+    {
+        // Arrange
+        var mapping = new CouchbaseTypeMapping(typeof(JsonArray), "ARRAY");
+        var jsonArray = new JsonArray();
+
+        // Act
+        var literal = mapping.GenerateSqlLiteral(jsonArray);
+
+        // Assert
+        Assert.Equal("[]", literal);
+    }
+
+    [Fact]
+    public void GenerateSqlLiteral_WithNestedJsonObject_EmitsValidJson()
+    {
+        // Arrange
+        var mapping = new CouchbaseTypeMapping(typeof(JsonObject), "OBJECT");
+        var jsonObject = new JsonObject
+        {
+            ["outer"] = new JsonObject
+            {
+                ["inner"] = "value"
+            }
+        };
+
+        // Act
+        var literal = mapping.GenerateSqlLiteral(jsonObject);
+
+        // Assert
+        Assert.Equal("{\"outer\":{\"inner\":\"value\"}}", literal);
+    }
+
+    [Fact]
+    public void GenerateSqlLiteral_WithJsonObjectContainingArray_EmitsValidJson()
+    {
+        // Arrange
+        var mapping = new CouchbaseTypeMapping(typeof(JsonObject), "OBJECT");
+        var jsonObject = new JsonObject
+        {
+            ["items"] = new JsonArray { "a", "b", "c" }
+        };
+
+        // Act
+        var literal = mapping.GenerateSqlLiteral(jsonObject);
+
+        // Assert
+        Assert.Equal("{\"items\":[\"a\",\"b\",\"c\"]}", literal);
+    }
+
+    [Fact]
+    public void GenerateSqlLiteral_WithNull_ReturnsNull()
+    {
+        // Arrange
+        var mapping = new CouchbaseTypeMapping(typeof(JsonObject), "OBJECT");
+
+        // Act
+        var literal = mapping.GenerateSqlLiteral(null);
+
+        // Assert
+        Assert.Equal("NULL", literal);
+    }
+
+    [Fact]
+    public void GenerateSqlLiteral_WithJsonObjectContainingSpecialChars_EmitsProperlyEscapedJson()
+    {
+        // Arrange
+        var mapping = new CouchbaseTypeMapping(typeof(JsonObject), "OBJECT");
+        var jsonObject = new JsonObject
+        {
+            ["text"] = "line1\nline2\ttab",
+            ["quote"] = "say \"hello\""
+        };
+
+        // Act
+        var literal = mapping.GenerateSqlLiteral(jsonObject);
+
+        // Assert - JSON escaping should be handled by System.Text.Json
+        // Newline and tab are escaped
+        Assert.Contains(@"\n", literal);
+        Assert.Contains(@"\t", literal);
+        // System.Text.Json escapes quotes as \u0022
+        Assert.Contains(@"\u0022", literal);
     }
 
     #endregion

--- a/tests/Couchbase.EntityFrameworkCore.UnitTests/Couchbase/EntityFrameworkCore/Storage/Internal/CouchbaseTypeMappingTests.cs
+++ b/tests/Couchbase.EntityFrameworkCore.UnitTests/Couchbase/EntityFrameworkCore/Storage/Internal/CouchbaseTypeMappingTests.cs
@@ -1,6 +1,5 @@
 using System.Text.Json.Nodes;
 using Couchbase.EntityFrameworkCore.Storage.Internal;
-using Microsoft.EntityFrameworkCore.ChangeTracking;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Xunit;
 


### PR DESCRIPTION
**CouchbaseTypeMappingSource**

   **Purpose:** Maps .NET CLR types to Couchbase JSON store types for Entity Framework Core.

   **Changes Made:**
   1. Added comprehensive type mappings for all common .NET types:
     •  Numeric types → NUMBER: int, uint, long, ulong, short, ushort, byte, sbyte, float, double, decimal
     •  Boolean → BOOLEAN: bool
     •  String types → STRING: string, char
     •  Date/time types → STRING (ISO 8601): DateTime, DateTimeOffset, DateOnly, TimeOnly, TimeSpan
     •  Other types → STRING: Guid, byte[] (Base64)
     •  JSON types: JsonObject → OBJECT, JsonArray → ARRAY

   2. Added XML documentation explaining Couchbase's JSON type model

   3. Updated JSON type registrations to pass correct store types ("OBJECT", "ARRAY") instead of generic "couchbase"

   ──────────────────────────────────────────

   **CouchbaseTypeMapping**

   **Purpose:** Custom RelationalTypeMapping for Couchbase JSON types (OBJECT and ARRAY).

   **Changes Made:**
   1. Removed unused fields: _clrType, _comparer, _keyComparer, _jsonValueReaderWriter (base class already stores these via parameters)

   2. Added `storeType` parameter to constructor to properly differentiate between JSON types:
     •  JsonObject → "OBJECT"
     •  JsonArray → "ARRAY"

   3. Fixed constructor implementation to use WithComposedConverter for properly setting comparers and JSON reader/writer

   5. Added XML documentation for all public members

   6. `SqlLiteralFormatString` returns "\"{0}\"" for SQL++ string literal formatting

   ──────────────────────────────────────────

   **Test Coverage**

   CouchbaseTypeMappingSourceTests (47 tests):
   •  Individual tests for each mapped type verifying correct store type
   •  Nullable type handling
   •  Theory tests for all numeric and string-serialized types

   CouchbaseTypeMappingTests (14 tests):
   •  Constructor tests (store type, CLR type)
   •  Clone behavior preservation
   •  WithComposedConverter behavior
   •  SqlLiteralFormatString verification
   •  Type inheritance verification

**Update - changes in this PR:**

   **New files created:**
   •  CouchbaseBoolTypeMapping.cs - Emits TRUE/FALSE literals
   •  CouchbaseByteArrayTypeMapping.cs - Emits Base64 in single quotes
   •  CouchbaseBoolTypeMappingTests.cs - 9 tests
   •  CouchbaseByteArrayTypeMappingTests.cs - 10 tests

   **Modified files:**
   •  CouchbaseTypeMappingSource.cs - Added comprehensive type mappings, fixed null ClrType handling
   •  CouchbaseTypeMapping.cs - Removed SqlLiteralFormatString, added GenerateNonNullSqlLiteral for raw JSON
   •  CouchbaseTypeMappingSourceTests.cs - 63 tests covering all mappings and SQL++ literal validation

   **Key fixes:**
   •  Boolean literals: 1/0 → TRUE/FALSE
   •  Byte arrays: hex format → Base64 single-quoted strings
   •  JSON types: quoted strings → raw JSON literals
   •  Null ClrType: throws → falls back to base implementation