### PR TITLE
Value Generation - Phase 3: Sequence Lifecycle Management

### DIFF
--- a/docs/specs/primary-key-value-generation.md
+++ b/docs/specs/primary-key-value-generation.md
@@ -1,9 +1,9 @@
 # Couchbase EF Core Primary Key Value Generation Specification
 
-**Status:** Complete (Phase 1-2)  
+**Status:** Complete (Phase 1-3)
 **Created:** 2026-05-05  
 **Updated:** 2026-05-06  
-**Phases:** 1-2 (Complete), 3-4 (Deferred)
+**Phases:** 1-3 (Complete), 4 (Deferred)
 
 ---
 
@@ -97,29 +97,60 @@ public class Order
 
 ---
 
-## Phase 3: Sequence Lifecycle Management 📋 DEFERRED
+## Phase 3: Sequence Lifecycle Management ✅ COMPLETE
 
-### 3.1 Update `CouchbaseDatabaseCreator.CreateTables()`
+### 3.1 `CouchbaseSequenceOptions` Record
 
-- Scan model for sequence configurations
-- Execute `CREATE SEQUENCE IF NOT EXISTS bucket.scope.sequence_name`
-- Support sequence options: `START WITH`, `INCREMENT BY`, `MAXVALUE`, `CYCLE`
-
-### 3.2 Sequence Options Model
+**Location:** `src/Couchbase.EntityFrameworkCore/ValueGeneration/CouchbaseSequenceOptions.cs`
 
 ```csharp
-public class CouchbaseSequenceOptions
+public sealed record CouchbaseSequenceOptions
 {
-    public long StartWith { get; set; } = 1;
-    public long IncrementBy { get; set; } = 1;
-    public long? MaxValue { get; set; }
-    public bool Cycle { get; set; } = false;
+    public long StartWith { get; init; } = 1;
+    public long IncrementBy { get; init; } = 1;
+    public long? MaxValue { get; init; }
+    public long? MinValue { get; init; }
+    public bool Cycle { get; init; } = false;
+    public int? CacheSize { get; init; }
 }
 ```
 
-### 3.3 Sequence Drop on Delete
+- Generates SQL++ `CREATE SEQUENCE` options clause via `ToSqlOptionsClause()`
+- Supports all Couchbase sequence options: START WITH, INCREMENT BY, MAXVALUE, MINVALUE, CYCLE, CACHE
 
-- Add sequence cleanup in `CouchbaseDatabaseCreator.Delete()`
+### 3.2 Fluent API with Options
+
+```csharp
+modelBuilder.Entity<Order>()
+    .Property(e => e.Id)
+    .UseSequence("order_seq", new CouchbaseSequenceOptions
+    {
+        StartWith = 1000,
+        IncrementBy = 10
+    });
+```
+
+### 3.3 Attribute with Options
+
+```csharp
+public class Order
+{
+    [CouchbaseSequence("order_seq", StartWith = 1000, IncrementBy = 10)]
+    public long Id { get; set; }
+}
+```
+
+### 3.4 Auto-Creation on EnsureCreatedAsync
+
+- `CouchbaseDatabaseCreator.CreateSequencesAsync()` scans model for sequence annotations
+- Executes `CREATE SEQUENCE IF NOT EXISTS bucket.scope.sequence_name {options}`
+- Called automatically during `EnsureCreatedAsync()`
+
+### 3.5 Sequence Drop on DeleteAsync
+
+- `CouchbaseDatabaseCreator.DropSequencesAsync()` drops all model sequences
+- Executes `DROP SEQUENCE IF EXISTS bucket.scope.sequence_name`
+- Called during `DeleteAsync()` before bucket deletion
 
 ---
 
@@ -139,55 +170,52 @@ public class CouchbaseSequenceOptions
 
 ## Files Created/Modified
 
-### Phase 1-2 (Complete)
+### Phase 1-3 (Complete)
 
 | File | Action | Description |
 |------|--------|-------------|
 | `ValueGeneration/CouchbaseSequenceValueGenerator.cs` | Created | Generic value generator for sequences |
 | `ValueGeneration/CouchbaseValueGeneratorSelector.cs` | Created | Selects generators based on property annotations |
-| `Metadata/CouchbaseSequenceAttribute.cs` | Created | Data annotation for sequence configuration |
-| `Extensions/CouchbasePropertyBuilderExtensions.cs` | Created | `UseSequence()` fluent API |
-| `Metadata/Conventions/CouchbaseSequenceConvention.cs` | Created | Processes sequence attributes |
+| `ValueGeneration/CouchbaseSequenceOptions.cs` | Created | Sequence configuration options (Phase 3) |
+| `Metadata/CouchbaseSequenceAttribute.cs` | Created | Data annotation with options support |
+| `Extensions/CouchbasePropertyBuilderExtensions.cs` | Created | `UseSequence()` fluent API with options overloads |
+| `Metadata/Conventions/CouchbaseSequenceConvention.cs` | Created | Processes sequence attributes with options |
 | `Extensions/CouchbaseServiceCollectionExtensions.cs` | Modified | Registers `CouchbaseValueGeneratorSelector` |
 | `Storage/Internal/CouchbaseSaveChangesInterceptor.cs` | Modified | Generates sequence values during save |
+| `Storage/Internal/CouchbaseDatabaseCreator.cs` | Modified | Auto-creates/drops sequences (Phase 3) |
 
-### Phase 3-4 (Deferred)
+### Phase 4 (Deferred)
 
 | File | Action |
 |------|--------|
-| `ValueGeneration/CouchbaseSequenceOptions.cs` | Create |
-| `Storage/Internal/CouchbaseDatabaseCreator.cs` | Modify |
-| `Extensions/CouchbasePropertyBuilderExtensions.cs` | Extend |
+| `Extensions/CouchbasePropertyBuilderExtensions.cs` | Extend with GUID/ULID support |
 
 ---
 
 ## Test Coverage
 
-### Unit Tests (Phase 1-2) ✅
+### Unit Tests (Phase 1-3) ✅
 
 | Test File | Tests | Description |
 |-----------|-------|-------------|
 | `CouchbaseSequenceValueGeneratorTests.cs` | 12 | Constructor validation, type support, query generation |
 | `CouchbaseSequenceAttributeTests.cs` | 10 | Attribute construction and properties |
 | `CouchbasePropertyBuilderExtensionsTests.cs` | 11 | Fluent API annotation setting, scope override |
+| `CouchbaseSequenceOptionsTests.cs` | 13 | Options record, SQL clause generation (Phase 3) |
 
-### Integration Tests (Phase 1-2) ✅
+### Integration Tests (Phase 1-3) ✅
 
 | Test File | Tests | Description |
 |-----------|-------|-------------|
-| `SequenceValueGenerationTests.cs` | 6 | End-to-end DI/model/save pipeline verification |
+| `SequenceValueGenerationTests.cs` | 7 | End-to-end DI/model/save pipeline, options verification |
 
-Key integration test: `EndToEnd_DIRegistration_SelectorUsedDuringSaveChanges` verifies:
-1. `IValueGeneratorSelector` resolves to `CouchbaseValueGeneratorSelector`
-2. Property has sequence annotation and `ValueGenerated.OnAdd`
-3. Selector creates `CouchbaseSequenceValueGenerator<T>`
-4. `SaveChangesAsync` assigns positive sequence value to entity
+Key integration tests:
+- `EndToEnd_DIRegistration_SelectorUsedDuringSaveChanges` - Full pipeline verification
+- `UseSequence_WithOptions_SetsAnnotationCorrectly` - Options annotation verification
 
-### Integration Tests (Phase 3-4, Deferred)
+### Integration Tests (Phase 4, Deferred)
 
-- Sequence auto-creation on EnsureCreated
-- Batch insert pre-fetches multiple values
-- Sequence options applied correctly
+- GUID/ULID key generation
 
 ---
 
@@ -196,7 +224,7 @@ Key integration test: `EndToEnd_DIRegistration_SelectorUsedDuringSaveChanges` ve
 - Requires Couchbase Server 7.0+
 - Sequences are scoped to bucket.scope
 - Supports numeric types: `int`, `long`, `short`, `byte`, `uint`, `ulong`, `ushort`, `decimal`
-- Sequences must be created manually before use (Phase 3 will add auto-creation)
+- Sequences are auto-created during `EnsureCreatedAsync()` with configured options
 
 ---
 
@@ -206,8 +234,8 @@ Key integration test: `EndToEnd_DIRegistration_SelectorUsedDuringSaveChanges` ve
 |-------|----------|--------|
 | Phase 1: Core Infrastructure | 2-4 hours | ~3 hours |
 | Phase 2: Fluent API & Annotations | 1-2 hours | ~1 hour |
-| Phase 3: Sequence Lifecycle | 1-2 hours | Deferred |
+| Phase 3: Sequence Lifecycle | 1-2 hours | ~1 hour |
 | Phase 4: Client-Side GUID | 30 min | Deferred |
-| Testing | 2-3 hours | ~2 hours |
+| Testing | 2-3 hours | ~2.5 hours |
 
-**Phase 1-2 Total: ~6 hours**
+**Phase 1-3 Total: ~7.5 hours**

--- a/docs/specs/primary-key-value-generation.md
+++ b/docs/specs/primary-key-value-generation.md
@@ -1,8 +1,8 @@
 # Couchbase EF Core Primary Key Value Generation Specification
 
-**Status:** Complete (Phase 1-3)
+**Status:** Complete (Phase 1-3)  
 **Created:** 2026-05-05  
-**Updated:** 2026-05-06  
+**Updated:** 2026-05-07  
 **Phases:** 1-3 (Complete), 4 (Deferred)
 
 ---
@@ -31,9 +31,9 @@ Documentation: https://docs.couchbase.com/server/current/n1ql/n1ql-language-refe
 **Location:** `src/Couchbase.EntityFrameworkCore/ValueGeneration/CouchbaseSequenceValueGenerator.cs`
 
 - Generic value generator supporting `int`, `long`, `short`, `byte`, `uint`, `ulong`, `ushort`, `decimal`
-- Executes `SELECT NEXT VALUE FOR \`bucket\`.\`scope\`.\`sequence_name\``
+- Executes `SELECT NEXT VALUE FOR bucket.scope.sequence_name`
+- Uses `BuildSequenceQuery(ISqlGenerationHelper)` for centralized SQL generation with proper identifier escaping
 - Gets `IRelationalConnection` from `EntityEntry.Context` at runtime (avoids DI lifetime issues)
-- Properly escapes bucket, scope, and sequence names with backticks
 
 ### 1.2 `CouchbaseValueGeneratorSelector`
 
@@ -43,6 +43,7 @@ Documentation: https://docs.couchbase.com/server/current/n1ql/n1ql-language-refe
 - Checks for `Couchbase:SequenceName` annotation on properties
 - Creates appropriate generic `CouchbaseSequenceValueGenerator<T>` via reflection
 - Supports optional `Couchbase:SequenceScope` annotation for scope override
+- Defines annotation keys: `SequenceNameAnnotation`, `SequenceScopeAnnotation`, `SequenceOptionsAnnotation`, `SequenceAutoCreateAnnotation`
 
 ### 1.3 DI Registration
 
@@ -76,6 +77,8 @@ modelBuilder.Entity<Order>()
     .UseSequence("analytics", "order_seq");  // Custom scope
 ```
 
+**Important:** All overloads clear any previously set auto-create annotations to ensure consistent behavior. No-options overloads also clear scope and options annotations.
+
 ### 2.2 Data Annotation: `[CouchbaseSequence]`
 
 **Location:** `src/Couchbase.EntityFrameworkCore/Metadata/CouchbaseSequenceAttribute.cs`
@@ -86,7 +89,24 @@ public class Order
     [CouchbaseSequence("order_seq")]
     public long Id { get; set; }
 }
+
+// With options
+public class OrderWithOptions
+{
+    [CouchbaseSequence("order_seq", StartWith = 1000, IncrementBy = 10, AutoCreate = true)]
+    public long Id { get; set; }
+}
 ```
+
+**Properties:**
+- `SequenceName` - Required sequence name
+- `Scope` - Optional scope override (null = use DbContext scope)
+- `StartWith` - Starting value (default: 1)
+- `IncrementBy` - Increment value (default: 1)
+- `Cycle` - Whether to restart at limit (default: false)
+- `AutoCreate` - Auto-create on EnsureCreatedAsync (default: true)
+
+**Note:** Sequences targeting a non-default scope (via `Scope` property) will not be auto-created even if `AutoCreate = true`, as the scope may not exist.
 
 ### 2.3 Convention: `CouchbaseSequenceConvention`
 
@@ -94,6 +114,8 @@ public class Order
 
 - Processes `CouchbaseSequenceAttribute` during model building
 - Sets annotations based on attribute configuration
+- Only stores `AutoCreate` annotation when `false` (true is default)
+- Only stores options annotation when non-default values are specified
 
 ---
 
@@ -112,11 +134,14 @@ public sealed record CouchbaseSequenceOptions
     public long? MinValue { get; init; }
     public bool Cycle { get; init; } = false;
     public int? CacheSize { get; init; }
+    
+    public string ToSqlOptionsClause() { ... }  // Public method for SQL generation
 }
 ```
 
 - Generates SQL++ `CREATE SEQUENCE` options clause via `ToSqlOptionsClause()`
 - Supports all Couchbase sequence options: START WITH, INCREMENT BY, MAXVALUE, MINVALUE, CYCLE, CACHE
+- `ToSqlOptionsClause()` is public for testability and reuse
 
 ### 3.2 Fluent API with Options
 
@@ -144,13 +169,51 @@ public class Order
 
 - `CouchbaseDatabaseCreator.CreateSequencesAsync()` scans model for sequence annotations
 - Executes `CREATE SEQUENCE IF NOT EXISTS bucket.scope.sequence_name {options}`
-- Called automatically during `EnsureCreatedAsync()`
+- Called automatically during `EnsureCreatedAsync()` (always, even if bucket existed)
+- Uses `ISqlGenerationHelper.DelimitIdentifier()` for proper identifier escaping
+- Detects and throws `InvalidOperationException` for conflicting sequence options across properties
+- Skips sequences with `AutoCreate = false` (logs at Debug level)
+- Skips sequences targeting non-default scopes with warning (scope may not exist)
 
 ### 3.5 Sequence Drop on DeleteAsync
 
 - `CouchbaseDatabaseCreator.DropSequencesAsync()` drops all model sequences
 - Executes `DROP SEQUENCE IF EXISTS bucket.scope.sequence_name`
 - Called during `DeleteAsync()` before bucket deletion
+- Exceptions are suppressed with warning log (cleanup should not fail delete)
+
+### 3.6 AutoCreateScopes Option
+
+**Location:** `src/Couchbase.EntityFrameworkCore/Infrastructure/CouchbaseDbContextOptionsBuilder.cs`
+
+```csharp
+optionsBuilder.UseCouchbase(clusterOptions, opts =>
+{
+    opts.Bucket = "myBucket";
+    opts.Scope = "myScope";
+    opts.AutoCreateScopes = true;  // Enable auto-creation of non-default scopes
+});
+```
+
+- When `true`, scopes referenced in entity keyspace mappings are created automatically
+- When `false` (default), collections in non-default scopes are skipped with a warning
+- Affects both collection and sequence creation
+
+### 3.7 CouchbaseSqlGenerationHelper Security Fix
+
+**Location:** `src/Couchbase.EntityFrameworkCore/Storage/Internal/CouchbaseSqlGenerationHelper.cs`
+
+- Added `EscapeIdentifier()` overrides to properly escape backticks by doubling them
+- Prevents SQL++ injection via malicious identifier names
+- Example: `` my`name `` → `` `my``name` ``
+
+### 3.8 CouchbaseDatabaseCreator Improvements
+
+- `InitializeAsync()` is now idempotent (avoids double-initialization)
+- `GetBucketAsync()` has retry limits (10 retries, 500ms delay) instead of infinite loop
+- Fixed bug: `CreateScopeAsync()` was checking Bucket name instead of Scope name
+- Proper logging throughout
+- Removed unused methods `ScopeExistsAsync()` and `CollectionsExistsAsync()` (dead code with brittle logic)
 
 ---
 
@@ -174,15 +237,18 @@ public class Order
 
 | File | Action | Description |
 |------|--------|-------------|
-| `ValueGeneration/CouchbaseSequenceValueGenerator.cs` | Created | Generic value generator for sequences |
-| `ValueGeneration/CouchbaseValueGeneratorSelector.cs` | Created | Selects generators based on property annotations |
-| `ValueGeneration/CouchbaseSequenceOptions.cs` | Created | Sequence configuration options (Phase 3) |
-| `Metadata/CouchbaseSequenceAttribute.cs` | Created | Data annotation with options support |
-| `Extensions/CouchbasePropertyBuilderExtensions.cs` | Created | `UseSequence()` fluent API with options overloads |
-| `Metadata/Conventions/CouchbaseSequenceConvention.cs` | Created | Processes sequence attributes with options |
-| `Extensions/CouchbaseServiceCollectionExtensions.cs` | Modified | Registers `CouchbaseValueGeneratorSelector` |
-| `Storage/Internal/CouchbaseSaveChangesInterceptor.cs` | Modified | Generates sequence values during save |
-| `Storage/Internal/CouchbaseDatabaseCreator.cs` | Modified | Auto-creates/drops sequences (Phase 3) |
+| `ValueGeneration/CouchbaseSequenceValueGenerator.cs` | Created | Generic value generator using `BuildSequenceQuery(ISqlGenerationHelper)` |
+| `ValueGeneration/CouchbaseValueGeneratorSelector.cs` | Created | Selects generators, defines annotation keys |
+| `ValueGeneration/CouchbaseSequenceOptions.cs` | Created | Sequence options with public `ToSqlOptionsClause()` |
+| `Metadata/CouchbaseSequenceAttribute.cs` | Created | Data annotation with `StartWith`, `IncrementBy`, `Cycle`, `AutoCreate` |
+| `Extensions/CouchbasePropertyBuilderExtensions.cs` | Created | `UseSequence()` fluent API (all overloads clear auto-create annotation) |
+| `Metadata/Conventions/CouchbaseSequenceConvention.cs` | Created | Processes attributes, stores options/auto-create annotations |
+| `Extensions/CouchbaseServiceCollectionExtensions.cs` | Modified | Registers selector after `TryAddCoreServices()` |
+| `Storage/Internal/CouchbaseSaveChangesInterceptor.cs` | Modified | Generates sequence values using `IsTemporary` check |
+| `Storage/Internal/CouchbaseDatabaseCreator.cs` | Modified | Sequence lifecycle, idempotent init, retry limits, scope fix |
+| `Storage/Internal/CouchbaseSqlGenerationHelper.cs` | Modified | `EscapeIdentifier()` for backtick escaping (security) |
+| `Infrastructure/CouchbaseDbContextOptionsBuilder.cs` | Modified | Added `AutoCreateScopes` property |
+| `Infrastructure/ICouchbaseDbContextOptionsBuilder.cs` | Modified | Added `AutoCreateScopes` to interface |
 
 ### Phase 4 (Deferred)
 
@@ -198,10 +264,16 @@ public class Order
 
 | Test File | Tests | Description |
 |-----------|-------|-------------|
-| `CouchbaseSequenceValueGeneratorTests.cs` | 12 | Constructor validation, type support, query generation |
-| `CouchbaseSequenceAttributeTests.cs` | 10 | Attribute construction and properties |
-| `CouchbasePropertyBuilderExtensionsTests.cs` | 11 | Fluent API annotation setting, scope override |
-| `CouchbaseSequenceOptionsTests.cs` | 13 | Options record, SQL clause generation (Phase 3) |
+| `CouchbaseSequenceValueGeneratorTests.cs` | 12 | Constructor validation, type support, query generation with `ISqlGenerationHelper` |
+| `CouchbaseSequenceAttributeTests.cs` | 17 | Attribute construction, properties, defaults |
+| `CouchbasePropertyBuilderExtensionsTests.cs` | 21 | Fluent API, scope override, options clearing behavior |
+| `CouchbaseSequenceOptionsTests.cs` | 13 | Options record, SQL clause generation |
+| `CouchbaseDatabaseCreatorTests.cs` | 15 | Bucket/Scope usage, idempotent init, AutoCreateScopes |
+| `CouchbaseSqlGenerationHelperTests.cs` | 15 | Backtick escaping, parameter naming |
+| `CouchbaseDbContextOptionsBuilderTests.cs` | 8 | AutoCreateScopes, Bucket, Scope properties |
+| `BoolAnnotationReadingTests.cs` | 5 | Boxed bool annotation pattern matching |
+
+**Total Unit Tests:** 450
 
 ### Integration Tests (Phase 1-3) ✅
 
@@ -212,6 +284,11 @@ public class Order
 Key integration tests:
 - `EndToEnd_DIRegistration_SelectorUsedDuringSaveChanges` - Full pipeline verification
 - `UseSequence_WithOptions_SetsAnnotationCorrectly` - Options annotation verification
+- `EnsureCreatedAsync_AutoCreatesSequence_WithOptions` - Sequence auto-creation
+
+### Key Test: Bucket/Scope Confusion Bug
+
+`CouchbaseDatabaseCreatorTests.EnsureCreatedAsync_ChecksForCorrectScopeNotBucket` specifically tests the scenario where bucket name matches a scope name but the configured scope doesn't exist. This would have caught the original bug where `CreateScopeAsync()` was checking `Bucket` instead of `Scope`.
 
 ### Integration Tests (Phase 4, Deferred)
 
@@ -225,6 +302,22 @@ Key integration tests:
 - Sequences are scoped to bucket.scope
 - Supports numeric types: `int`, `long`, `short`, `byte`, `uint`, `ulong`, `ushort`, `decimal`
 - Sequences are auto-created during `EnsureCreatedAsync()` with configured options
+- Sequences targeting non-default scopes are not auto-created (scope may not exist)
+- `AutoCreateScopes` must be enabled to auto-create collections in non-default scopes
+
+---
+
+## Bug Fixes During Implementation
+
+| Bug | Fix | Test Coverage |
+|-----|-----|---------------|
+| `CreateScopeAsync()` checked Bucket instead of Scope | Changed to use `.Scope` | `EnsureCreatedAsync_ChecksForCorrectScopeNotBucket` |
+| Backticks in identifiers not escaped (security) | Added `EscapeIdentifier()` to double backticks | `CouchbaseSqlGenerationHelperTests` (15 tests) |
+| Boxed bool annotations read with `as bool?` (fails) | Changed to pattern matching `is bool b ? b : default` | `BoolAnnotationReadingTests` |
+| `GetBucketAsync()` retried infinitely | Added max 10 retries with 500ms delay | N/A (infrastructure) |
+| Double initialization in `DeleteAsync()` | Made `InitializeAsync()` idempotent | `MultipleOperations_InitializesClusterOnlyOnce` |
+| `UseSequence` options overloads didn't clear auto-create | All overloads now clear `SequenceAutoCreateAnnotation` | N/A (consistency) |
+| Unused methods with brittle logic | Removed `ScopeExistsAsync()` and `CollectionsExistsAsync()` | N/A (dead code removal) |
 
 ---
 
@@ -234,8 +327,8 @@ Key integration tests:
 |-------|----------|--------|
 | Phase 1: Core Infrastructure | 2-4 hours | ~3 hours |
 | Phase 2: Fluent API & Annotations | 1-2 hours | ~1 hour |
-| Phase 3: Sequence Lifecycle | 1-2 hours | ~1 hour |
+| Phase 3: Sequence Lifecycle | 1-2 hours | ~2 hours |
 | Phase 4: Client-Side GUID | 30 min | Deferred |
-| Testing | 2-3 hours | ~2.5 hours |
+| Testing & Bug Fixes | 2-3 hours | ~3 hours |
 
-**Phase 1-3 Total: ~7.5 hours**
+**Phase 1-3 Total: ~9 hours**

--- a/src/Couchbase.EntityFrameworkCore/Extensions/CouchbasePropertyBuilderExtensions.cs
+++ b/src/Couchbase.EntityFrameworkCore/Extensions/CouchbasePropertyBuilderExtensions.cs
@@ -119,6 +119,10 @@ public static class CouchbasePropertyBuilderExtensions
     /// When using <see cref="Microsoft.EntityFrameworkCore.DbContext.Database"/>.<see cref="Microsoft.EntityFrameworkCore.Infrastructure.DatabaseFacade.EnsureCreatedAsync"/>,
     /// the sequence will be automatically created with the specified options.
     /// </para>
+    /// <para>
+    /// This overload clears any previously configured scope override or auto-create settings,
+    /// reverting to default behavior (auto-create enabled).
+    /// </para>
     /// </remarks>
     /// <param name="propertyBuilder">The property builder.</param>
     /// <param name="sequenceName">The name of the sequence.</param>
@@ -147,6 +151,7 @@ public static class CouchbasePropertyBuilderExtensions
             CouchbaseValueGeneratorSelector.SequenceNameAnnotation,
             sequenceName);
 
+        // Clear any previous scope override to revert to default
         propertyBuilder.HasAnnotation(
             CouchbaseValueGeneratorSelector.SequenceScopeAnnotation,
             null);
@@ -154,6 +159,11 @@ public static class CouchbasePropertyBuilderExtensions
         propertyBuilder.HasAnnotation(
             CouchbaseValueGeneratorSelector.SequenceOptionsAnnotation,
             options);
+
+        // Clear any previous auto-create override to revert to default (true)
+        propertyBuilder.HasAnnotation(
+            CouchbaseValueGeneratorSelector.SequenceAutoCreateAnnotation,
+            null);
 
         propertyBuilder.ValueGeneratedOnAdd();
 
@@ -164,6 +174,15 @@ public static class CouchbasePropertyBuilderExtensions
     /// Configures the property to have its value generated using a Couchbase sequence
     /// in the specified scope with custom options.
     /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The scope specified here overrides the DbContext-level scope for this sequence.
+    /// </para>
+    /// <para>
+    /// This overload clears any previously configured auto-create settings,
+    /// reverting to default behavior (auto-create enabled).
+    /// </para>
+    /// </remarks>
     /// <param name="propertyBuilder">The property builder.</param>
     /// <param name="scope">The scope containing the sequence.</param>
     /// <param name="sequenceName">The name of the sequence.</param>
@@ -190,6 +209,11 @@ public static class CouchbasePropertyBuilderExtensions
         propertyBuilder.HasAnnotation(
             CouchbaseValueGeneratorSelector.SequenceOptionsAnnotation,
             options);
+
+        // Clear any previous auto-create override to revert to default (true)
+        propertyBuilder.HasAnnotation(
+            CouchbaseValueGeneratorSelector.SequenceAutoCreateAnnotation,
+            null);
 
         propertyBuilder.ValueGeneratedOnAdd();
 

--- a/src/Couchbase.EntityFrameworkCore/Extensions/CouchbasePropertyBuilderExtensions.cs
+++ b/src/Couchbase.EntityFrameworkCore/Extensions/CouchbasePropertyBuilderExtensions.cs
@@ -1,5 +1,4 @@
 using Couchbase.EntityFrameworkCore.ValueGeneration;
-using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
 
 namespace Couchbase.EntityFrameworkCore.Extensions;
@@ -90,6 +89,92 @@ public static class CouchbasePropertyBuilderExtensions
         propertyBuilder.HasAnnotation(
             CouchbaseValueGeneratorSelector.SequenceScopeAnnotation,
             scope);
+
+        propertyBuilder.ValueGeneratedOnAdd();
+
+        return propertyBuilder;
+    }
+
+    /// <summary>
+    /// Configures the property to have its value generated using a Couchbase sequence
+    /// with custom options.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// When using <see cref="Microsoft.EntityFrameworkCore.DbContext.Database"/>.<see cref="Microsoft.EntityFrameworkCore.Infrastructure.DatabaseFacade.EnsureCreatedAsync"/>,
+    /// the sequence will be automatically created with the specified options.
+    /// </para>
+    /// </remarks>
+    /// <param name="propertyBuilder">The property builder.</param>
+    /// <param name="sequenceName">The name of the sequence.</param>
+    /// <param name="options">The sequence options (start value, increment, etc.).</param>
+    /// <returns>The same property builder for method chaining.</returns>
+    /// <example>
+    /// <code>
+    /// modelBuilder.Entity&lt;Order&gt;()
+    ///     .Property(e => e.Id)
+    ///     .UseSequence("order_seq", new CouchbaseSequenceOptions
+    ///     {
+    ///         StartWith = 1000,
+    ///         IncrementBy = 10
+    ///     });
+    /// </code>
+    /// </example>
+    public static PropertyBuilder<TProperty> UseSequence<TProperty>(
+        this PropertyBuilder<TProperty> propertyBuilder,
+        string sequenceName,
+        CouchbaseSequenceOptions options)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(sequenceName);
+        ArgumentNullException.ThrowIfNull(options);
+
+        propertyBuilder.HasAnnotation(
+            CouchbaseValueGeneratorSelector.SequenceNameAnnotation,
+            sequenceName);
+
+        propertyBuilder.HasAnnotation(
+            CouchbaseValueGeneratorSelector.SequenceScopeAnnotation,
+            null);
+
+        propertyBuilder.HasAnnotation(
+            CouchbaseValueGeneratorSelector.SequenceOptionsAnnotation,
+            options);
+
+        propertyBuilder.ValueGeneratedOnAdd();
+
+        return propertyBuilder;
+    }
+
+    /// <summary>
+    /// Configures the property to have its value generated using a Couchbase sequence
+    /// in the specified scope with custom options.
+    /// </summary>
+    /// <param name="propertyBuilder">The property builder.</param>
+    /// <param name="scope">The scope containing the sequence.</param>
+    /// <param name="sequenceName">The name of the sequence.</param>
+    /// <param name="options">The sequence options (start value, increment, etc.).</param>
+    /// <returns>The same property builder for method chaining.</returns>
+    public static PropertyBuilder<TProperty> UseSequence<TProperty>(
+        this PropertyBuilder<TProperty> propertyBuilder,
+        string scope,
+        string sequenceName,
+        CouchbaseSequenceOptions options)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(scope);
+        ArgumentException.ThrowIfNullOrEmpty(sequenceName);
+        ArgumentNullException.ThrowIfNull(options);
+
+        propertyBuilder.HasAnnotation(
+            CouchbaseValueGeneratorSelector.SequenceNameAnnotation,
+            sequenceName);
+
+        propertyBuilder.HasAnnotation(
+            CouchbaseValueGeneratorSelector.SequenceScopeAnnotation,
+            scope);
+
+        propertyBuilder.HasAnnotation(
+            CouchbaseValueGeneratorSelector.SequenceOptionsAnnotation,
+            options);
 
         propertyBuilder.ValueGeneratedOnAdd();
 

--- a/src/Couchbase.EntityFrameworkCore/Extensions/CouchbasePropertyBuilderExtensions.cs
+++ b/src/Couchbase.EntityFrameworkCore/Extensions/CouchbasePropertyBuilderExtensions.cs
@@ -9,15 +9,16 @@ namespace Couchbase.EntityFrameworkCore.Extensions;
 public static class CouchbasePropertyBuilderExtensions
 {
     /// <summary>
-    /// Configures the property to have its value generated using a Couchbase sequence.
+    /// Configures the property to have its value generated using a Couchbase sequence
+    /// with default options.
     /// </summary>
     /// <remarks>
     /// <para>
-    /// The sequence must already exist in the database. Use the Couchbase SQL++ statement
-    /// <c>CREATE SEQUENCE bucket.scope.sequence_name</c> to create the sequence.
+    /// The sequence will be looked up in the bucket and scope configured on the DbContext.
     /// </para>
     /// <para>
-    /// The sequence will be looked up in the bucket and scope configured on the DbContext.
+    /// This overload clears any previously configured scope override, custom options, or
+    /// auto-create settings, reverting to default behavior.
     /// </para>
     /// </remarks>
     /// <param name="propertyBuilder">The property builder.</param>
@@ -40,9 +41,15 @@ public static class CouchbasePropertyBuilderExtensions
             CouchbaseValueGeneratorSelector.SequenceNameAnnotation,
             sequenceName);
 
-        // Clear any previous scope override to revert to DbContext-level scope
+        // Clear any previous overrides to revert to defaults
         propertyBuilder.HasAnnotation(
             CouchbaseValueGeneratorSelector.SequenceScopeAnnotation,
+            null);
+        propertyBuilder.HasAnnotation(
+            CouchbaseValueGeneratorSelector.SequenceOptionsAnnotation,
+            null);
+        propertyBuilder.HasAnnotation(
+            CouchbaseValueGeneratorSelector.SequenceAutoCreateAnnotation,
             null);
 
         propertyBuilder.ValueGeneratedOnAdd();
@@ -52,15 +59,15 @@ public static class CouchbasePropertyBuilderExtensions
 
     /// <summary>
     /// Configures the property to have its value generated using a Couchbase sequence
-    /// in the specified scope.
+    /// in the specified scope with default options.
     /// </summary>
     /// <remarks>
     /// <para>
-    /// The sequence must already exist in the database. Use the Couchbase SQL++ statement
-    /// <c>CREATE SEQUENCE bucket.scope.sequence_name</c> to create the sequence.
+    /// The scope specified here overrides the DbContext-level scope for this sequence.
     /// </para>
     /// <para>
-    /// The scope specified here overrides the DbContext-level scope for this sequence.
+    /// This overload clears any previously configured custom options or auto-create settings,
+    /// reverting to default behavior.
     /// </para>
     /// </remarks>
     /// <param name="propertyBuilder">The property builder.</param>
@@ -89,6 +96,14 @@ public static class CouchbasePropertyBuilderExtensions
         propertyBuilder.HasAnnotation(
             CouchbaseValueGeneratorSelector.SequenceScopeAnnotation,
             scope);
+
+        // Clear any previous options/auto-create overrides to revert to defaults
+        propertyBuilder.HasAnnotation(
+            CouchbaseValueGeneratorSelector.SequenceOptionsAnnotation,
+            null);
+        propertyBuilder.HasAnnotation(
+            CouchbaseValueGeneratorSelector.SequenceAutoCreateAnnotation,
+            null);
 
         propertyBuilder.ValueGeneratedOnAdd();
 
@@ -182,8 +197,13 @@ public static class CouchbasePropertyBuilderExtensions
     }
 
     /// <summary>
-    /// Configures the property to have its value generated using a Couchbase sequence.
+    /// Configures the property to have its value generated using a Couchbase sequence
+    /// with default options.
     /// </summary>
+    /// <remarks>
+    /// This overload clears any previously configured scope override, custom options, or
+    /// auto-create settings, reverting to default behavior.
+    /// </remarks>
     /// <param name="propertyBuilder">The property builder.</param>
     /// <param name="sequenceName">The name of the sequence.</param>
     /// <returns>The same property builder for method chaining.</returns>
@@ -197,9 +217,15 @@ public static class CouchbasePropertyBuilderExtensions
             CouchbaseValueGeneratorSelector.SequenceNameAnnotation,
             sequenceName);
 
-        // Clear any previous scope override to revert to DbContext-level scope
+        // Clear any previous overrides to revert to defaults
         propertyBuilder.HasAnnotation(
             CouchbaseValueGeneratorSelector.SequenceScopeAnnotation,
+            null);
+        propertyBuilder.HasAnnotation(
+            CouchbaseValueGeneratorSelector.SequenceOptionsAnnotation,
+            null);
+        propertyBuilder.HasAnnotation(
+            CouchbaseValueGeneratorSelector.SequenceAutoCreateAnnotation,
             null);
 
         propertyBuilder.ValueGeneratedOnAdd();
@@ -209,8 +235,12 @@ public static class CouchbasePropertyBuilderExtensions
 
     /// <summary>
     /// Configures the property to have its value generated using a Couchbase sequence
-    /// in the specified scope.
+    /// in the specified scope with default options.
     /// </summary>
+    /// <remarks>
+    /// This overload clears any previously configured custom options or auto-create settings,
+    /// reverting to default behavior.
+    /// </remarks>
     /// <param name="propertyBuilder">The property builder.</param>
     /// <param name="scope">The scope containing the sequence.</param>
     /// <param name="sequenceName">The name of the sequence.</param>
@@ -230,6 +260,14 @@ public static class CouchbasePropertyBuilderExtensions
         propertyBuilder.HasAnnotation(
             CouchbaseValueGeneratorSelector.SequenceScopeAnnotation,
             scope);
+
+        // Clear any previous options/auto-create overrides to revert to defaults
+        propertyBuilder.HasAnnotation(
+            CouchbaseValueGeneratorSelector.SequenceOptionsAnnotation,
+            null);
+        propertyBuilder.HasAnnotation(
+            CouchbaseValueGeneratorSelector.SequenceAutoCreateAnnotation,
+            null);
 
         propertyBuilder.ValueGeneratedOnAdd();
 

--- a/src/Couchbase.EntityFrameworkCore/Infrastructure/CouchbaseDbContextOptionsBuilder.cs
+++ b/src/Couchbase.EntityFrameworkCore/Infrastructure/CouchbaseDbContextOptionsBuilder.cs
@@ -31,6 +31,8 @@ public class CouchbaseDbContextOptionsBuilder : ICouchbaseDbContextOptionsBuilde
 
     public string Scope { get; set; }
 
+    public bool AutoCreateScopes { get; set; }
+
     DbContextOptionsBuilder ICouchbaseDbContextOptionsBuilder.OptionsBuilder => OptionsBuilder;
 }
 
@@ -45,6 +47,17 @@ public interface ICouchbaseDbContextOptionsBuilder
     public string Bucket { get; set; }
 
     public string Scope { get; set; }
+
+    /// <summary>
+    /// Gets or sets whether to automatically create non-default scopes referenced by entity mappings
+    /// when <see cref="Microsoft.EntityFrameworkCore.Infrastructure.DatabaseFacade.EnsureCreatedAsync"/> is called.
+    /// Defaults to false.
+    /// </summary>
+    /// <remarks>
+    /// When false, collections mapped to non-default scopes will be skipped with a warning.
+    /// When true, any scopes referenced in entity keyspace mappings will be created automatically.
+    /// </remarks>
+    public bool AutoCreateScopes { get; set; }
 }
 
 /* ************************************************************

--- a/src/Couchbase.EntityFrameworkCore/Metadata/Conventions/CouchbaseSequenceConvention.cs
+++ b/src/Couchbase.EntityFrameworkCore/Metadata/Conventions/CouchbaseSequenceConvention.cs
@@ -38,6 +38,23 @@ public class CouchbaseSequenceConvention : PropertyAttributeConventionBase<Couch
                 attribute.Scope);
         }
 
+        // Create sequence options from attribute properties
+        var options = new CouchbaseSequenceOptions
+        {
+            StartWith = attribute.StartWith,
+            IncrementBy = attribute.IncrementBy,
+            Cycle = attribute.Cycle
+        };
+
+        // Only set options annotation if not using defaults (to reduce annotation noise)
+        if (options != CouchbaseSequenceOptions.Default || !attribute.AutoCreate)
+        {
+            // Store auto-create flag with options by using a wrapper or separate annotation
+            propertyBuilder.HasAnnotation(
+                CouchbaseValueGeneratorSelector.SequenceOptionsAnnotation,
+                options);
+        }
+
         // Mark the property as ValueGeneratedOnAdd
         propertyBuilder.ValueGenerated(ValueGenerated.OnAdd);
     }

--- a/src/Couchbase.EntityFrameworkCore/Metadata/Conventions/CouchbaseSequenceConvention.cs
+++ b/src/Couchbase.EntityFrameworkCore/Metadata/Conventions/CouchbaseSequenceConvention.cs
@@ -47,12 +47,19 @@ public class CouchbaseSequenceConvention : PropertyAttributeConventionBase<Couch
         };
 
         // Only set options annotation if not using defaults (to reduce annotation noise)
-        if (options != CouchbaseSequenceOptions.Default || !attribute.AutoCreate)
+        if (options != CouchbaseSequenceOptions.Default)
         {
-            // Store auto-create flag with options by using a wrapper or separate annotation
             propertyBuilder.HasAnnotation(
                 CouchbaseValueGeneratorSelector.SequenceOptionsAnnotation,
                 options);
+        }
+
+        // Store auto-create flag (only if false, since true is the default)
+        if (!attribute.AutoCreate)
+        {
+            propertyBuilder.HasAnnotation(
+                CouchbaseValueGeneratorSelector.SequenceAutoCreateAnnotation,
+                false);
         }
 
         // Mark the property as ValueGeneratedOnAdd

--- a/src/Couchbase.EntityFrameworkCore/Metadata/CouchbaseSequenceAttribute.cs
+++ b/src/Couchbase.EntityFrameworkCore/Metadata/CouchbaseSequenceAttribute.cs
@@ -10,8 +10,8 @@ namespace Couchbase.EntityFrameworkCore.Metadata;
 /// entity is added to the context.
 /// </para>
 /// <para>
-/// The sequence must already exist in the database. Use the Couchbase SQL++ statement
-/// <c>CREATE SEQUENCE bucket.scope.sequence_name</c> to create the sequence.
+/// If <see cref="AutoCreate"/> is true (default), the sequence will be created automatically
+/// when <see cref="Microsoft.EntityFrameworkCore.Infrastructure.DatabaseFacade.EnsureCreatedAsync"/> is called.
 /// </para>
 /// </remarks>
 /// <example>
@@ -62,4 +62,26 @@ public class CouchbaseSequenceAttribute : Attribute
     /// Gets the scope containing the sequence, or <c>null</c> to use the DbContext-level scope.
     /// </summary>
     public string? Scope { get; }
+
+    /// <summary>
+    /// Gets or sets the starting value of the sequence. Defaults to 1.
+    /// </summary>
+    public long StartWith { get; set; } = 1;
+
+    /// <summary>
+    /// Gets or sets the increment value for each call to NEXT VALUE FOR. Defaults to 1.
+    /// </summary>
+    public long IncrementBy { get; set; } = 1;
+
+    /// <summary>
+    /// Gets or sets whether the sequence should restart when the limit is reached.
+    /// Defaults to false.
+    /// </summary>
+    public bool Cycle { get; set; } = false;
+
+    /// <summary>
+    /// Gets or sets whether to automatically create the sequence on EnsureCreated.
+    /// Defaults to true.
+    /// </summary>
+    public bool AutoCreate { get; set; } = true;
 }

--- a/src/Couchbase.EntityFrameworkCore/Metadata/CouchbaseSequenceAttribute.cs
+++ b/src/Couchbase.EntityFrameworkCore/Metadata/CouchbaseSequenceAttribute.cs
@@ -11,7 +11,10 @@ namespace Couchbase.EntityFrameworkCore.Metadata;
 /// </para>
 /// <para>
 /// If <see cref="AutoCreate"/> is true (default), the sequence will be created automatically
-/// when <see cref="Microsoft.EntityFrameworkCore.Infrastructure.DatabaseFacade.EnsureCreatedAsync"/> is called.
+/// when <see cref="Microsoft.EntityFrameworkCore.Infrastructure.DatabaseFacade.EnsureCreatedAsync"/> is called,
+/// provided the sequence uses the DbContext-level scope. Sequences targeting a non-default scope
+/// (via the <see cref="Scope"/> property) will not be auto-created, as the scope may not exist.
+/// A warning will be logged in this case; create the scope and sequence manually or use the default scope.
 /// </para>
 /// </remarks>
 /// <example>
@@ -80,8 +83,14 @@ public class CouchbaseSequenceAttribute : Attribute
     public bool Cycle { get; set; } = false;
 
     /// <summary>
-    /// Gets or sets whether to automatically create the sequence on EnsureCreated.
+    /// Gets or sets whether to automatically create the sequence when
+    /// <see cref="Microsoft.EntityFrameworkCore.Infrastructure.DatabaseFacade.EnsureCreatedAsync"/> is called.
     /// Defaults to true.
     /// </summary>
+    /// <remarks>
+    /// Auto-creation only applies to sequences using the DbContext-level scope.
+    /// Sequences targeting a non-default scope (via <see cref="Scope"/>) will not be
+    /// auto-created even if this property is true, as the scope may not exist.
+    /// </remarks>
     public bool AutoCreate { get; set; } = true;
 }

--- a/src/Couchbase.EntityFrameworkCore/Storage/Internal/CouchbaseDatabaseCreator.cs
+++ b/src/Couchbase.EntityFrameworkCore/Storage/Internal/CouchbaseDatabaseCreator.cs
@@ -3,6 +3,7 @@ using Couchbase.Diagnostics;
 using Couchbase.EntityFrameworkCore.Extensions;
 using Couchbase.EntityFrameworkCore.Infrastructure;
 using Couchbase.EntityFrameworkCore.Utils;
+using Couchbase.EntityFrameworkCore.ValueGeneration;
 using Couchbase.Extensions.DependencyInjection;
 using Couchbase.Management.Buckets;
 using Couchbase.Management.Collections;
@@ -147,6 +148,112 @@ public class CouchbaseDatabaseCreator :  RelationalDatabaseCreator
         }
     }
 
+    private async Task CreateSequencesAsync()
+    {
+        var bucket = await GetBucketAsync();
+        var scope = await bucket.ScopeAsync(_couchbaseDbContextOptionsBuilder.Scope);
+
+        // Collect all unique sequences from the model
+        var sequences = new Dictionary<string, (string Scope, CouchbaseSequenceOptions Options)>();
+
+        foreach (var entityType in _designTimeModel.Model.GetEntityTypes())
+        {
+            foreach (var property in entityType.GetProperties())
+            {
+                var sequenceName = property.FindAnnotation(CouchbaseValueGeneratorSelector.SequenceNameAnnotation)?.Value as string;
+                if (string.IsNullOrEmpty(sequenceName))
+                {
+                    continue;
+                }
+
+                // Get scope override or use default
+                var sequenceScope = property.FindAnnotation(CouchbaseValueGeneratorSelector.SequenceScopeAnnotation)?.Value as string
+                    ?? _couchbaseDbContextOptionsBuilder.Scope;
+
+                // Get options or use default
+                var options = property.FindAnnotation(CouchbaseValueGeneratorSelector.SequenceOptionsAnnotation)?.Value as CouchbaseSequenceOptions
+                    ?? CouchbaseSequenceOptions.Default;
+
+                // Use scope.sequenceName as key to handle sequences in different scopes
+                var key = $"{sequenceScope}.{sequenceName}";
+                if (!sequences.ContainsKey(key))
+                {
+                    sequences[key] = (sequenceScope, options);
+                }
+            }
+        }
+
+        // Create each sequence
+        foreach (var (key, (sequenceScope, options)) in sequences)
+        {
+            var sequenceName = key.Split('.').Last();
+            await CreateSequenceAsync(sequenceScope, sequenceName, options);
+        }
+    }
+
+    private async Task CreateSequenceAsync(string scope, string sequenceName, CouchbaseSequenceOptions options)
+    {
+        try
+        {
+            var bucket = await GetBucketAsync();
+            var scopeObj = await bucket.ScopeAsync(scope);
+
+            // Build CREATE SEQUENCE statement
+            var sql = $"CREATE SEQUENCE IF NOT EXISTS `{_couchbaseDbContextOptionsBuilder.Bucket}`.`{scope}`.`{sequenceName}` {options.ToSqlOptionsClause()}";
+
+            _logger.LogDebug("Creating sequence: {Sql}", sql);
+
+            await scopeObj.QueryAsync<dynamic>(sql);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Failed to create sequence {SequenceName} in scope {Scope}", sequenceName, scope);
+        }
+    }
+
+    private async Task DropSequencesAsync()
+    {
+        var bucket = await GetBucketAsync();
+
+        // Collect all unique sequences from the model
+        var sequences = new HashSet<(string Scope, string Name)>();
+
+        foreach (var entityType in _designTimeModel.Model.GetEntityTypes())
+        {
+            foreach (var property in entityType.GetProperties())
+            {
+                var sequenceName = property.FindAnnotation(CouchbaseValueGeneratorSelector.SequenceNameAnnotation)?.Value as string;
+                if (string.IsNullOrEmpty(sequenceName))
+                {
+                    continue;
+                }
+
+                var sequenceScope = property.FindAnnotation(CouchbaseValueGeneratorSelector.SequenceScopeAnnotation)?.Value as string
+                    ?? _couchbaseDbContextOptionsBuilder.Scope;
+
+                sequences.Add((sequenceScope, sequenceName));
+            }
+        }
+
+        // Drop each sequence
+        foreach (var (scope, sequenceName) in sequences)
+        {
+            try
+            {
+                var scopeObj = await bucket.ScopeAsync(scope);
+                var sql = $"DROP SEQUENCE IF EXISTS `{_couchbaseDbContextOptionsBuilder.Bucket}`.`{scope}`.`{sequenceName}`";
+
+                _logger.LogDebug("Dropping sequence: {Sql}", sql);
+
+                await scopeObj.QueryAsync<dynamic>(sql);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex, "Failed to drop sequence {SequenceName} in scope {Scope}", sequenceName, scope);
+            }
+        }
+    }
+
     /// <summary>
     ///     Creates the physical database. Does not attempt to populate it with any schema.
     /// </summary>
@@ -232,10 +339,39 @@ public class CouchbaseDatabaseCreator :  RelationalDatabaseCreator
             await CreateAsync(cancellationToken).ConfigureAwait(false);
             await CreateScopeAsync();
             await CreateCollectionsAsync();
+            await CreateSequencesAsync();
             return true;
         }
 
         return false;
+    }
+
+    /// <summary>
+    /// Asynchronously deletes the database.
+    /// </summary>
+    public override async Task DeleteAsync(CancellationToken cancellationToken = new CancellationToken())
+    {
+        await InitializeAsync(cancellationToken);
+
+        // Drop sequences before deleting the bucket
+        try
+        {
+            await DropSequencesAsync();
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Failed to drop sequences during delete.");
+        }
+
+        var manager = _cluster.Buckets;
+        try
+        {
+            await manager.DropBucketAsync(_couchbaseDbContextOptionsBuilder.Bucket);
+        }
+        catch (BucketNotFoundException)
+        {
+            _logger.LogWarning("Couchbase bucket not found during delete.");
+        }
     }
 }
 

--- a/src/Couchbase.EntityFrameworkCore/Storage/Internal/CouchbaseDatabaseCreator.cs
+++ b/src/Couchbase.EntityFrameworkCore/Storage/Internal/CouchbaseDatabaseCreator.cs
@@ -226,30 +226,23 @@ public class CouchbaseDatabaseCreator :  RelationalDatabaseCreator
 
     private async Task CreateSequenceAsync(string scope, string sequenceName, CouchbaseSequenceOptions options)
     {
-        try
+        var bucket = await GetBucketAsync();
+        var scopeObj = await bucket.ScopeAsync(scope);
+
+        // Build CREATE SEQUENCE statement using proper identifier escaping
+        var bucketIdentifier = _sqlGenerationHelper.DelimitIdentifier(_couchbaseDbContextOptionsBuilder.Bucket);
+        var scopeIdentifier = _sqlGenerationHelper.DelimitIdentifier(scope);
+        var sequenceIdentifier = _sqlGenerationHelper.DelimitIdentifier(sequenceName);
+
+        var sql = $"CREATE SEQUENCE IF NOT EXISTS {bucketIdentifier}.{scopeIdentifier}.{sequenceIdentifier} {options.ToSqlOptionsClause()}";
+
+        _logger.LogDebug("Creating sequence: {Sql}", sql);
+
+        using var result = await scopeObj.QueryAsync<dynamic>(sql);
+
+        // Drain all rows to ensure query completes
+        await foreach (var _ in result.Rows)
         {
-            var bucket = await GetBucketAsync();
-            var scopeObj = await bucket.ScopeAsync(scope);
-
-            // Build CREATE SEQUENCE statement using proper identifier escaping
-            var bucketIdentifier = _sqlGenerationHelper.DelimitIdentifier(_couchbaseDbContextOptionsBuilder.Bucket);
-            var scopeIdentifier = _sqlGenerationHelper.DelimitIdentifier(scope);
-            var sequenceIdentifier = _sqlGenerationHelper.DelimitIdentifier(sequenceName);
-
-            var sql = $"CREATE SEQUENCE IF NOT EXISTS {bucketIdentifier}.{scopeIdentifier}.{sequenceIdentifier} {options.ToSqlOptionsClause()}";
-
-            _logger.LogDebug("Creating sequence: {Sql}", sql);
-
-            using var result = await scopeObj.QueryAsync<dynamic>(sql);
-
-            // Drain all rows to ensure query completes
-            await foreach (var _ in result.Rows)
-            {
-            }
-        }
-        catch (Exception ex)
-        {
-            _logger.LogWarning(ex, "Failed to create sequence {SequenceName} in scope {Scope}", sequenceName, scope);
         }
     }
 
@@ -302,6 +295,8 @@ public class CouchbaseDatabaseCreator :  RelationalDatabaseCreator
             }
             catch (Exception ex)
             {
+                // Suppress during cleanup - sequence/scope may not exist, bucket may be deleted next.
+                // Log at Warning so unexpected failures are visible.
                 _logger.LogWarning(ex, "Failed to drop sequence {SequenceName} in scope {Scope}", sequenceName, scope);
             }
         }

--- a/src/Couchbase.EntityFrameworkCore/Storage/Internal/CouchbaseDatabaseCreator.cs
+++ b/src/Couchbase.EntityFrameworkCore/Storage/Internal/CouchbaseDatabaseCreator.cs
@@ -191,8 +191,9 @@ public class CouchbaseDatabaseCreator :  RelationalDatabaseCreator
                 }
 
                 // Check if auto-create is disabled (defaults to true if annotation not present)
+                // Note: Use pattern matching for unboxing; 'as bool?' doesn't work for boxed value types
                 var autoCreateAnnotation = property.FindAnnotation(CouchbaseValueGeneratorSelector.SequenceAutoCreateAnnotation);
-                var autoCreate = autoCreateAnnotation?.Value as bool? ?? true;
+                var autoCreate = autoCreateAnnotation?.Value is bool b ? b : true;
                 if (!autoCreate)
                 {
                     _logger.LogDebug("Skipping auto-creation of sequence {SequenceName} (AutoCreate = false)", sequenceName);

--- a/src/Couchbase.EntityFrameworkCore/Storage/Internal/CouchbaseDatabaseCreator.cs
+++ b/src/Couchbase.EntityFrameworkCore/Storage/Internal/CouchbaseDatabaseCreator.cs
@@ -185,7 +185,20 @@ public class CouchbaseDatabaseCreator :  RelationalDatabaseCreator
 
                 // Use scope.sequenceName as key to handle sequences in different scopes
                 var key = $"{sequenceScope}.{sequenceName}";
-                if (!sequences.ContainsKey(key))
+                if (sequences.TryGetValue(key, out var existing))
+                {
+                    // Check for conflicting options
+                    if (existing.Options != options)
+                    {
+                        var propertyPath = $"{property.DeclaringType.ClrType.Name}.{property.Name}";
+                        throw new InvalidOperationException(
+                            $"Conflicting sequence options detected for sequence '{sequenceName}' in scope '{sequenceScope}'. " +
+                            $"Property '{propertyPath}' specifies different options than a previously configured property. " +
+                            $"Existing: {existing.Options.ToSqlOptionsClause()}, Conflicting: {options.ToSqlOptionsClause()}. " +
+                            $"Ensure all properties using the same sequence have identical options.");
+                    }
+                }
+                else
                 {
                     sequences[key] = (sequenceScope, options);
                 }

--- a/src/Couchbase.EntityFrameworkCore/Storage/Internal/CouchbaseDatabaseCreator.cs
+++ b/src/Couchbase.EntityFrameworkCore/Storage/Internal/CouchbaseDatabaseCreator.cs
@@ -1,6 +1,4 @@
 using System.Diagnostics;
-using Couchbase.Diagnostics;
-using Couchbase.EntityFrameworkCore.Extensions;
 using Couchbase.EntityFrameworkCore.Infrastructure;
 using Couchbase.EntityFrameworkCore.Metadata;
 using Couchbase.EntityFrameworkCore.Utils;
@@ -8,7 +6,6 @@ using Couchbase.EntityFrameworkCore.ValueGeneration;
 using Couchbase.Extensions.DependencyInjection;
 using Couchbase.Management.Buckets;
 using Couchbase.Management.Collections;
-using Google.Api;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Storage;

--- a/src/Couchbase.EntityFrameworkCore/Storage/Internal/CouchbaseDatabaseCreator.cs
+++ b/src/Couchbase.EntityFrameworkCore/Storage/Internal/CouchbaseDatabaseCreator.cs
@@ -22,6 +22,7 @@ public class CouchbaseDatabaseCreator :  RelationalDatabaseCreator
     private readonly ILogger<CouchbaseDatabaseCreator> _logger;
     private readonly IServiceProvider _serviceProvider;
     private readonly ICouchbaseDbContextOptionsBuilder _couchbaseDbContextOptionsBuilder;
+    private readonly ISqlGenerationHelper _sqlGenerationHelper;
     private ICluster _cluster;
 
     public CouchbaseDatabaseCreator(RelationalDatabaseCreatorDependencies dependencies,
@@ -29,13 +30,15 @@ public class CouchbaseDatabaseCreator :  RelationalDatabaseCreator
         IServiceProvider serviceProvider,
         IDesignTimeModel designTimeModel,
         ILogger<CouchbaseDatabaseCreator> logger,
-        ICouchbaseDbContextOptionsBuilder couchbaseDbContextOptionsBuilder) : base(dependencies)
+        ICouchbaseDbContextOptionsBuilder couchbaseDbContextOptionsBuilder,
+        ISqlGenerationHelper sqlGenerationHelper) : base(dependencies)
     {
         _database = database;
         _designTimeModel = designTimeModel;
         _logger = logger;
         _serviceProvider = serviceProvider;
         _couchbaseDbContextOptionsBuilder = couchbaseDbContextOptionsBuilder;
+        _sqlGenerationHelper = sqlGenerationHelper;
     }
 
     private async Task InitializeAsync(CancellationToken cancellationToken = default)
@@ -207,8 +210,12 @@ public class CouchbaseDatabaseCreator :  RelationalDatabaseCreator
             var bucket = await GetBucketAsync();
             var scopeObj = await bucket.ScopeAsync(scope);
 
-            // Build CREATE SEQUENCE statement
-            var sql = $"CREATE SEQUENCE IF NOT EXISTS `{_couchbaseDbContextOptionsBuilder.Bucket}`.`{scope}`.`{sequenceName}` {options.ToSqlOptionsClause()}";
+            // Build CREATE SEQUENCE statement using proper identifier escaping
+            var bucketIdentifier = _sqlGenerationHelper.DelimitIdentifier(_couchbaseDbContextOptionsBuilder.Bucket);
+            var scopeIdentifier = _sqlGenerationHelper.DelimitIdentifier(scope);
+            var sequenceIdentifier = _sqlGenerationHelper.DelimitIdentifier(sequenceName);
+
+            var sql = $"CREATE SEQUENCE IF NOT EXISTS {bucketIdentifier}.{scopeIdentifier}.{sequenceIdentifier} {options.ToSqlOptionsClause()}";
 
             _logger.LogDebug("Creating sequence: {Sql}", sql);
 
@@ -250,7 +257,13 @@ public class CouchbaseDatabaseCreator :  RelationalDatabaseCreator
             try
             {
                 var scopeObj = await bucket.ScopeAsync(scope);
-                var sql = $"DROP SEQUENCE IF EXISTS `{_couchbaseDbContextOptionsBuilder.Bucket}`.`{scope}`.`{sequenceName}`";
+
+                // Use proper identifier escaping
+                var bucketIdentifier = _sqlGenerationHelper.DelimitIdentifier(_couchbaseDbContextOptionsBuilder.Bucket);
+                var scopeIdentifier = _sqlGenerationHelper.DelimitIdentifier(scope);
+                var sequenceIdentifier = _sqlGenerationHelper.DelimitIdentifier(sequenceName);
+
+                var sql = $"DROP SEQUENCE IF EXISTS {bucketIdentifier}.{scopeIdentifier}.{sequenceIdentifier}";
 
                 _logger.LogDebug("Dropping sequence: {Sql}", sql);
 

--- a/src/Couchbase.EntityFrameworkCore/Storage/Internal/CouchbaseDatabaseCreator.cs
+++ b/src/Couchbase.EntityFrameworkCore/Storage/Internal/CouchbaseDatabaseCreator.cs
@@ -139,32 +139,75 @@ public class CouchbaseDatabaseCreator :  RelationalDatabaseCreator
     private async Task CreateCollectionsAsync()
     {
         var manager = (await GetBucketAsync()).Collections;
+
+        // Collect all collections and their scopes from the model
+        var collections = new List<(string Scope, string Collection, string EntityName)>();
+        var nonDefaultScopes = new HashSet<string>();
+
         foreach (var entityType in _designTimeModel.Model.GetEntityTypes())
         {
+            var tableName = entityType.GetTableName();
+            if (string.IsNullOrEmpty(tableName))
+            {
+                continue;
+            }
+
+            string collectionName;
+            string scopeName;
+
+            if (CouchbaseKeyspace.TryParse(tableName, out var keyspace))
+            {
+                collectionName = keyspace!.Value.Collection;
+                scopeName = keyspace.Value.Scope;
+            }
+            else
+            {
+                // Fallback: use table name as collection name in default scope
+                collectionName = tableName;
+                scopeName = _couchbaseDbContextOptionsBuilder.Scope;
+            }
+
+            collections.Add((scopeName, collectionName, entityType.ClrType.Name));
+
+            if (scopeName != _couchbaseDbContextOptionsBuilder.Scope)
+            {
+                nonDefaultScopes.Add(scopeName);
+            }
+        }
+
+        // Create non-default scopes if AutoCreateScopes is enabled
+        if (_couchbaseDbContextOptionsBuilder.AutoCreateScopes && nonDefaultScopes.Count > 0)
+        {
+            foreach (var scope in nonDefaultScopes)
+            {
+                try
+                {
+                    await manager.CreateScopeAsync(scope);
+                    _logger.LogDebug("Created scope {ScopeName}", scope);
+                }
+                catch (ScopeExistsException)
+                {
+                    // Scope already exists, continue
+                }
+            }
+        }
+
+        // Create collections
+        foreach (var (scopeName, collectionName, entityName) in collections)
+        {
+            // Skip non-default scope collections if AutoCreateScopes is disabled
+            if (scopeName != _couchbaseDbContextOptionsBuilder.Scope && !_couchbaseDbContextOptionsBuilder.AutoCreateScopes)
+            {
+                _logger.LogWarning(
+                    "Collection '{CollectionName}' for entity '{EntityName}' targets non-default scope '{ScopeName}' " +
+                    "and will not be auto-created. The scope may not exist. " +
+                    "Create the scope and collection manually, or enable AutoCreateScopes in DbContext options.",
+                    collectionName, entityName, scopeName);
+                continue;
+            }
+
             try
             {
-                // Get the collection name from the keyspace (bucket.scope.collection format)
-                var tableName = entityType.GetTableName();
-                if (string.IsNullOrEmpty(tableName))
-                {
-                    continue;
-                }
-
-                string collectionName;
-                string scopeName;
-
-                if (CouchbaseKeyspace.TryParse(tableName, out var keyspace))
-                {
-                    collectionName = keyspace!.Value.Collection;
-                    scopeName = keyspace.Value.Scope;
-                }
-                else
-                {
-                    // Fallback: use table name as collection name in default scope
-                    collectionName = tableName;
-                    scopeName = _couchbaseDbContextOptionsBuilder.Scope;
-                }
-
                 await manager.CreateCollectionAsync(scopeName, collectionName, new CreateCollectionSettings());
             }
             catch (CollectionExistsException)

--- a/src/Couchbase.EntityFrameworkCore/Storage/Internal/CouchbaseDatabaseCreator.cs
+++ b/src/Couchbase.EntityFrameworkCore/Storage/Internal/CouchbaseDatabaseCreator.cs
@@ -45,6 +45,11 @@ public class CouchbaseDatabaseCreator :  RelationalDatabaseCreator
 
     private async Task InitializeAsync(CancellationToken cancellationToken = default)
     {
+        if (_cluster != null)
+        {
+            return;
+        }
+
         var clusterProvider = _serviceProvider.GetRequiredService<IClusterProvider>();
         _cluster = await clusterProvider.GetClusterAsync();
     }

--- a/src/Couchbase.EntityFrameworkCore/Storage/Internal/CouchbaseDatabaseCreator.cs
+++ b/src/Couchbase.EntityFrameworkCore/Storage/Internal/CouchbaseDatabaseCreator.cs
@@ -154,7 +154,8 @@ public class CouchbaseDatabaseCreator :  RelationalDatabaseCreator
     private async Task CreateSequencesAsync()
     {
         // Collect all unique sequences from the model that should be auto-created
-        var sequences = new Dictionary<string, (string Scope, CouchbaseSequenceOptions Options)>();
+        // Use tuple key (scope, name) to avoid delimiter parsing issues
+        var sequences = new Dictionary<(string Scope, string Name), CouchbaseSequenceOptions>();
 
         foreach (var entityType in _designTimeModel.Model.GetEntityTypes())
         {
@@ -195,33 +196,31 @@ public class CouchbaseDatabaseCreator :  RelationalDatabaseCreator
                 var options = property.FindAnnotation(CouchbaseValueGeneratorSelector.SequenceOptionsAnnotation)?.Value as CouchbaseSequenceOptions
                     ?? CouchbaseSequenceOptions.Default;
 
-                // Use scope.sequenceName as key to handle sequences in different scopes
-                var key = $"{sequenceScope}.{sequenceName}";
-                if (sequences.TryGetValue(key, out var existing))
+                var key = (sequenceScope, sequenceName);
+                if (sequences.TryGetValue(key, out var existingOptions))
                 {
                     // Check for conflicting options
-                    if (existing.Options != options)
+                    if (existingOptions != options)
                     {
                         var propertyPath = $"{property.DeclaringType.ClrType.Name}.{property.Name}";
                         throw new InvalidOperationException(
                             $"Conflicting sequence options detected for sequence '{sequenceName}' in scope '{sequenceScope}'. " +
                             $"Property '{propertyPath}' specifies different options than a previously configured property. " +
-                            $"Existing: {existing.Options.ToSqlOptionsClause()}, Conflicting: {options.ToSqlOptionsClause()}. " +
+                            $"Existing: {existingOptions.ToSqlOptionsClause()}, Conflicting: {options.ToSqlOptionsClause()}. " +
                             $"Ensure all properties using the same sequence have identical options.");
                     }
                 }
                 else
                 {
-                    sequences[key] = (sequenceScope, options);
+                    sequences[key] = options;
                 }
             }
         }
 
         // Create each sequence
-        foreach (var (key, (sequenceScope, options)) in sequences)
+        foreach (var ((scope, name), options) in sequences)
         {
-            var sequenceName = key.Split('.').Last();
-            await CreateSequenceAsync(sequenceScope, sequenceName, options);
+            await CreateSequenceAsync(scope, name, options);
         }
     }
 

--- a/src/Couchbase.EntityFrameworkCore/Storage/Internal/CouchbaseDatabaseCreator.cs
+++ b/src/Couchbase.EntityFrameworkCore/Storage/Internal/CouchbaseDatabaseCreator.cs
@@ -176,8 +176,20 @@ public class CouchbaseDatabaseCreator :  RelationalDatabaseCreator
                 }
 
                 // Get scope override or use default
-                var sequenceScope = property.FindAnnotation(CouchbaseValueGeneratorSelector.SequenceScopeAnnotation)?.Value as string
-                    ?? _couchbaseDbContextOptionsBuilder.Scope;
+                var scopeOverride = property.FindAnnotation(CouchbaseValueGeneratorSelector.SequenceScopeAnnotation)?.Value as string;
+                var sequenceScope = scopeOverride ?? _couchbaseDbContextOptionsBuilder.Scope;
+
+                // Skip auto-creation for sequences in non-default scopes (scope may not exist)
+                if (scopeOverride != null && scopeOverride != _couchbaseDbContextOptionsBuilder.Scope)
+                {
+                    var propertyPath = $"{property.DeclaringType.ClrType.Name}.{property.Name}";
+                    _logger.LogWarning(
+                        "Sequence '{SequenceName}' for property '{PropertyPath}' targets non-default scope '{SequenceScope}' " +
+                        "and will not be auto-created. The scope may not exist. " +
+                        "Create the scope and sequence manually, or use the default scope, or set AutoCreate = false to suppress this warning.",
+                        sequenceName, propertyPath, sequenceScope);
+                    continue;
+                }
 
                 // Get options or use default
                 var options = property.FindAnnotation(CouchbaseValueGeneratorSelector.SequenceOptionsAnnotation)?.Value as CouchbaseSequenceOptions

--- a/src/Couchbase.EntityFrameworkCore/Storage/Internal/CouchbaseDatabaseCreator.cs
+++ b/src/Couchbase.EntityFrameworkCore/Storage/Internal/CouchbaseDatabaseCreator.cs
@@ -153,9 +153,6 @@ public class CouchbaseDatabaseCreator :  RelationalDatabaseCreator
 
     private async Task CreateSequencesAsync()
     {
-        var bucket = await GetBucketAsync();
-        var scope = await bucket.ScopeAsync(_couchbaseDbContextOptionsBuilder.Scope);
-
         // Collect all unique sequences from the model that should be auto-created
         var sequences = new Dictionary<string, (string Scope, CouchbaseSequenceOptions Options)>();
 
@@ -219,7 +216,12 @@ public class CouchbaseDatabaseCreator :  RelationalDatabaseCreator
 
             _logger.LogDebug("Creating sequence: {Sql}", sql);
 
-            await scopeObj.QueryAsync<dynamic>(sql);
+            using var result = await scopeObj.QueryAsync<dynamic>(sql);
+
+            // Drain all rows to ensure query completes
+            await foreach (var _ in result.Rows)
+            {
+            }
         }
         catch (Exception ex)
         {
@@ -267,7 +269,12 @@ public class CouchbaseDatabaseCreator :  RelationalDatabaseCreator
 
                 _logger.LogDebug("Dropping sequence: {Sql}", sql);
 
-                await scopeObj.QueryAsync<dynamic>(sql);
+                using var result = await scopeObj.QueryAsync<dynamic>(sql);
+
+                // Drain all rows to ensure query completes
+                await foreach (var _ in result.Rows)
+                {
+                }
             }
             catch (Exception ex)
             {

--- a/src/Couchbase.EntityFrameworkCore/Storage/Internal/CouchbaseDatabaseCreator.cs
+++ b/src/Couchbase.EntityFrameworkCore/Storage/Internal/CouchbaseDatabaseCreator.cs
@@ -362,14 +362,18 @@ public class CouchbaseDatabaseCreator :  RelationalDatabaseCreator
     {
         await InitializeAsync(cancellationToken);
 
-        // Drop sequences before deleting the bucket
-        try
+        // Only attempt to drop sequences if the bucket exists
+        // GetBucketAsync retries indefinitely, so we check existence first
+        if (await ExistsAsync(cancellationToken).ConfigureAwait(false))
         {
-            await DropSequencesAsync();
-        }
-        catch (Exception ex)
-        {
-            _logger.LogWarning(ex, "Failed to drop sequences during delete.");
+            try
+            {
+                await DropSequencesAsync();
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex, "Failed to drop sequences during delete.");
+            }
         }
 
         var manager = _cluster.Buckets;

--- a/src/Couchbase.EntityFrameworkCore/Storage/Internal/CouchbaseDatabaseCreator.cs
+++ b/src/Couchbase.EntityFrameworkCore/Storage/Internal/CouchbaseDatabaseCreator.cs
@@ -87,54 +87,6 @@ public class CouchbaseDatabaseCreator :  RelationalDatabaseCreator
         throw new UnreachableException();
     }
 
-    private async Task<bool> ScopeExistsAsync()
-    {
-        var manager = (await GetBucketAsync()).Collections;
-        try
-        {
-            var scopes = await manager.GetAllScopesAsync();
-            return scopes.Contains(new ScopeSpec(_couchbaseDbContextOptionsBuilder.Scope));
-        }
-        catch (Exception e)
-        {
-            _logger.LogWarning(e, "Failed to check if scope '{ScopeName}' exists", _couchbaseDbContextOptionsBuilder.Scope);
-            return false;
-        }
-    }
-
-    private async Task<bool> CollectionsExistsAsync()
-    {
-        var manager = (await GetBucketAsync()).Collections;
-
-        try
-        {
-            var scopes = await manager.GetAllScopesAsync();
-            var scope = scopes.FirstOrDefault(x => x.Name == _couchbaseDbContextOptionsBuilder.Scope);
-
-            if (scope == null)
-            {
-                _logger.LogDebug("Scope '{ScopeName}' not found when checking for collections", _couchbaseDbContextOptionsBuilder.Scope);
-                return false;
-            }
-
-            var entityTypes = _designTimeModel.Model.GetEntityTypes();
-            foreach (var entityType in entityTypes)
-            {
-                var collectionName = entityType.Name.Split('+')[1];
-                if (scope.Collections.Contains(new CollectionSpec(scope.Name, collectionName)))
-                {
-                    return true;
-                }
-            }
-        }
-        catch (Exception e)
-        {
-            _logger.LogWarning(e, "Failed to check if collections exist in scope '{ScopeName}'", _couchbaseDbContextOptionsBuilder.Scope);
-        }
-
-        return false;
-    }
-
     public override bool HasTables()
     {
         return true;

--- a/src/Couchbase.EntityFrameworkCore/Storage/Internal/CouchbaseDatabaseCreator.cs
+++ b/src/Couchbase.EntityFrameworkCore/Storage/Internal/CouchbaseDatabaseCreator.cs
@@ -153,7 +153,7 @@ public class CouchbaseDatabaseCreator :  RelationalDatabaseCreator
         var bucket = await GetBucketAsync();
         var scope = await bucket.ScopeAsync(_couchbaseDbContextOptionsBuilder.Scope);
 
-        // Collect all unique sequences from the model
+        // Collect all unique sequences from the model that should be auto-created
         var sequences = new Dictionary<string, (string Scope, CouchbaseSequenceOptions Options)>();
 
         foreach (var entityType in _designTimeModel.Model.GetEntityTypes())
@@ -163,6 +163,15 @@ public class CouchbaseDatabaseCreator :  RelationalDatabaseCreator
                 var sequenceName = property.FindAnnotation(CouchbaseValueGeneratorSelector.SequenceNameAnnotation)?.Value as string;
                 if (string.IsNullOrEmpty(sequenceName))
                 {
+                    continue;
+                }
+
+                // Check if auto-create is disabled (defaults to true if annotation not present)
+                var autoCreateAnnotation = property.FindAnnotation(CouchbaseValueGeneratorSelector.SequenceAutoCreateAnnotation);
+                var autoCreate = autoCreateAnnotation?.Value as bool? ?? true;
+                if (!autoCreate)
+                {
+                    _logger.LogDebug("Skipping auto-creation of sequence {SequenceName} (AutoCreate = false)", sequenceName);
                     continue;
                 }
 

--- a/src/Couchbase.EntityFrameworkCore/Storage/Internal/CouchbaseDatabaseCreator.cs
+++ b/src/Couchbase.EntityFrameworkCore/Storage/Internal/CouchbaseDatabaseCreator.cs
@@ -2,12 +2,14 @@ using System.Diagnostics;
 using Couchbase.Diagnostics;
 using Couchbase.EntityFrameworkCore.Extensions;
 using Couchbase.EntityFrameworkCore.Infrastructure;
+using Couchbase.EntityFrameworkCore.Metadata;
 using Couchbase.EntityFrameworkCore.Utils;
 using Couchbase.EntityFrameworkCore.ValueGeneration;
 using Couchbase.Extensions.DependencyInjection;
 using Couchbase.Management.Buckets;
 using Couchbase.Management.Collections;
 using Google.Api;
+using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Storage;
 using Microsoft.Extensions.DependencyInjection;
@@ -141,8 +143,29 @@ public class CouchbaseDatabaseCreator :  RelationalDatabaseCreator
         {
             try
             {
-               await manager.CreateCollectionAsync(_couchbaseDbContextOptionsBuilder.Scope, 
-                   entityType.Name.Split('+')[1], new CreateCollectionSettings());
+                // Get the collection name from the keyspace (bucket.scope.collection format)
+                var tableName = entityType.GetTableName();
+                if (string.IsNullOrEmpty(tableName))
+                {
+                    continue;
+                }
+
+                string collectionName;
+                string scopeName;
+
+                if (CouchbaseKeyspace.TryParse(tableName, out var keyspace))
+                {
+                    collectionName = keyspace!.Value.Collection;
+                    scopeName = keyspace.Value.Scope;
+                }
+                else
+                {
+                    // Fallback: use table name as collection name in default scope
+                    collectionName = tableName;
+                    scopeName = _couchbaseDbContextOptionsBuilder.Scope;
+                }
+
+                await manager.CreateCollectionAsync(scopeName, collectionName, new CreateCollectionSettings());
             }
             catch (CollectionExistsException)
             {
@@ -382,16 +405,21 @@ public class CouchbaseDatabaseCreator :  RelationalDatabaseCreator
     /// <returns></returns>
     public override async Task<bool> EnsureCreatedAsync(CancellationToken cancellationToken = new CancellationToken())
     {
+        var created = false;
+
         if (!await ExistsAsync(cancellationToken).ConfigureAwait(false))
         {
             await CreateAsync(cancellationToken).ConfigureAwait(false);
-            await CreateScopeAsync();
-            await CreateCollectionsAsync();
-            await CreateSequencesAsync();
-            return true;
+            created = true;
         }
 
-        return false;
+        // Always ensure scope, collections, and sequences exist
+        // even if bucket already existed (they use IF NOT EXISTS / catch-exists patterns)
+        await CreateScopeAsync();
+        await CreateCollectionsAsync();
+        await CreateSequencesAsync();
+
+        return created;
     }
 
     /// <summary>

--- a/src/Couchbase.EntityFrameworkCore/Storage/Internal/CouchbaseDatabaseCreator.cs
+++ b/src/Couchbase.EntityFrameworkCore/Storage/Internal/CouchbaseDatabaseCreator.cs
@@ -397,12 +397,16 @@ public class CouchbaseDatabaseCreator :  RelationalDatabaseCreator
     }
 
     /// <summary>
-    /// Asynchronously ensures that the database for the context exists. If it exists, no action is taken.
-    /// If it does not exist then the database and all its schema are created. If the database exists, then
-    /// no effort is made to ensure it is compatible with the model for this context.
+    /// Asynchronously ensures that the database for the context exists.
+    /// If the bucket does not exist, it is created.
+    /// Scopes, collections, and sequences are always created if they don't exist,
+    /// regardless of whether the bucket already existed.
     /// </summary>
-    /// <param name="cancellationToken"></param>
-    /// <returns></returns>
+    /// <param name="cancellationToken">A cancellation token.</param>
+    /// <returns>
+    /// <see langword="true"/> if the bucket was created; <see langword="false"/> if it already existed.
+    /// Note: scopes, collections, and sequences are created in both cases.
+    /// </returns>
     public override async Task<bool> EnsureCreatedAsync(CancellationToken cancellationToken = new CancellationToken())
     {
         var created = false;

--- a/src/Couchbase.EntityFrameworkCore/Storage/Internal/CouchbaseDatabaseCreator.cs
+++ b/src/Couchbase.EntityFrameworkCore/Storage/Internal/CouchbaseDatabaseCreator.cs
@@ -451,7 +451,7 @@ public class CouchbaseDatabaseCreator :  RelationalDatabaseCreator
         await InitializeAsync(cancellationToken);
 
         // Only attempt to drop sequences if the bucket exists
-        // GetBucketAsync retries indefinitely, so we check existence first
+        // GetBucketAsync retries up to 10 times, so we check existence first to fail fast
         if (await ExistsAsync(cancellationToken).ConfigureAwait(false))
         {
             try

--- a/src/Couchbase.EntityFrameworkCore/Storage/Internal/CouchbaseDatabaseCreator.cs
+++ b/src/Couchbase.EntityFrameworkCore/Storage/Internal/CouchbaseDatabaseCreator.cs
@@ -54,66 +54,82 @@ public class CouchbaseDatabaseCreator :  RelationalDatabaseCreator
         _cluster = await clusterProvider.GetClusterAsync();
     }
 
-    private async Task<IBucket> GetBucketAsync(TimeSpan? timeout = null, CancellationToken cancellationToken = default)
+    private async Task<IBucket> GetBucketAsync(CancellationToken cancellationToken = default)
     {
-        IBucket bucket = null;
-        var exists = false;
-        do
+        const int maxRetries = 10;
+        const int delayMs = 500;
+
+        for (var attempt = 1; attempt <= maxRetries; attempt++)
         {
+            cancellationToken.ThrowIfCancellationRequested();
+
             try
             {
-                bucket = await _cluster.BucketAsync(_couchbaseDbContextOptionsBuilder.Bucket);
-                exists = true;
+                return await _cluster.BucketAsync(_couchbaseDbContextOptionsBuilder.Bucket);
             }
             catch (Exception e)
             {
-                _logger.LogWarning("Couchbase bucket could not be retrieved. {0}", e);
-            }
-        }while (!exists);
+                if (attempt == maxRetries)
+                {
+                    _logger.LogError(e, "Failed to retrieve Couchbase bucket '{BucketName}' after {MaxRetries} attempts",
+                        _couchbaseDbContextOptionsBuilder.Bucket, maxRetries);
+                    throw;
+                }
 
-        Debug.Assert(bucket != null, nameof(bucket) + " != null");
-        return bucket;
+                _logger.LogWarning(e, "Couchbase bucket '{BucketName}' could not be retrieved (attempt {Attempt}/{MaxRetries}). Retrying...",
+                    _couchbaseDbContextOptionsBuilder.Bucket, attempt, maxRetries);
+
+                await Task.Delay(delayMs, cancellationToken);
+            }
+        }
+
+        // Unreachable, but required for compiler
+        throw new UnreachableException();
     }
 
     private async Task<bool> ScopeExistsAsync()
     {
-        var exists = false;
         var manager = (await GetBucketAsync()).Collections;
         try
         {
             var scopes = await manager.GetAllScopesAsync();
-            if (scopes.Contains(new ScopeSpec(_couchbaseDbContextOptionsBuilder.Scope)))
-            {
-                exists = true;
-            }
+            return scopes.Contains(new ScopeSpec(_couchbaseDbContextOptionsBuilder.Scope));
         }
         catch (Exception e)
         {
-            Console.WriteLine(e);
+            _logger.LogWarning(e, "Failed to check if scope '{ScopeName}' exists", _couchbaseDbContextOptionsBuilder.Scope);
+            return false;
         }
-        return exists;
     }
 
     private async Task<bool> CollectionsExistsAsync()
     {
         var manager = (await GetBucketAsync()).Collections;
-        var scopes = await manager.GetAllScopesAsync();
 
         try
         {
+            var scopes = await manager.GetAllScopesAsync();
             var scope = scopes.FirstOrDefault(x => x.Name == _couchbaseDbContextOptionsBuilder.Scope);
+
+            if (scope == null)
+            {
+                _logger.LogDebug("Scope '{ScopeName}' not found when checking for collections", _couchbaseDbContextOptionsBuilder.Scope);
+                return false;
+            }
+
             var entityTypes = _designTimeModel.Model.GetEntityTypes();
             foreach (var entityType in entityTypes)
             {
-                if (scope!.Collections.Contains(new CollectionSpec(scope.Name, entityType.Name.Split('+')[1])))
+                var collectionName = entityType.Name.Split('+')[1];
+                if (scope.Collections.Contains(new CollectionSpec(scope.Name, collectionName)))
                 {
                     return true;
                 }
             }
         }
-        catch (Exception)
+        catch (Exception e)
         {
-            _logger.LogWarning("Couchbase collection could not be retrieved.");
+            _logger.LogWarning(e, "Failed to check if collections exist in scope '{ScopeName}'", _couchbaseDbContextOptionsBuilder.Scope);
         }
 
         return false;
@@ -128,7 +144,7 @@ public class CouchbaseDatabaseCreator :  RelationalDatabaseCreator
     {
         var manager = (await GetBucketAsync()).Collections;
         var scopes = await manager.GetAllScopesAsync();
-        if(!scopes.Contains(new ScopeSpec(_couchbaseDbContextOptionsBuilder.Bucket)))
+        if(!scopes.Contains(new ScopeSpec(_couchbaseDbContextOptionsBuilder.Scope)))
         {
             try
             {

--- a/src/Couchbase.EntityFrameworkCore/Storage/Internal/CouchbaseSqlGenerationHelper.cs
+++ b/src/Couchbase.EntityFrameworkCore/Storage/Internal/CouchbaseSqlGenerationHelper.cs
@@ -15,9 +15,39 @@ public class CouchbaseSqlGenerationHelper : RelationalSqlGenerationHelper
         EscapeIdentifier(builder, identifier);
         builder.Append('`');
     }
-    
-   public override string DelimitIdentifier(string identifier)
+
+    public override string DelimitIdentifier(string identifier)
         => $"`{EscapeIdentifier(identifier)}`";
+
+    /// <summary>
+    /// Escapes backticks in identifiers by doubling them.
+    /// This is necessary because Couchbase SQL++ uses backticks as identifier delimiters.
+    /// </summary>
+    public override string EscapeIdentifier(string identifier)
+        => identifier.Replace("`", "``");
+
+    /// <summary>
+    /// Escapes backticks in identifiers by doubling them.
+    /// This is necessary because Couchbase SQL++ uses backticks as identifier delimiters.
+    /// </summary>
+    public override void EscapeIdentifier(StringBuilder builder, string identifier)
+    {
+        var start = 0;
+        for (var i = 0; i < identifier.Length; i++)
+        {
+            if (identifier[i] == '`')
+            {
+                builder.Append(identifier, start, i - start);
+                builder.Append("``");
+                start = i + 1;
+            }
+        }
+
+        if (start < identifier.Length)
+        {
+            builder.Append(identifier, start, identifier.Length - start);
+        }
+    }
 
    public override string GenerateParameterName(string name) =>
        name.StartsWith("$", StringComparison.Ordinal)

--- a/src/Couchbase.EntityFrameworkCore/ValueGeneration/CouchbaseSequenceOptions.cs
+++ b/src/Couchbase.EntityFrameworkCore/ValueGeneration/CouchbaseSequenceOptions.cs
@@ -1,0 +1,90 @@
+namespace Couchbase.EntityFrameworkCore.ValueGeneration;
+
+/// <summary>
+/// Options for configuring a Couchbase sequence.
+/// </summary>
+/// <remarks>
+/// These options map to the SQL++ CREATE SEQUENCE statement options:
+/// <code>
+/// CREATE SEQUENCE bucket.scope.sequence_name
+///     START WITH {StartWith}
+///     INCREMENT BY {IncrementBy}
+///     [MAXVALUE {MaxValue}]
+///     [MINVALUE {MinValue}]
+///     [CYCLE | NO CYCLE]
+///     [CACHE {CacheSize}]
+/// </code>
+/// </remarks>
+public sealed record CouchbaseSequenceOptions
+{
+    /// <summary>
+    /// The starting value of the sequence. Defaults to 1.
+    /// </summary>
+    public long StartWith { get; init; } = 1;
+
+    /// <summary>
+    /// The increment value for each call to NEXT VALUE FOR. Defaults to 1.
+    /// Can be negative for descending sequences.
+    /// </summary>
+    public long IncrementBy { get; init; } = 1;
+
+    /// <summary>
+    /// The maximum value the sequence can generate.
+    /// If null, defaults to the maximum value for the sequence's data type.
+    /// </summary>
+    public long? MaxValue { get; init; }
+
+    /// <summary>
+    /// The minimum value the sequence can generate.
+    /// If null, defaults to the minimum value for the sequence's data type.
+    /// </summary>
+    public long? MinValue { get; init; }
+
+    /// <summary>
+    /// Whether the sequence should restart from MinValue/MaxValue when the limit is reached.
+    /// Defaults to false (NO CYCLE).
+    /// </summary>
+    public bool Cycle { get; init; } = false;
+
+    /// <summary>
+    /// The number of sequence values to cache for performance.
+    /// If null, uses the database default (typically 50).
+    /// </summary>
+    public int? CacheSize { get; init; }
+
+    /// <summary>
+    /// Default sequence options (START WITH 1, INCREMENT BY 1, NO CYCLE).
+    /// </summary>
+    public static CouchbaseSequenceOptions Default { get; } = new();
+
+    /// <summary>
+    /// Generates the SQL++ options clause for CREATE SEQUENCE.
+    /// </summary>
+    internal string ToSqlOptionsClause()
+    {
+        var parts = new List<string>
+        {
+            $"START WITH {StartWith}",
+            $"INCREMENT BY {IncrementBy}"
+        };
+
+        if (MaxValue.HasValue)
+        {
+            parts.Add($"MAXVALUE {MaxValue.Value}");
+        }
+
+        if (MinValue.HasValue)
+        {
+            parts.Add($"MINVALUE {MinValue.Value}");
+        }
+
+        parts.Add(Cycle ? "CYCLE" : "NO CYCLE");
+
+        if (CacheSize.HasValue)
+        {
+            parts.Add($"CACHE {CacheSize.Value}");
+        }
+
+        return string.Join(" ", parts);
+    }
+}

--- a/src/Couchbase.EntityFrameworkCore/ValueGeneration/CouchbaseSequenceOptions.cs
+++ b/src/Couchbase.EntityFrameworkCore/ValueGeneration/CouchbaseSequenceOptions.cs
@@ -60,7 +60,10 @@ public sealed record CouchbaseSequenceOptions
     /// <summary>
     /// Generates the SQL++ options clause for CREATE SEQUENCE.
     /// </summary>
-    internal string ToSqlOptionsClause()
+    /// <returns>
+    /// A string containing the SQL++ options (e.g., "START WITH 1 INCREMENT BY 1 NO CYCLE").
+    /// </returns>
+    public string ToSqlOptionsClause()
     {
         var parts = new List<string>
         {

--- a/src/Couchbase.EntityFrameworkCore/ValueGeneration/CouchbaseSequenceValueGenerator.cs
+++ b/src/Couchbase.EntityFrameworkCore/ValueGeneration/CouchbaseSequenceValueGenerator.cs
@@ -1,4 +1,3 @@
-using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.ChangeTracking;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Storage;
@@ -64,21 +63,22 @@ public class CouchbaseSequenceValueGenerator<T> : ValueGenerator<T>
     }
 
     /// <summary>
-    /// Gets the SQL++ query used to fetch the next sequence value.
-    /// </summary>
-    /// <remarks>
-    /// Uses backtick-delimited identifiers for bucket, scope, and sequence name.
-    /// Backticks within identifiers are escaped by doubling them.
-    /// </remarks>
-    public string SequenceQuery => $"SELECT NEXT VALUE FOR `{EscapeIdentifier(_bucket)}`.`{EscapeIdentifier(_scope)}`.`{EscapeIdentifier(_sequenceName)}`";
-
-    private static string EscapeIdentifier(string identifier)
-        => identifier.Replace("`", "``");
-
-    /// <summary>
     /// Gets a value indicating whether values may be temporary (false for sequences).
     /// </summary>
     public override bool GeneratesTemporaryValues => false;
+
+    /// <summary>
+    /// Builds the SQL++ query to fetch the next sequence value using the provided SQL generation helper.
+    /// </summary>
+    /// <param name="sqlGenerationHelper">The SQL generation helper for proper identifier escaping.</param>
+    /// <returns>The SQL++ query string.</returns>
+    public string BuildSequenceQuery(ISqlGenerationHelper sqlGenerationHelper)
+    {
+        var bucket = sqlGenerationHelper.DelimitIdentifier(_bucket);
+        var scope = sqlGenerationHelper.DelimitIdentifier(_scope);
+        var sequence = sqlGenerationHelper.DelimitIdentifier(_sequenceName);
+        return $"SELECT NEXT VALUE FOR {bucket}.{scope}.{sequence}";
+    }
 
     /// <summary>
     /// Generates the next value for the sequence synchronously.
@@ -103,7 +103,8 @@ public class CouchbaseSequenceValueGenerator<T> : ValueGenerator<T>
         EntityEntry entry,
         CancellationToken cancellationToken = default)
     {
-        var query = SequenceQuery;
+        var sqlGenerationHelper = entry.Context.GetService<ISqlGenerationHelper>();
+        var query = BuildSequenceQuery(sqlGenerationHelper);
         var longValue = await ExecuteSequenceQueryAsync(entry, query, cancellationToken).ConfigureAwait(false);
         return ConvertToTargetType(longValue);
     }

--- a/src/Couchbase.EntityFrameworkCore/ValueGeneration/CouchbaseSequenceValueGenerator.cs
+++ b/src/Couchbase.EntityFrameworkCore/ValueGeneration/CouchbaseSequenceValueGenerator.cs
@@ -66,7 +66,14 @@ public class CouchbaseSequenceValueGenerator<T> : ValueGenerator<T>
     /// <summary>
     /// Gets the SQL++ query used to fetch the next sequence value.
     /// </summary>
-    public string SequenceQuery => $"SELECT NEXT VALUE FOR `{_bucket}`.`{_scope}`.`{_sequenceName}`";
+    /// <remarks>
+    /// Uses backtick-delimited identifiers for bucket, scope, and sequence name.
+    /// Backticks within identifiers are escaped by doubling them.
+    /// </remarks>
+    public string SequenceQuery => $"SELECT NEXT VALUE FOR `{EscapeIdentifier(_bucket)}`.`{EscapeIdentifier(_scope)}`.`{EscapeIdentifier(_sequenceName)}`";
+
+    private static string EscapeIdentifier(string identifier)
+        => identifier.Replace("`", "``");
 
     /// <summary>
     /// Gets a value indicating whether values may be temporary (false for sequences).

--- a/src/Couchbase.EntityFrameworkCore/ValueGeneration/CouchbaseValueGeneratorSelector.cs
+++ b/src/Couchbase.EntityFrameworkCore/ValueGeneration/CouchbaseValueGeneratorSelector.cs
@@ -31,6 +31,12 @@ public class CouchbaseValueGeneratorSelector : RelationalValueGeneratorSelector
     /// </summary>
     public const string SequenceOptionsAnnotation = "Couchbase:SequenceOptions";
 
+    /// <summary>
+    /// The annotation key for whether to auto-create the sequence on EnsureCreatedAsync.
+    /// Defaults to true if not present.
+    /// </summary>
+    public const string SequenceAutoCreateAnnotation = "Couchbase:SequenceAutoCreate";
+
     private static readonly MethodInfo CreateSequenceGeneratorMethod =
         typeof(CouchbaseValueGeneratorSelector).GetMethod(
             nameof(CreateSequenceValueGeneratorOfType),

--- a/src/Couchbase.EntityFrameworkCore/ValueGeneration/CouchbaseValueGeneratorSelector.cs
+++ b/src/Couchbase.EntityFrameworkCore/ValueGeneration/CouchbaseValueGeneratorSelector.cs
@@ -26,6 +26,11 @@ public class CouchbaseValueGeneratorSelector : RelationalValueGeneratorSelector
     /// </summary>
     public const string SequenceScopeAnnotation = "Couchbase:SequenceScope";
 
+    /// <summary>
+    /// The annotation key for sequence options (start value, increment, etc.).
+    /// </summary>
+    public const string SequenceOptionsAnnotation = "Couchbase:SequenceOptions";
+
     private static readonly MethodInfo CreateSequenceGeneratorMethod =
         typeof(CouchbaseValueGeneratorSelector).GetMethod(
             nameof(CreateSequenceValueGeneratorOfType),

--- a/tests/Couchbase.EntityFrameworkCore.IntegrationTests/Tests/SequenceValueGenerationTests.cs
+++ b/tests/Couchbase.EntityFrameworkCore.IntegrationTests/Tests/SequenceValueGenerationTests.cs
@@ -360,6 +360,139 @@ public class SequenceValueGenerationTests : IAsyncLifetime
     }
 
     /// <summary>
+    /// Integration test verifying that EnsureCreatedAsync auto-creates sequences.
+    /// Tests the full lifecycle:
+    /// 1. Drop sequence if exists (clean slate)
+    /// 2. Call EnsureCreatedAsync (should create sequence with specified options)
+    /// 3. Verify sequence works via NEXT VALUE FOR
+    /// 4. Verify sequence options were applied (StartWith, IncrementBy)
+    /// </summary>
+    [Fact]
+    public async Task EnsureCreatedAsync_AutoCreatesSequence_WithOptions()
+    {
+        const string autoCreateSeqName = "ensure_created_test_seq";
+
+        // Step 1: Clean up any existing sequence
+        await DropSequenceIfExistsAsync(autoCreateSeqName);
+        _outputHelper.WriteLine("Step 1: Dropped sequence if existed");
+
+        // Step 2: Create context with auto-create sequence configuration
+        var optionsBuilder = new DbContextOptionsBuilder<EnsureCreatedSequenceDbContext>();
+        optionsBuilder.UseCouchbase(
+            new ClusterOptions()
+                .WithConnectionString(_fixture.Host)
+                .WithPasswordAuthentication(_fixture.Username, _fixture.Password),
+            couchbaseDbContextOptions =>
+            {
+                couchbaseDbContextOptions.Bucket = _fixture.BucketName;
+                couchbaseDbContextOptions.Scope = _fixture.ScopeName;
+            });
+
+        await using var context = new EnsureCreatedSequenceDbContext(optionsBuilder.Options);
+
+        // Step 3: Call EnsureCreatedAsync - this should create the sequence
+        await context.Database.EnsureCreatedAsync();
+        _outputHelper.WriteLine("Step 2: EnsureCreatedAsync completed");
+
+        // Step 4: Verify sequence was created by fetching next value
+        var connection = context.Database.GetDbConnection();
+        await connection.OpenAsync();
+
+        using var command = connection.CreateCommand();
+        command.CommandText = $"SELECT NEXT VALUE FOR `{_fixture.BucketName}`.`{_fixture.ScopeName}`.`{autoCreateSeqName}`";
+        _outputHelper.WriteLine($"Step 3: Executing query: {command.CommandText}");
+
+        var result = await command.ExecuteScalarAsync();
+        Assert.NotNull(result);
+        var firstValue = Convert.ToInt64(result);
+        _outputHelper.WriteLine($"Step 3: First sequence value = {firstValue}");
+
+        // Verify StartWith option was applied (should start at 100)
+        Assert.Equal(100, firstValue);
+
+        // Step 5: Fetch another value to verify IncrementBy
+        result = await command.ExecuteScalarAsync();
+        var secondValue = Convert.ToInt64(result);
+        _outputHelper.WriteLine($"Step 4: Second sequence value = {secondValue}");
+
+        // Verify IncrementBy option was applied (should increment by 5)
+        Assert.Equal(105, secondValue);
+
+        // Cleanup
+        await DropSequenceIfExistsAsync(autoCreateSeqName);
+        _outputHelper.WriteLine("Cleanup: Dropped test sequence");
+
+        _outputHelper.WriteLine("TEST PASSED: EnsureCreatedAsync auto-created sequence with correct options");
+    }
+
+    /// <summary>
+    /// Integration test verifying that SaveChangesAsync works with auto-created sequences.
+    /// Full end-to-end: EnsureCreatedAsync creates sequence, then SaveChanges uses it.
+    /// </summary>
+    [Fact]
+    public async Task EnsureCreatedAsync_ThenSaveChanges_UsesAutoCreatedSequence()
+    {
+        const string autoCreateSeqName = "e2e_auto_seq";
+
+        // Clean up
+        await DropSequenceIfExistsAsync(autoCreateSeqName);
+
+        var optionsBuilder = new DbContextOptionsBuilder<E2EAutoCreateSequenceDbContext>();
+        optionsBuilder.UseCouchbase(
+            new ClusterOptions()
+                .WithConnectionString(_fixture.Host)
+                .WithPasswordAuthentication(_fixture.Username, _fixture.Password),
+            couchbaseDbContextOptions =>
+            {
+                couchbaseDbContextOptions.Bucket = _fixture.BucketName;
+                couchbaseDbContextOptions.Scope = _fixture.ScopeName;
+            });
+
+        await using var context = new E2EAutoCreateSequenceDbContext(optionsBuilder.Options);
+
+        // Create collection and sequence via EnsureCreatedAsync
+        await context.Database.EnsureCreatedAsync();
+        _outputHelper.WriteLine("EnsureCreatedAsync completed");
+
+        // Create entity with default Id (0)
+        var entity = new E2EAutoCreateEntity { Name = "Auto-created sequence test" };
+        Assert.Equal(0, entity.Id);
+
+        // Add and save - should use the auto-created sequence
+        context.Entities.Add(entity);
+        await context.SaveChangesAsync();
+
+        // Verify Id was assigned from sequence (starts at 1)
+        Assert.True(entity.Id > 0, $"Expected positive Id from sequence, got {entity.Id}");
+        _outputHelper.WriteLine($"Entity saved with Id = {entity.Id}");
+
+        // Cleanup
+        context.Entities.Remove(entity);
+        await context.SaveChangesAsync();
+        await DropSequenceIfExistsAsync(autoCreateSeqName);
+
+        _outputHelper.WriteLine("TEST PASSED: End-to-end auto-create sequence workflow verified");
+    }
+
+    private async Task DropSequenceIfExistsAsync(string sequenceName)
+    {
+        try
+        {
+            await using var context = CreateSequenceTestDbContext();
+            var connection = context.Database.GetDbConnection();
+            await connection.OpenAsync();
+
+            using var command = connection.CreateCommand();
+            command.CommandText = $"DROP SEQUENCE IF EXISTS `{_fixture.BucketName}`.`{_fixture.ScopeName}`.`{sequenceName}`";
+            await command.ExecuteNonQueryAsync();
+        }
+        catch (Exception ex)
+        {
+            _outputHelper.WriteLine($"Note: Could not drop sequence {sequenceName}: {ex.Message}");
+        }
+    }
+
+    /// <summary>
     /// Test entity with long Id using sequence value generation via fluent API.
     /// </summary>
     public class SequenceTestEntity
@@ -447,6 +580,84 @@ public class SequenceValueGenerationTests : IAsyncLifetime
                 entity.HasKey(e => e.Id);
                 entity.Property(e => e.Id).UseSequence(_sequenceName);
                 entity.ToCouchbaseCollection(this, "sequence_test_int_entities");
+            });
+
+            modelBuilder.ConfigureToCouchbase(this, true);
+        }
+    }
+
+    /// <summary>
+    /// Entity for EnsureCreatedAsync sequence auto-creation test.
+    /// </summary>
+    public class EnsureCreatedSequenceEntity
+    {
+        public long Id { get; set; }
+        public string Name { get; set; } = string.Empty;
+    }
+
+    /// <summary>
+    /// DbContext for testing EnsureCreatedAsync sequence auto-creation with custom options.
+    /// </summary>
+    public class EnsureCreatedSequenceDbContext : DbContext
+    {
+        public EnsureCreatedSequenceDbContext(DbContextOptions<EnsureCreatedSequenceDbContext> options)
+            : base(options)
+        {
+        }
+
+        public DbSet<EnsureCreatedSequenceEntity> Entities { get; set; }
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            base.OnModelCreating(modelBuilder);
+
+            modelBuilder.Entity<EnsureCreatedSequenceEntity>(entity =>
+            {
+                entity.HasKey(e => e.Id);
+                // Configure sequence with specific options to verify they're applied
+                entity.Property(e => e.Id).UseSequence("ensure_created_test_seq", new CouchbaseSequenceOptions
+                {
+                    StartWith = 100,
+                    IncrementBy = 5
+                });
+                entity.ToCouchbaseCollection(this, "ensure_created_test_entities");
+            });
+
+            modelBuilder.ConfigureToCouchbase(this, true);
+        }
+    }
+
+    /// <summary>
+    /// Entity for end-to-end auto-create sequence test.
+    /// </summary>
+    public class E2EAutoCreateEntity
+    {
+        public long Id { get; set; }
+        public string Name { get; set; } = string.Empty;
+    }
+
+    /// <summary>
+    /// DbContext for end-to-end auto-create sequence test.
+    /// </summary>
+    public class E2EAutoCreateSequenceDbContext : DbContext
+    {
+        public E2EAutoCreateSequenceDbContext(DbContextOptions<E2EAutoCreateSequenceDbContext> options)
+            : base(options)
+        {
+        }
+
+        public DbSet<E2EAutoCreateEntity> Entities { get; set; }
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            base.OnModelCreating(modelBuilder);
+
+            modelBuilder.Entity<E2EAutoCreateEntity>(entity =>
+            {
+                entity.HasKey(e => e.Id);
+                // Default options (StartWith = 1, IncrementBy = 1)
+                entity.Property(e => e.Id).UseSequence("e2e_auto_seq");
+                entity.ToCouchbaseCollection(this, "e2e_auto_create_entities");
             });
 
             modelBuilder.ConfigureToCouchbase(this, true);

--- a/tests/Couchbase.EntityFrameworkCore.IntegrationTests/Tests/SequenceValueGenerationTests.cs
+++ b/tests/Couchbase.EntityFrameworkCore.IntegrationTests/Tests/SequenceValueGenerationTests.cs
@@ -323,9 +323,6 @@ public class SequenceValueGenerationTests : IAsyncLifetime
     public async Task UseSequence_WithOptions_SetsAnnotationCorrectly()
     {
         // Arrange
-        await using var context = CreateSequenceTestDbContext();
-
-        // Create a test context with options
         var optionsBuilder = new DbContextOptionsBuilder<AutoCreateSequenceDbContext>();
         optionsBuilder.UseCouchbase(
             new ClusterOptions()

--- a/tests/Couchbase.EntityFrameworkCore.IntegrationTests/Tests/SequenceValueGenerationTests.cs
+++ b/tests/Couchbase.EntityFrameworkCore.IntegrationTests/Tests/SequenceValueGenerationTests.cs
@@ -1,8 +1,6 @@
-using System.Runtime.CompilerServices;
 using Couchbase.EntityFrameworkCode.IntegrationTests.Fixtures;
 using Couchbase.EntityFrameworkCore;
 using Couchbase.EntityFrameworkCore.Extensions;
-using Couchbase.EntityFrameworkCore.Metadata;
 using Couchbase.EntityFrameworkCore.ValueGeneration;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
@@ -198,23 +196,23 @@ public class SequenceValueGenerationTests : IAsyncLifetime
     {
         // Diagnostic test to verify the model is configured correctly
         await using var context = CreateSequenceTestDbContext();
-        
+
         var entityType = context.Model.FindEntityType(typeof(SequenceTestEntity));
         Assert.NotNull(entityType);
-        
+
         var idProperty = entityType.FindProperty(nameof(SequenceTestEntity.Id));
         Assert.NotNull(idProperty);
-        
+
         // Check ValueGenerated
         _outputHelper.WriteLine($"ValueGenerated: {idProperty.ValueGenerated}");
         Assert.Equal(Microsoft.EntityFrameworkCore.Metadata.ValueGenerated.OnAdd, idProperty.ValueGenerated);
-        
+
         // Check for sequence annotation
         var sequenceAnnotation = idProperty.FindAnnotation(CouchbaseValueGeneratorSelector.SequenceNameAnnotation);
         _outputHelper.WriteLine($"SequenceAnnotation: {sequenceAnnotation?.Value}");
         Assert.NotNull(sequenceAnnotation);
         Assert.Equal(SequenceName, sequenceAnnotation.Value);
-        
+
         // Check that the value generator selector is our implementation
         var selector = context.GetService<IValueGeneratorSelector>();
         _outputHelper.WriteLine($"Selector type: {selector?.GetType().FullName}");
@@ -321,6 +319,46 @@ public class SequenceValueGenerationTests : IAsyncLifetime
             $"Expected cancellation-related exception but got: {exception.GetType().Name}");
     }
 
+    [Fact]
+    public async Task UseSequence_WithOptions_SetsAnnotationCorrectly()
+    {
+        // Arrange
+        await using var context = CreateSequenceTestDbContext();
+
+        // Create a test context with options
+        var optionsBuilder = new DbContextOptionsBuilder<AutoCreateSequenceDbContext>();
+        optionsBuilder.UseCouchbase(
+            new ClusterOptions()
+                .WithConnectionString(_fixture.Host)
+                .WithPasswordAuthentication(_fixture.Username, _fixture.Password),
+            couchbaseDbContextOptions =>
+            {
+                couchbaseDbContextOptions.Bucket = _fixture.BucketName;
+                couchbaseDbContextOptions.Scope = _fixture.ScopeName;
+            });
+
+        await using var testContext = new AutoCreateSequenceDbContext(optionsBuilder.Options);
+
+        // Act
+        var entityType = testContext.Model.FindEntityType(typeof(AutoCreateSequenceEntity))!;
+        var idProperty = entityType.FindProperty(nameof(AutoCreateSequenceEntity.Id))!;
+
+        // Assert
+        var sequenceAnnotation = idProperty.FindAnnotation(CouchbaseValueGeneratorSelector.SequenceNameAnnotation);
+        Assert.NotNull(sequenceAnnotation);
+        Assert.Equal("auto_seq", sequenceAnnotation.Value);
+
+        var optionsAnnotation = idProperty.FindAnnotation(CouchbaseValueGeneratorSelector.SequenceOptionsAnnotation);
+        Assert.NotNull(optionsAnnotation);
+
+        var options = optionsAnnotation.Value as CouchbaseSequenceOptions;
+        Assert.NotNull(options);
+        Assert.Equal(1000, options.StartWith);
+        Assert.Equal(10, options.IncrementBy);
+
+        _outputHelper.WriteLine($"Sequence options: StartWith={options.StartWith}, IncrementBy={options.IncrementBy}");
+    }
+
     /// <summary>
     /// Test entity with long Id using sequence value generation via fluent API.
     /// </summary>
@@ -328,6 +366,43 @@ public class SequenceValueGenerationTests : IAsyncLifetime
     {
         public long Id { get; set; }
         public string Name { get; set; } = string.Empty;
+    }
+
+    /// <summary>
+    /// Test entity for auto-create sequence tests.
+    /// </summary>
+    public class AutoCreateSequenceEntity
+    {
+        public long Id { get; set; }
+        public string Name { get; set; } = string.Empty;
+    }
+
+    /// <summary>
+    /// DbContext for testing sequence auto-creation with options.
+    /// </summary>
+    public class AutoCreateSequenceDbContext : DbContext
+    {
+        public AutoCreateSequenceDbContext(DbContextOptions<AutoCreateSequenceDbContext> options)
+            : base(options)
+        {
+        }
+
+        public DbSet<AutoCreateSequenceEntity> AutoCreateEntities { get; set; }
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            base.OnModelCreating(modelBuilder);
+
+            modelBuilder.Entity<AutoCreateSequenceEntity>(entity =>
+            {
+                entity.HasKey(e => e.Id);
+                entity.Property(e => e.Id).UseSequence("auto_seq", new CouchbaseSequenceOptions
+                {
+                    StartWith = 1000,
+                    IncrementBy = 10
+                });
+            });
+        }
     }
 
     /// <summary>

--- a/tests/Couchbase.EntityFrameworkCore.UnitTests/Couchbase/EntityFrameworkCore/Extensions/CouchbasePropertyBuilderExtensionsTests.cs
+++ b/tests/Couchbase.EntityFrameworkCore.UnitTests/Couchbase/EntityFrameworkCore/Extensions/CouchbasePropertyBuilderExtensionsTests.cs
@@ -197,6 +197,251 @@ public class CouchbasePropertyBuilderExtensionsTests
         Assert.Null(scopeName); // Scope should be cleared
     }
 
+    [Fact]
+    public void UseSequence_WithOptions_SetsOptionsAnnotation()
+    {
+        // Arrange
+        var modelBuilder = new ModelBuilder();
+        var entityBuilder = modelBuilder.Entity<TestEntity>();
+        var options = new CouchbaseSequenceOptions
+        {
+            StartWith = 100,
+            IncrementBy = 5
+        };
+
+        // Act
+        entityBuilder.Property(e => e.Id).UseSequence("order_seq", options);
+
+        // Assert
+        var model = modelBuilder.Model;
+        var entityType = model.FindEntityType(typeof(TestEntity));
+        var property = entityType!.FindProperty(nameof(TestEntity.Id));
+        
+        var storedOptions = property!.FindAnnotation(CouchbaseValueGeneratorSelector.SequenceOptionsAnnotation)?.Value as CouchbaseSequenceOptions;
+        Assert.NotNull(storedOptions);
+        Assert.Equal(100, storedOptions.StartWith);
+        Assert.Equal(5, storedOptions.IncrementBy);
+    }
+
+    [Fact]
+    public void UseSequence_WithoutOptions_ClearsPreviousOptionsAnnotation()
+    {
+        // Arrange
+        var modelBuilder = new ModelBuilder();
+        var entityBuilder = modelBuilder.Entity<TestEntity>();
+        var options = new CouchbaseSequenceOptions
+        {
+            StartWith = 100,
+            IncrementBy = 5
+        };
+
+        // Act - First configure with options, then override without options
+        entityBuilder.Property(e => e.Id)
+            .UseSequence("order_seq", options)
+            .UseSequence("order_seq"); // Should clear the options
+
+        // Assert
+        var model = modelBuilder.Model;
+        var entityType = model.FindEntityType(typeof(TestEntity));
+        var property = entityType!.FindProperty(nameof(TestEntity.Id));
+        
+        var storedOptions = property!.FindAnnotation(CouchbaseValueGeneratorSelector.SequenceOptionsAnnotation)?.Value;
+        Assert.Null(storedOptions); // Options should be cleared
+    }
+
+    [Fact]
+    public void UseSequence_WithScope_WithoutOptions_ClearsPreviousOptionsAnnotation()
+    {
+        // Arrange
+        var modelBuilder = new ModelBuilder();
+        var entityBuilder = modelBuilder.Entity<TestEntity>();
+        var options = new CouchbaseSequenceOptions
+        {
+            StartWith = 100,
+            IncrementBy = 5
+        };
+
+        // Act - First configure with scope and options, then override with scope only
+        entityBuilder.Property(e => e.Id)
+            .UseSequence("analytics", "order_seq", options)
+            .UseSequence("analytics", "order_seq"); // Should clear the options
+
+        // Assert
+        var model = modelBuilder.Model;
+        var entityType = model.FindEntityType(typeof(TestEntity));
+        var property = entityType!.FindProperty(nameof(TestEntity.Id));
+        
+        var storedOptions = property!.FindAnnotation(CouchbaseValueGeneratorSelector.SequenceOptionsAnnotation)?.Value;
+        var scopeName = property!.FindAnnotation(CouchbaseValueGeneratorSelector.SequenceScopeAnnotation)?.Value;
+        
+        Assert.Null(storedOptions); // Options should be cleared
+        Assert.Equal("analytics", scopeName); // Scope should still be set
+    }
+
+    [Fact]
+    public void UseSequence_WithoutOptions_ClearsPreviousAutoCreateAnnotation()
+    {
+        // Arrange
+        var modelBuilder = new ModelBuilder();
+        var entityBuilder = modelBuilder.Entity<TestEntity>();
+
+        // First, manually set the auto-create annotation to simulate attribute processing
+        entityBuilder.Property(e => e.Id)
+            .HasAnnotation(CouchbaseValueGeneratorSelector.SequenceNameAnnotation, "order_seq")
+            .HasAnnotation(CouchbaseValueGeneratorSelector.SequenceAutoCreateAnnotation, false);
+
+        // Act - Now call UseSequence without options, which should clear auto-create
+        entityBuilder.Property(e => e.Id).UseSequence("order_seq");
+
+        // Assert
+        var model = modelBuilder.Model;
+        var entityType = model.FindEntityType(typeof(TestEntity));
+        var property = entityType!.FindProperty(nameof(TestEntity.Id));
+        
+        var autoCreate = property!.FindAnnotation(CouchbaseValueGeneratorSelector.SequenceAutoCreateAnnotation)?.Value;
+        Assert.Null(autoCreate); // Auto-create annotation should be cleared
+    }
+
+    [Fact]
+    public void UseSequence_NonGeneric_WithoutOptions_ClearsPreviousOptionsAnnotation()
+    {
+        // Arrange
+        var modelBuilder = new ModelBuilder();
+        var entityBuilder = modelBuilder.Entity<TestEntity>();
+        var options = new CouchbaseSequenceOptions
+        {
+            StartWith = 100,
+            IncrementBy = 5
+        };
+
+        // Act - First configure with options, then override without options using non-generic
+        entityBuilder.Property(e => e.Id).UseSequence("order_seq", options);
+        entityBuilder.Property(nameof(TestEntity.Id)).UseSequence("order_seq"); // Should clear the options
+
+        // Assert
+        var model = modelBuilder.Model;
+        var entityType = model.FindEntityType(typeof(TestEntity));
+        var property = entityType!.FindProperty(nameof(TestEntity.Id));
+        
+        var storedOptions = property!.FindAnnotation(CouchbaseValueGeneratorSelector.SequenceOptionsAnnotation)?.Value;
+        Assert.Null(storedOptions); // Options should be cleared
+    }
+
+    [Fact]
+    public void UseSequence_NonGeneric_WithScope_WithoutOptions_ClearsPreviousOptionsAnnotation()
+    {
+        // Arrange
+        var modelBuilder = new ModelBuilder();
+        var entityBuilder = modelBuilder.Entity<TestEntity>();
+        var options = new CouchbaseSequenceOptions
+        {
+            StartWith = 100,
+            IncrementBy = 5
+        };
+
+        // Act - First configure with scope and options, then override with scope only
+        entityBuilder.Property(e => e.Id).UseSequence("analytics", "order_seq", options);
+        entityBuilder.Property(nameof(TestEntity.Id)).UseSequence("analytics", "order_seq"); // Should clear the options
+
+        // Assert
+        var model = modelBuilder.Model;
+        var entityType = model.FindEntityType(typeof(TestEntity));
+        var property = entityType!.FindProperty(nameof(TestEntity.Id));
+        
+        var storedOptions = property!.FindAnnotation(CouchbaseValueGeneratorSelector.SequenceOptionsAnnotation)?.Value;
+        Assert.Null(storedOptions); // Options should be cleared
+    }
+
+    [Fact]
+    public void UseSequence_ChainingFromOptionsToNoOptions_ClearsAllOverrides()
+    {
+        // Arrange
+        var modelBuilder = new ModelBuilder();
+        var entityBuilder = modelBuilder.Entity<TestEntity>();
+        var options = new CouchbaseSequenceOptions
+        {
+            StartWith = 100,
+            IncrementBy = 5
+        };
+
+        // Act - Configure with all options, then clear with basic overload
+        entityBuilder.Property(e => e.Id)
+            .UseSequence("custom_scope", "first_seq", options)
+            .UseSequence("second_seq"); // Should clear scope, options, auto-create
+
+        // Assert
+        var model = modelBuilder.Model;
+        var entityType = model.FindEntityType(typeof(TestEntity));
+        var property = entityType!.FindProperty(nameof(TestEntity.Id));
+        
+        var sequenceName = property!.FindAnnotation(CouchbaseValueGeneratorSelector.SequenceNameAnnotation)?.Value;
+        var scopeName = property!.FindAnnotation(CouchbaseValueGeneratorSelector.SequenceScopeAnnotation)?.Value;
+        var storedOptions = property!.FindAnnotation(CouchbaseValueGeneratorSelector.SequenceOptionsAnnotation)?.Value;
+        var autoCreate = property!.FindAnnotation(CouchbaseValueGeneratorSelector.SequenceAutoCreateAnnotation)?.Value;
+        
+        Assert.Equal("second_seq", sequenceName); // New sequence name
+        Assert.Null(scopeName); // Scope should be cleared
+        Assert.Null(storedOptions); // Options should be cleared
+        Assert.Null(autoCreate); // Auto-create should be cleared
+    }
+
+    [Fact]
+    public void UseSequence_WithScopeAndOptions_SetsBothAnnotations()
+    {
+        // Arrange
+        var modelBuilder = new ModelBuilder();
+        var entityBuilder = modelBuilder.Entity<TestEntity>();
+        var options = new CouchbaseSequenceOptions
+        {
+            StartWith = 500,
+            IncrementBy = 10,
+            Cycle = true
+        };
+
+        // Act
+        entityBuilder.Property(e => e.Id).UseSequence("analytics", "order_seq", options);
+
+        // Assert
+        var model = modelBuilder.Model;
+        var entityType = model.FindEntityType(typeof(TestEntity));
+        var property = entityType!.FindProperty(nameof(TestEntity.Id));
+        
+        var sequenceName = property!.FindAnnotation(CouchbaseValueGeneratorSelector.SequenceNameAnnotation)?.Value;
+        var scopeName = property!.FindAnnotation(CouchbaseValueGeneratorSelector.SequenceScopeAnnotation)?.Value;
+        var storedOptions = property!.FindAnnotation(CouchbaseValueGeneratorSelector.SequenceOptionsAnnotation)?.Value as CouchbaseSequenceOptions;
+        
+        Assert.Equal("order_seq", sequenceName);
+        Assert.Equal("analytics", scopeName);
+        Assert.NotNull(storedOptions);
+        Assert.Equal(500, storedOptions.StartWith);
+        Assert.Equal(10, storedOptions.IncrementBy);
+        Assert.True(storedOptions.Cycle);
+    }
+
+    [Fact]
+    public void UseSequence_WithNullOptions_ThrowsArgumentNullException()
+    {
+        // Arrange
+        var modelBuilder = new ModelBuilder();
+        var entityBuilder = modelBuilder.Entity<TestEntity>();
+
+        // Act & Assert
+        Assert.Throws<ArgumentNullException>(() => 
+            entityBuilder.Property(e => e.Id).UseSequence("order_seq", (CouchbaseSequenceOptions)null!));
+    }
+
+    [Fact]
+    public void UseSequence_WithScopeAndNullOptions_ThrowsArgumentNullException()
+    {
+        // Arrange
+        var modelBuilder = new ModelBuilder();
+        var entityBuilder = modelBuilder.Entity<TestEntity>();
+
+        // Act & Assert
+        Assert.Throws<ArgumentNullException>(() => 
+            entityBuilder.Property(e => e.Id).UseSequence("analytics", "order_seq", null!));
+    }
+
     private class TestEntity
     {
         public long Id { get; set; }

--- a/tests/Couchbase.EntityFrameworkCore.UnitTests/Couchbase/EntityFrameworkCore/Infrastructure/CouchbaseDbContextOptionsBuilderTests.cs
+++ b/tests/Couchbase.EntityFrameworkCore.UnitTests/Couchbase/EntityFrameworkCore/Infrastructure/CouchbaseDbContextOptionsBuilderTests.cs
@@ -1,0 +1,113 @@
+using Couchbase.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore;
+using Xunit;
+
+namespace Couchbase.EntityFrameworkCore.UnitTests.Couchbase.EntityFrameworkCore.Infrastructure;
+
+public class CouchbaseDbContextOptionsBuilderTests
+{
+    [Fact]
+    public void AutoCreateScopes_DefaultsToFalse()
+    {
+        // Arrange
+        var dbContextOptionsBuilder = new DbContextOptionsBuilder();
+        var clusterOptions = new ClusterOptions().WithConnectionString("couchbase://localhost");
+
+        // Act
+        var builder = new CouchbaseDbContextOptionsBuilder(dbContextOptionsBuilder, clusterOptions);
+
+        // Assert
+        Assert.False(builder.AutoCreateScopes);
+    }
+
+    [Fact]
+    public void AutoCreateScopes_CanBeSetToTrue()
+    {
+        // Arrange
+        var dbContextOptionsBuilder = new DbContextOptionsBuilder();
+        var clusterOptions = new ClusterOptions().WithConnectionString("couchbase://localhost");
+        var builder = new CouchbaseDbContextOptionsBuilder(dbContextOptionsBuilder, clusterOptions);
+
+        // Act
+        builder.AutoCreateScopes = true;
+
+        // Assert
+        Assert.True(builder.AutoCreateScopes);
+    }
+
+    [Fact]
+    public void AutoCreateScopes_CanBeSetViaInterface()
+    {
+        // Arrange
+        var dbContextOptionsBuilder = new DbContextOptionsBuilder();
+        var clusterOptions = new ClusterOptions().WithConnectionString("couchbase://localhost");
+        ICouchbaseDbContextOptionsBuilder builder = new CouchbaseDbContextOptionsBuilder(dbContextOptionsBuilder, clusterOptions);
+
+        // Act
+        builder.AutoCreateScopes = true;
+
+        // Assert
+        Assert.True(builder.AutoCreateScopes);
+    }
+
+    [Fact]
+    public void Bucket_CanBeSet()
+    {
+        // Arrange
+        var dbContextOptionsBuilder = new DbContextOptionsBuilder();
+        var clusterOptions = new ClusterOptions().WithConnectionString("couchbase://localhost");
+        var builder = new CouchbaseDbContextOptionsBuilder(dbContextOptionsBuilder, clusterOptions);
+
+        // Act
+        builder.Bucket = "testBucket";
+
+        // Assert
+        Assert.Equal("testBucket", builder.Bucket);
+    }
+
+    [Fact]
+    public void Scope_CanBeSet()
+    {
+        // Arrange
+        var dbContextOptionsBuilder = new DbContextOptionsBuilder();
+        var clusterOptions = new ClusterOptions().WithConnectionString("couchbase://localhost");
+        var builder = new CouchbaseDbContextOptionsBuilder(dbContextOptionsBuilder, clusterOptions);
+
+        // Act
+        builder.Scope = "testScope";
+
+        // Assert
+        Assert.Equal("testScope", builder.Scope);
+    }
+
+    [Fact]
+    public void Constructor_WithConnectionString_SetsClusterOptions()
+    {
+        // Arrange
+        var dbContextOptionsBuilder = new DbContextOptionsBuilder();
+        var connectionString = "couchbase://localhost";
+
+        // Act
+        var builder = new CouchbaseDbContextOptionsBuilder(dbContextOptionsBuilder, connectionString);
+
+        // Assert
+        Assert.NotNull(builder.ClusterOptions);
+        Assert.Equal(connectionString, builder.ClusterOptions.ConnectionString);
+    }
+
+    [Fact]
+    public void Constructor_WithClusterOptions_PreservesClusterOptions()
+    {
+        // Arrange
+        var dbContextOptionsBuilder = new DbContextOptionsBuilder();
+        var clusterOptions = new ClusterOptions()
+            .WithConnectionString("couchbase://localhost")
+            .WithCredentials("user", "password");
+
+        // Act
+        var builder = new CouchbaseDbContextOptionsBuilder(dbContextOptionsBuilder, clusterOptions);
+
+        // Assert
+        Assert.Same(clusterOptions, builder.ClusterOptions);
+    }
+}

--- a/tests/Couchbase.EntityFrameworkCore.UnitTests/Couchbase/EntityFrameworkCore/Metadata/Conventions/CouchbaseSequenceConventionTests.cs
+++ b/tests/Couchbase.EntityFrameworkCore.UnitTests/Couchbase/EntityFrameworkCore/Metadata/Conventions/CouchbaseSequenceConventionTests.cs
@@ -1,0 +1,109 @@
+using Couchbase.EntityFrameworkCore.ValueGeneration;
+using Microsoft.EntityFrameworkCore;
+using Xunit;
+
+namespace Couchbase.EntityFrameworkCore.UnitTests.Couchbase.EntityFrameworkCore.Metadata.Conventions;
+
+/// <summary>
+/// Tests for verifying that boolean annotations can be properly read from EF model.
+/// </summary>
+public class BoolAnnotationReadingTests
+{
+    [Fact]
+    public void PatternMatching_ReadsBoxedBoolCorrectly()
+    {
+        // Arrange - simulate how EF stores annotation values (boxed)
+        object boxedFalse = false;
+        object boxedTrue = true;
+
+        // Act - using pattern matching
+        var readFalse = boxedFalse is bool b1 ? b1 : true;
+        var readTrue = boxedTrue is bool b2 ? b2 : false;
+
+        // Assert
+        Assert.False(readFalse);
+        Assert.True(readTrue);
+    }
+
+    [Fact]
+    public void PatternMatching_NullDefaultsCorrectly()
+    {
+        // Arrange - simulate missing annotation
+        object? nullValue = null;
+
+        // Act - using pattern matching with default
+        var result = nullValue is bool b ? b : true;
+
+        // Assert - defaults to true when null
+        Assert.True(result);
+    }
+
+    [Fact]
+    public void AnnotationValue_AutoCreateFalse_CanBeRead()
+    {
+        // Arrange - create model builder and set annotation like the convention does
+        var modelBuilder = new ModelBuilder();
+        modelBuilder.Entity<TestEntity>()
+            .Property(e => e.Id)
+            .HasAnnotation(CouchbaseValueGeneratorSelector.SequenceAutoCreateAnnotation, false);
+
+        var model = modelBuilder.FinalizeModel();
+        var property = model.FindEntityType(typeof(TestEntity))!.FindProperty(nameof(TestEntity.Id))!;
+
+        // Act - read the annotation using pattern matching
+        var annotation = property.FindAnnotation(CouchbaseValueGeneratorSelector.SequenceAutoCreateAnnotation);
+        var autoCreate = annotation?.Value is bool b ? b : true;
+
+        // Assert
+        Assert.NotNull(annotation);
+        Assert.False(autoCreate);
+    }
+
+    [Fact]
+    public void AnnotationValue_AutoCreateTrue_CanBeRead()
+    {
+        // Arrange - create model builder and set annotation
+        var modelBuilder = new ModelBuilder();
+        modelBuilder.Entity<TestEntity>()
+            .Property(e => e.Id)
+            .HasAnnotation(CouchbaseValueGeneratorSelector.SequenceAutoCreateAnnotation, true);
+
+        var model = modelBuilder.FinalizeModel();
+        var property = model.FindEntityType(typeof(TestEntity))!.FindProperty(nameof(TestEntity.Id))!;
+
+        // Act - read the annotation using pattern matching
+        var annotation = property.FindAnnotation(CouchbaseValueGeneratorSelector.SequenceAutoCreateAnnotation);
+        var autoCreate = annotation?.Value is bool b ? b : true;
+
+        // Assert
+        Assert.NotNull(annotation);
+        Assert.True(autoCreate);
+    }
+
+    [Fact]
+    public void AnnotationValue_MissingAnnotation_DefaultsToTrue()
+    {
+        // Arrange - create model builder without the annotation
+        var modelBuilder = new ModelBuilder();
+        modelBuilder.Entity<TestEntity>()
+            .Property(e => e.Id)
+            .HasAnnotation(CouchbaseValueGeneratorSelector.SequenceNameAnnotation, "test_seq"); // Set some other annotation
+
+        var model = modelBuilder.FinalizeModel();
+        var property = model.FindEntityType(typeof(TestEntity))!.FindProperty(nameof(TestEntity.Id))!;
+
+        // Act - read the annotation (should be null)
+        var annotation = property.FindAnnotation(CouchbaseValueGeneratorSelector.SequenceAutoCreateAnnotation);
+        var autoCreate = annotation?.Value is bool b ? b : true;
+
+        // Assert - defaults to true when annotation is missing
+        Assert.Null(annotation);
+        Assert.True(autoCreate);
+    }
+
+    private class TestEntity
+    {
+        public long Id { get; set; }
+        public string? Name { get; set; }
+    }
+}

--- a/tests/Couchbase.EntityFrameworkCore.UnitTests/Couchbase/EntityFrameworkCore/Metadata/CouchbaseSequenceAttributeTests.cs
+++ b/tests/Couchbase.EntityFrameworkCore.UnitTests/Couchbase/EntityFrameworkCore/Metadata/CouchbaseSequenceAttributeTests.cs
@@ -100,6 +100,79 @@ public class CouchbaseSequenceAttributeTests
         Assert.Equal("counters", attribute.Scope);
     }
 
+    [Fact]
+    public void StartWith_DefaultsToOne()
+    {
+        // Arrange & Act
+        var attribute = new CouchbaseSequenceAttribute("test_seq");
+
+        // Assert
+        Assert.Equal(1, attribute.StartWith);
+    }
+
+    [Fact]
+    public void IncrementBy_DefaultsToOne()
+    {
+        // Arrange & Act
+        var attribute = new CouchbaseSequenceAttribute("test_seq");
+
+        // Assert
+        Assert.Equal(1, attribute.IncrementBy);
+    }
+
+    [Fact]
+    public void Cycle_DefaultsToFalse()
+    {
+        // Arrange & Act
+        var attribute = new CouchbaseSequenceAttribute("test_seq");
+
+        // Assert
+        Assert.False(attribute.Cycle);
+    }
+
+    [Fact]
+    public void AutoCreate_DefaultsToTrue()
+    {
+        // Arrange & Act
+        var attribute = new CouchbaseSequenceAttribute("test_seq");
+
+        // Assert
+        Assert.True(attribute.AutoCreate);
+    }
+
+    [Fact]
+    public void AutoCreate_CanBeSetToFalse()
+    {
+        // Arrange & Act
+        var attribute = new CouchbaseSequenceAttribute("test_seq")
+        {
+            AutoCreate = false
+        };
+
+        // Assert
+        Assert.False(attribute.AutoCreate);
+    }
+
+    [Fact]
+    public void AllProperties_CanBeCustomized()
+    {
+        // Arrange & Act
+        var attribute = new CouchbaseSequenceAttribute("test_seq")
+        {
+            StartWith = 100,
+            IncrementBy = 5,
+            Cycle = true,
+            AutoCreate = false
+        };
+
+        // Assert
+        Assert.Equal("test_seq", attribute.SequenceName);
+        Assert.Equal(100, attribute.StartWith);
+        Assert.Equal(5, attribute.IncrementBy);
+        Assert.True(attribute.Cycle);
+        Assert.False(attribute.AutoCreate);
+    }
+
     private class TestEntity
     {
         [CouchbaseSequence("test_seq")]

--- a/tests/Couchbase.EntityFrameworkCore.UnitTests/Couchbase/EntityFrameworkCore/Storage/Internal/CouchbaseDatabaseCreatorTests.cs
+++ b/tests/Couchbase.EntityFrameworkCore.UnitTests/Couchbase/EntityFrameworkCore/Storage/Internal/CouchbaseDatabaseCreatorTests.cs
@@ -1,0 +1,537 @@
+using Couchbase.EntityFrameworkCore.Infrastructure;
+using Couchbase.EntityFrameworkCore.Storage.Internal;
+using Couchbase.EntityFrameworkCore.ValueGeneration;
+using Couchbase.Extensions.DependencyInjection;
+using Couchbase.Management.Buckets;
+using Couchbase.Management.Collections;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
+using Microsoft.EntityFrameworkCore.Storage;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Xunit;
+
+namespace Couchbase.EntityFrameworkCore.UnitTests.Couchbase.EntityFrameworkCore.Storage.Internal;
+
+public class CouchbaseDatabaseCreatorTests
+{
+    private readonly Mock<IDatabase> _mockDatabase;
+    private readonly Mock<IDesignTimeModel> _mockDesignTimeModel;
+    private readonly Mock<ILogger<CouchbaseDatabaseCreator>> _mockLogger;
+    private readonly Mock<IServiceProvider> _mockServiceProvider;
+    private readonly Mock<ICouchbaseDbContextOptionsBuilder> _mockOptions;
+    private readonly Mock<ISqlGenerationHelper> _mockSqlGenerationHelper;
+    private readonly Mock<IClusterProvider> _mockClusterProvider;
+    private readonly Mock<ICluster> _mockCluster;
+    private readonly Mock<IBucket> _mockBucket;
+    private readonly Mock<ICouchbaseCollectionManager> _mockCollectionManager;
+    private readonly Mock<IBucketManager> _mockBucketManager;
+    private readonly Mock<IModel> _mockModel;
+
+    public CouchbaseDatabaseCreatorTests()
+    {
+        _mockDatabase = new Mock<IDatabase>();
+        _mockDesignTimeModel = new Mock<IDesignTimeModel>();
+        _mockLogger = new Mock<ILogger<CouchbaseDatabaseCreator>>();
+        _mockServiceProvider = new Mock<IServiceProvider>();
+        _mockOptions = new Mock<ICouchbaseDbContextOptionsBuilder>();
+        _mockSqlGenerationHelper = new Mock<ISqlGenerationHelper>();
+        _mockClusterProvider = new Mock<IClusterProvider>();
+        _mockCluster = new Mock<ICluster>();
+        _mockBucket = new Mock<IBucket>();
+        _mockCollectionManager = new Mock<ICouchbaseCollectionManager>();
+        _mockBucketManager = new Mock<IBucketManager>();
+        _mockModel = new Mock<IModel>();
+
+        // Default setup
+        _mockOptions.Setup(o => o.Bucket).Returns("test-bucket");
+        _mockOptions.Setup(o => o.Scope).Returns("test-scope");
+        _mockOptions.Setup(o => o.AutoCreateScopes).Returns(false);
+
+        _mockServiceProvider.Setup(sp => sp.GetService(typeof(IClusterProvider)))
+            .Returns(_mockClusterProvider.Object);
+        _mockClusterProvider.Setup(cp => cp.GetClusterAsync())
+            .ReturnsAsync(_mockCluster.Object);
+        _mockCluster.Setup(c => c.BucketAsync("test-bucket"))
+            .ReturnsAsync(_mockBucket.Object);
+        _mockCluster.Setup(c => c.Buckets).Returns(_mockBucketManager.Object);
+        _mockBucket.Setup(b => b.Collections).Returns(_mockCollectionManager.Object);
+
+        _mockDesignTimeModel.Setup(m => m.Model).Returns(_mockModel.Object);
+        _mockModel.Setup(m => m.GetEntityTypes()).Returns(Array.Empty<IEntityType>());
+
+        _mockSqlGenerationHelper.Setup(h => h.DelimitIdentifier(It.IsAny<string>()))
+            .Returns<string>(s => $"`{s}`");
+    }
+
+    private CouchbaseDatabaseCreator CreateCreator()
+    {
+        // Create minimal dependencies - we'll use reflection or make methods testable
+        var dependencies = CreateMockDependencies();
+        return new CouchbaseDatabaseCreator(
+            dependencies,
+            _mockDatabase.Object,
+            _mockServiceProvider.Object,
+            _mockDesignTimeModel.Object,
+            _mockLogger.Object,
+            _mockOptions.Object,
+            _mockSqlGenerationHelper.Object);
+    }
+
+    private RelationalDatabaseCreatorDependencies CreateMockDependencies()
+    {
+        var mockConnection = new Mock<IRelationalConnection>();
+        var mockModelDiffer = new Mock<IMigrationsModelDiffer>();
+        var mockMigrationsSqlGenerator = new Mock<IMigrationsSqlGenerator>();
+        var mockMigrationCommandExecutor = new Mock<IMigrationCommandExecutor>();
+        var mockSqlGenerationHelper = new Mock<ISqlGenerationHelper>();
+        var mockCurrentContext = new Mock<ICurrentDbContext>();
+        var mockModel = new Mock<IModel>();
+        var mockDbContextOptions = new Mock<IDbContextOptions>();
+        var mockCommandLogger = new Mock<IRelationalCommandDiagnosticsLogger>();
+        var mockExceptionDetector = new Mock<IExceptionDetector>();
+
+        var mockDbContext = new Mock<DbContext>();
+        mockCurrentContext.Setup(c => c.Context).Returns(mockDbContext.Object);
+
+        return new RelationalDatabaseCreatorDependencies(
+            mockConnection.Object,
+            mockModelDiffer.Object,
+            mockMigrationsSqlGenerator.Object,
+            mockMigrationCommandExecutor.Object,
+            mockSqlGenerationHelper.Object,
+            Mock.Of<IExecutionStrategy>(),
+            mockCurrentContext.Object,
+            mockDbContextOptions.Object,
+            mockCommandLogger.Object,
+            mockExceptionDetector.Object);
+    }
+
+    #region ExistsAsync Tests
+
+    [Fact]
+    public async Task ExistsAsync_WhenBucketExists_ReturnsTrue()
+    {
+        // Arrange
+        _mockBucketManager.Setup(m => m.GetBucketAsync("test-bucket", It.IsAny<GetBucketOptions>()))
+            .ReturnsAsync(new BucketSettings { Name = "test-bucket" });
+        var creator = CreateCreator();
+
+        // Act
+        var result = await creator.ExistsAsync();
+
+        // Assert
+        Assert.True(result);
+        _mockBucketManager.Verify(m => m.GetBucketAsync("test-bucket", It.IsAny<GetBucketOptions>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task ExistsAsync_WhenBucketNotFound_ReturnsFalse()
+    {
+        // Arrange
+        _mockBucketManager.Setup(m => m.GetBucketAsync("test-bucket", It.IsAny<GetBucketOptions>()))
+            .ThrowsAsync(new BucketNotFoundException("test-bucket"));
+        var creator = CreateCreator();
+
+        // Act
+        var result = await creator.ExistsAsync();
+
+        // Assert
+        Assert.False(result);
+    }
+
+    [Fact]
+    public async Task ExistsAsync_UsesBucketNameNotScopeName()
+    {
+        // Arrange - bucket and scope have different names
+        _mockOptions.Setup(o => o.Bucket).Returns("my-bucket");
+        _mockOptions.Setup(o => o.Scope).Returns("my-scope");
+        _mockBucketManager.Setup(m => m.GetBucketAsync("my-bucket", It.IsAny<GetBucketOptions>()))
+            .ReturnsAsync(new BucketSettings { Name = "my-bucket" });
+        var creator = CreateCreator();
+
+        // Act
+        await creator.ExistsAsync();
+
+        // Assert - should check for bucket, not scope
+        _mockBucketManager.Verify(m => m.GetBucketAsync("my-bucket", It.IsAny<GetBucketOptions>()), Times.Once);
+        _mockBucketManager.Verify(m => m.GetBucketAsync("my-scope", It.IsAny<GetBucketOptions>()), Times.Never);
+    }
+
+    #endregion
+
+    #region CreateAsync Tests
+
+    [Fact]
+    public async Task CreateAsync_CreatesBucketWithCorrectName()
+    {
+        // Arrange
+        _mockOptions.Setup(o => o.Bucket).Returns("new-bucket");
+        BucketSettings? capturedSettings = null;
+        _mockBucketManager.Setup(m => m.CreateBucketAsync(It.IsAny<BucketSettings>(), It.IsAny<CreateBucketOptions>()))
+            .Callback<BucketSettings, CreateBucketOptions>((s, _) => capturedSettings = s)
+            .Returns(Task.CompletedTask);
+        var creator = CreateCreator();
+
+        // Act
+        await creator.CreateAsync();
+
+        // Assert
+        Assert.NotNull(capturedSettings);
+        Assert.Equal("new-bucket", capturedSettings.Name);
+    }
+
+    [Fact]
+    public async Task CreateAsync_UsesBucketNameNotScopeName()
+    {
+        // Arrange
+        _mockOptions.Setup(o => o.Bucket).Returns("correct-bucket");
+        _mockOptions.Setup(o => o.Scope).Returns("some-scope");
+        BucketSettings? capturedSettings = null;
+        _mockBucketManager.Setup(m => m.CreateBucketAsync(It.IsAny<BucketSettings>(), It.IsAny<CreateBucketOptions>()))
+            .Callback<BucketSettings, CreateBucketOptions>((s, _) => capturedSettings = s)
+            .Returns(Task.CompletedTask);
+        var creator = CreateCreator();
+
+        // Act
+        await creator.CreateAsync();
+
+        // Assert
+        Assert.NotNull(capturedSettings);
+        Assert.Equal("correct-bucket", capturedSettings.Name);
+        Assert.NotEqual("some-scope", capturedSettings.Name);
+    }
+
+    [Fact]
+    public async Task CreateAsync_WhenBucketExists_DoesNotThrow()
+    {
+        // Arrange
+        _mockBucketManager.Setup(m => m.CreateBucketAsync(It.IsAny<BucketSettings>(), It.IsAny<CreateBucketOptions>()))
+            .ThrowsAsync(new BucketExistsException("test-bucket"));
+        var creator = CreateCreator();
+
+        // Act & Assert - should not throw
+        await creator.CreateAsync();
+    }
+
+    #endregion
+
+    #region EnsureCreatedAsync Tests - Scope Creation
+
+    [Fact]
+    public async Task EnsureCreatedAsync_ChecksForCorrectScopeNotBucket()
+    {
+        // Arrange - This test would have caught the original bug
+        _mockOptions.Setup(o => o.Bucket).Returns("my-bucket");
+        _mockOptions.Setup(o => o.Scope).Returns("my-scope");
+
+        // Bucket exists
+        _mockBucketManager.Setup(m => m.GetBucketAsync("my-bucket", It.IsAny<GetBucketOptions>()))
+            .ReturnsAsync(new BucketSettings { Name = "my-bucket" });
+
+        // Setup bucket retrieval for scope operations
+        _mockCluster.Setup(c => c.BucketAsync("my-bucket"))
+            .ReturnsAsync(_mockBucket.Object);
+
+        // Return scopes that include "my-bucket" but NOT "my-scope"
+        // If the bug existed (checking Bucket instead of Scope), scope creation would be skipped
+        var existingScopes = new List<ScopeSpec>
+        {
+            new ScopeSpec("my-bucket"), // Bucket name exists as a scope (edge case)
+            new ScopeSpec("_default")
+        };
+        _mockCollectionManager.Setup(m => m.GetAllScopesAsync(It.IsAny<GetAllScopesOptions>()))
+            .ReturnsAsync(existingScopes);
+
+        var creator = CreateCreator();
+
+        // Act
+        await creator.EnsureCreatedAsync();
+
+        // Assert - should attempt to create "my-scope", not skip because "my-bucket" scope exists
+        _mockCollectionManager.Verify(
+            m => m.CreateScopeAsync("my-scope", It.IsAny<CreateScopeOptions>()),
+            Times.Once,
+            "Should create scope using Scope name, not Bucket name");
+        _mockCollectionManager.Verify(
+            m => m.CreateScopeAsync("my-bucket", It.IsAny<CreateScopeOptions>()),
+            Times.Never,
+            "Should not try to create scope using Bucket name");
+    }
+
+    [Fact]
+    public async Task EnsureCreatedAsync_WhenScopeExists_DoesNotCreateScope()
+    {
+        // Arrange
+        _mockOptions.Setup(o => o.Bucket).Returns("my-bucket");
+        _mockOptions.Setup(o => o.Scope).Returns("my-scope");
+
+        _mockBucketManager.Setup(m => m.GetBucketAsync("my-bucket", It.IsAny<GetBucketOptions>()))
+            .ReturnsAsync(new BucketSettings { Name = "my-bucket" });
+
+        _mockCluster.Setup(c => c.BucketAsync("my-bucket"))
+            .ReturnsAsync(_mockBucket.Object);
+
+        // Scope already exists
+        var existingScopes = new List<ScopeSpec>
+        {
+            new ScopeSpec("my-scope"),
+            new ScopeSpec("_default")
+        };
+        _mockCollectionManager.Setup(m => m.GetAllScopesAsync(It.IsAny<GetAllScopesOptions>()))
+            .ReturnsAsync(existingScopes);
+
+        var creator = CreateCreator();
+
+        // Act
+        await creator.EnsureCreatedAsync();
+
+        // Assert - should not attempt to create scope since it exists
+        _mockCollectionManager.Verify(
+            m => m.CreateScopeAsync(It.IsAny<string>(), It.IsAny<CreateScopeOptions>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task EnsureCreatedAsync_WhenScopeDoesNotExist_CreatesScope()
+    {
+        // Arrange
+        _mockOptions.Setup(o => o.Bucket).Returns("my-bucket");
+        _mockOptions.Setup(o => o.Scope).Returns("new-scope");
+
+        _mockBucketManager.Setup(m => m.GetBucketAsync("my-bucket", It.IsAny<GetBucketOptions>()))
+            .ReturnsAsync(new BucketSettings { Name = "my-bucket" });
+
+        _mockCluster.Setup(c => c.BucketAsync("my-bucket"))
+            .ReturnsAsync(_mockBucket.Object);
+
+        // Scope does not exist
+        var existingScopes = new List<ScopeSpec>
+        {
+            new ScopeSpec("_default")
+        };
+        _mockCollectionManager.Setup(m => m.GetAllScopesAsync(It.IsAny<GetAllScopesOptions>()))
+            .ReturnsAsync(existingScopes);
+
+        var creator = CreateCreator();
+
+        // Act
+        await creator.EnsureCreatedAsync();
+
+        // Assert
+        _mockCollectionManager.Verify(
+            m => m.CreateScopeAsync("new-scope", It.IsAny<CreateScopeOptions>()),
+            Times.Once);
+    }
+
+    #endregion
+
+    #region EnsureCreatedAsync Tests - Collection Creation
+
+    [Fact]
+    public async Task EnsureCreatedAsync_CreatesCollectionsInCorrectScope()
+    {
+        // Arrange
+        _mockOptions.Setup(o => o.Bucket).Returns("my-bucket");
+        _mockOptions.Setup(o => o.Scope).Returns("my-scope");
+
+        _mockBucketManager.Setup(m => m.GetBucketAsync("my-bucket", It.IsAny<GetBucketOptions>()))
+            .ReturnsAsync(new BucketSettings { Name = "my-bucket" });
+
+        _mockCluster.Setup(c => c.BucketAsync("my-bucket"))
+            .ReturnsAsync(_mockBucket.Object);
+
+        var existingScopes = new List<ScopeSpec> { new ScopeSpec("my-scope") };
+        _mockCollectionManager.Setup(m => m.GetAllScopesAsync(It.IsAny<GetAllScopesOptions>()))
+            .ReturnsAsync(existingScopes);
+
+        // Setup entity type using annotation (GetTableName is an extension method that reads this)
+        var mockEntityType = new Mock<IEntityType>();
+        var mockTableNameAnnotation = new Mock<IAnnotation>();
+        mockTableNameAnnotation.Setup(a => a.Value).Returns("TestCollection");
+        mockEntityType.Setup(e => e.FindAnnotation("Relational:TableName")).Returns(mockTableNameAnnotation.Object);
+        mockEntityType.Setup(e => e.ClrType).Returns(typeof(TestEntity));
+        mockEntityType.Setup(e => e.GetProperties()).Returns(Array.Empty<IProperty>());
+        _mockModel.Setup(m => m.GetEntityTypes()).Returns(new[] { mockEntityType.Object });
+
+        var creator = CreateCreator();
+
+        // Act
+        await creator.EnsureCreatedAsync();
+
+        // Assert - collection should be created in the configured scope
+        _mockCollectionManager.Verify(
+            m => m.CreateCollectionAsync("my-scope", "TestCollection", It.IsAny<CreateCollectionSettings>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task EnsureCreatedAsync_WithAutoCreateScopes_CreatesNonDefaultScopes()
+    {
+        // Arrange
+        _mockOptions.Setup(o => o.Bucket).Returns("my-bucket");
+        _mockOptions.Setup(o => o.Scope).Returns("default-scope");
+        _mockOptions.Setup(o => o.AutoCreateScopes).Returns(true);
+
+        _mockBucketManager.Setup(m => m.GetBucketAsync("my-bucket", It.IsAny<GetBucketOptions>()))
+            .ReturnsAsync(new BucketSettings { Name = "my-bucket" });
+
+        _mockCluster.Setup(c => c.BucketAsync("my-bucket"))
+            .ReturnsAsync(_mockBucket.Object);
+
+        var existingScopes = new List<ScopeSpec> { new ScopeSpec("default-scope") };
+        _mockCollectionManager.Setup(m => m.GetAllScopesAsync(It.IsAny<GetAllScopesOptions>()))
+            .ReturnsAsync(existingScopes);
+
+        // Entity mapped to non-default scope via keyspace annotation
+        var mockEntityType = new Mock<IEntityType>();
+        var mockTableNameAnnotation = new Mock<IAnnotation>();
+        mockTableNameAnnotation.Setup(a => a.Value).Returns("my-bucket.other-scope.OtherCollection");
+        mockEntityType.Setup(e => e.FindAnnotation("Relational:TableName")).Returns(mockTableNameAnnotation.Object);
+        mockEntityType.Setup(e => e.ClrType).Returns(typeof(TestEntity));
+        mockEntityType.Setup(e => e.GetProperties()).Returns(Array.Empty<IProperty>());
+        _mockModel.Setup(m => m.GetEntityTypes()).Returns(new[] { mockEntityType.Object });
+
+        var creator = CreateCreator();
+
+        // Act
+        await creator.EnsureCreatedAsync();
+
+        // Assert - should create the non-default scope
+        _mockCollectionManager.Verify(
+            m => m.CreateScopeAsync("other-scope", It.IsAny<CreateScopeOptions>()),
+            Times.Once);
+        _mockCollectionManager.Verify(
+            m => m.CreateCollectionAsync("other-scope", "OtherCollection", It.IsAny<CreateCollectionSettings>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task EnsureCreatedAsync_WithoutAutoCreateScopes_SkipsNonDefaultScopeCollections()
+    {
+        // Arrange
+        _mockOptions.Setup(o => o.Bucket).Returns("my-bucket");
+        _mockOptions.Setup(o => o.Scope).Returns("default-scope");
+        _mockOptions.Setup(o => o.AutoCreateScopes).Returns(false);
+
+        _mockBucketManager.Setup(m => m.GetBucketAsync("my-bucket", It.IsAny<GetBucketOptions>()))
+            .ReturnsAsync(new BucketSettings { Name = "my-bucket" });
+
+        _mockCluster.Setup(c => c.BucketAsync("my-bucket"))
+            .ReturnsAsync(_mockBucket.Object);
+
+        var existingScopes = new List<ScopeSpec> { new ScopeSpec("default-scope") };
+        _mockCollectionManager.Setup(m => m.GetAllScopesAsync(It.IsAny<GetAllScopesOptions>()))
+            .ReturnsAsync(existingScopes);
+
+        // Entity mapped to non-default scope
+        var mockEntityType = new Mock<IEntityType>();
+        var mockTableNameAnnotation = new Mock<IAnnotation>();
+        mockTableNameAnnotation.Setup(a => a.Value).Returns("my-bucket.other-scope.OtherCollection");
+        mockEntityType.Setup(e => e.FindAnnotation("Relational:TableName")).Returns(mockTableNameAnnotation.Object);
+        mockEntityType.Setup(e => e.ClrType).Returns(typeof(TestEntity));
+        mockEntityType.Setup(e => e.GetProperties()).Returns(Array.Empty<IProperty>());
+        _mockModel.Setup(m => m.GetEntityTypes()).Returns(new[] { mockEntityType.Object });
+
+        var creator = CreateCreator();
+
+        // Act
+        await creator.EnsureCreatedAsync();
+
+        // Assert - should NOT create the non-default scope or collection
+        _mockCollectionManager.Verify(
+            m => m.CreateScopeAsync("other-scope", It.IsAny<CreateScopeOptions>()),
+            Times.Never);
+        _mockCollectionManager.Verify(
+            m => m.CreateCollectionAsync("other-scope", It.IsAny<string>(), It.IsAny<CreateCollectionSettings>()),
+            Times.Never);
+    }
+
+    #endregion
+
+    #region DeleteAsync Tests
+
+    [Fact]
+    public async Task DeleteAsync_DropsBucketWithCorrectName()
+    {
+        // Arrange
+        _mockOptions.Setup(o => o.Bucket).Returns("bucket-to-delete");
+        _mockOptions.Setup(o => o.Scope).Returns("some-scope");
+
+        // Bucket exists
+        _mockBucketManager.Setup(m => m.GetBucketAsync("bucket-to-delete", It.IsAny<GetBucketOptions>()))
+            .ReturnsAsync(new BucketSettings { Name = "bucket-to-delete" });
+
+        _mockCluster.Setup(c => c.BucketAsync("bucket-to-delete"))
+            .ReturnsAsync(_mockBucket.Object);
+
+        var creator = CreateCreator();
+
+        // Act
+        await creator.DeleteAsync();
+
+        // Assert - should drop bucket, not scope
+        _mockBucketManager.Verify(
+            m => m.DropBucketAsync("bucket-to-delete", It.IsAny<DropBucketOptions>()),
+            Times.Once);
+        _mockBucketManager.Verify(
+            m => m.DropBucketAsync("some-scope", It.IsAny<DropBucketOptions>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task DeleteAsync_WhenBucketNotFound_DoesNotThrow()
+    {
+        // Arrange
+        _mockBucketManager.Setup(m => m.GetBucketAsync("test-bucket", It.IsAny<GetBucketOptions>()))
+            .ThrowsAsync(new BucketNotFoundException("test-bucket"));
+        _mockBucketManager.Setup(m => m.DropBucketAsync("test-bucket", It.IsAny<DropBucketOptions>()))
+            .ThrowsAsync(new BucketNotFoundException("test-bucket"));
+
+        var creator = CreateCreator();
+
+        // Act & Assert - should not throw
+        await creator.DeleteAsync();
+    }
+
+    #endregion
+
+    #region InitializeAsync Idempotency Tests
+
+    [Fact]
+    public async Task MultipleOperations_InitializesClusterOnlyOnce()
+    {
+        // Arrange
+        _mockBucketManager.Setup(m => m.GetBucketAsync("test-bucket", It.IsAny<GetBucketOptions>()))
+            .ReturnsAsync(new BucketSettings { Name = "test-bucket" });
+
+        var existingScopes = new List<ScopeSpec> { new ScopeSpec("test-scope") };
+        _mockCollectionManager.Setup(m => m.GetAllScopesAsync(It.IsAny<GetAllScopesOptions>()))
+            .ReturnsAsync(existingScopes);
+
+        var creator = CreateCreator();
+
+        // Act - call multiple methods that require initialization
+        await creator.ExistsAsync();
+        await creator.ExistsAsync();
+        await creator.EnsureCreatedAsync();
+
+        // Assert - cluster provider should only be called once
+        _mockClusterProvider.Verify(
+            cp => cp.GetClusterAsync(),
+            Times.Once,
+            "InitializeAsync should be idempotent - cluster should only be retrieved once");
+    }
+
+    #endregion
+
+    private class TestEntity
+    {
+        public long Id { get; set; }
+        public string? Name { get; set; }
+    }
+}

--- a/tests/Couchbase.EntityFrameworkCore.UnitTests/Couchbase/EntityFrameworkCore/Storage/Internal/CouchbaseSqlGenerationHelperTests.cs
+++ b/tests/Couchbase.EntityFrameworkCore.UnitTests/Couchbase/EntityFrameworkCore/Storage/Internal/CouchbaseSqlGenerationHelperTests.cs
@@ -1,0 +1,183 @@
+using System.Text;
+using Couchbase.EntityFrameworkCore.Storage.Internal;
+using Microsoft.EntityFrameworkCore.Storage;
+using Moq;
+using Xunit;
+
+namespace Couchbase.EntityFrameworkCore.UnitTests.Couchbase.EntityFrameworkCore.Storage.Internal;
+
+public class CouchbaseSqlGenerationHelperTests
+{
+    private readonly CouchbaseSqlGenerationHelper _helper;
+
+    public CouchbaseSqlGenerationHelperTests()
+    {
+        var dependencies = new RelationalSqlGenerationHelperDependencies();
+        _helper = new CouchbaseSqlGenerationHelper(dependencies);
+    }
+
+    [Fact]
+    public void DelimitIdentifier_WrapsInBackticks()
+    {
+        // Act
+        var result = _helper.DelimitIdentifier("myIdentifier");
+
+        // Assert
+        Assert.Equal("`myIdentifier`", result);
+    }
+
+    [Fact]
+    public void DelimitIdentifier_EscapesBackticks()
+    {
+        // Act
+        var result = _helper.DelimitIdentifier("my`identifier");
+
+        // Assert
+        Assert.Equal("`my``identifier`", result);
+    }
+
+    [Fact]
+    public void DelimitIdentifier_EscapesMultipleBackticks()
+    {
+        // Act
+        var result = _helper.DelimitIdentifier("a`b`c");
+
+        // Assert
+        Assert.Equal("`a``b``c`", result);
+    }
+
+    [Fact]
+    public void DelimitIdentifier_EscapesConsecutiveBackticks()
+    {
+        // Act
+        var result = _helper.DelimitIdentifier("test``name");
+
+        // Assert
+        Assert.Equal("`test````name`", result);
+    }
+
+    [Fact]
+    public void DelimitIdentifier_EscapesBacktickAtStart()
+    {
+        // Act
+        var result = _helper.DelimitIdentifier("`start");
+
+        // Assert
+        Assert.Equal("```start`", result);
+    }
+
+    [Fact]
+    public void DelimitIdentifier_EscapesBacktickAtEnd()
+    {
+        // Act
+        var result = _helper.DelimitIdentifier("end`");
+
+        // Assert
+        Assert.Equal("`end```", result);
+    }
+
+    [Fact]
+    public void DelimitIdentifier_StringBuilder_WrapsInBackticks()
+    {
+        // Arrange
+        var builder = new StringBuilder();
+
+        // Act
+        _helper.DelimitIdentifier(builder, "myIdentifier");
+
+        // Assert
+        Assert.Equal("`myIdentifier`", builder.ToString());
+    }
+
+    [Fact]
+    public void DelimitIdentifier_StringBuilder_EscapesBackticks()
+    {
+        // Arrange
+        var builder = new StringBuilder();
+
+        // Act
+        _helper.DelimitIdentifier(builder, "my`identifier");
+
+        // Assert
+        Assert.Equal("`my``identifier`", builder.ToString());
+    }
+
+    [Fact]
+    public void EscapeIdentifier_DoublesBackticks()
+    {
+        // Act
+        var result = _helper.EscapeIdentifier("my`identifier");
+
+        // Assert
+        Assert.Equal("my``identifier", result);
+    }
+
+    [Fact]
+    public void EscapeIdentifier_NoBackticks_ReturnsUnchanged()
+    {
+        // Act
+        var result = _helper.EscapeIdentifier("myIdentifier");
+
+        // Assert
+        Assert.Equal("myIdentifier", result);
+    }
+
+    [Fact]
+    public void EscapeIdentifier_StringBuilder_DoublesBackticks()
+    {
+        // Arrange
+        var builder = new StringBuilder();
+
+        // Act
+        _helper.EscapeIdentifier(builder, "my`identifier");
+
+        // Assert
+        Assert.Equal("my``identifier", builder.ToString());
+    }
+
+    [Fact]
+    public void EscapeIdentifier_StringBuilder_NoBackticks_AppendsUnchanged()
+    {
+        // Arrange
+        var builder = new StringBuilder();
+
+        // Act
+        _helper.EscapeIdentifier(builder, "myIdentifier");
+
+        // Assert
+        Assert.Equal("myIdentifier", builder.ToString());
+    }
+
+    [Fact]
+    public void GenerateParameterName_AddsPrefix()
+    {
+        // Act
+        var result = _helper.GenerateParameterName("param");
+
+        // Assert
+        Assert.Equal("$param", result);
+    }
+
+    [Fact]
+    public void GenerateParameterName_AlreadyPrefixed_ReturnsUnchanged()
+    {
+        // Act
+        var result = _helper.GenerateParameterName("$param");
+
+        // Assert
+        Assert.Equal("$param", result);
+    }
+
+    [Fact]
+    public void GenerateParameterName_StringBuilder_AddsPrefix()
+    {
+        // Arrange
+        var builder = new StringBuilder();
+
+        // Act
+        _helper.GenerateParameterName(builder, "param");
+
+        // Assert
+        Assert.Equal("$param", builder.ToString());
+    }
+}

--- a/tests/Couchbase.EntityFrameworkCore.UnitTests/Couchbase/EntityFrameworkCore/ValueGeneration/CouchbaseSequenceOptionsTests.cs
+++ b/tests/Couchbase.EntityFrameworkCore.UnitTests/Couchbase/EntityFrameworkCore/ValueGeneration/CouchbaseSequenceOptionsTests.cs
@@ -1,0 +1,211 @@
+using Couchbase.EntityFrameworkCore.ValueGeneration;
+using Xunit;
+
+namespace Couchbase.EntityFrameworkCore.UnitTests.Couchbase.EntityFrameworkCore.ValueGeneration;
+
+public class CouchbaseSequenceOptionsTests
+{
+    [Fact]
+    public void Default_HasExpectedValues()
+    {
+        // Arrange & Act
+        var options = CouchbaseSequenceOptions.Default;
+
+        // Assert
+        Assert.Equal(1, options.StartWith);
+        Assert.Equal(1, options.IncrementBy);
+        Assert.Null(options.MaxValue);
+        Assert.Null(options.MinValue);
+        Assert.False(options.Cycle);
+        Assert.Null(options.CacheSize);
+    }
+
+    [Fact]
+    public void Constructor_WithInitializers_SetsProperties()
+    {
+        // Arrange & Act
+        var options = new CouchbaseSequenceOptions
+        {
+            StartWith = 100,
+            IncrementBy = 5,
+            MaxValue = 1000,
+            MinValue = 50,
+            Cycle = true,
+            CacheSize = 20
+        };
+
+        // Assert
+        Assert.Equal(100, options.StartWith);
+        Assert.Equal(5, options.IncrementBy);
+        Assert.Equal(1000, options.MaxValue);
+        Assert.Equal(50, options.MinValue);
+        Assert.True(options.Cycle);
+        Assert.Equal(20, options.CacheSize);
+    }
+
+    [Fact]
+    public void ToSqlOptionsClause_WithDefaults_ReturnsBasicClause()
+    {
+        // Arrange
+        var options = CouchbaseSequenceOptions.Default;
+
+        // Act
+        var clause = options.ToSqlOptionsClause();
+
+        // Assert
+        Assert.Equal("START WITH 1 INCREMENT BY 1 NO CYCLE", clause);
+    }
+
+    [Fact]
+    public void ToSqlOptionsClause_WithCustomStartAndIncrement_ReturnsCorrectClause()
+    {
+        // Arrange
+        var options = new CouchbaseSequenceOptions
+        {
+            StartWith = 1000,
+            IncrementBy = 10
+        };
+
+        // Act
+        var clause = options.ToSqlOptionsClause();
+
+        // Assert
+        Assert.Equal("START WITH 1000 INCREMENT BY 10 NO CYCLE", clause);
+    }
+
+    [Fact]
+    public void ToSqlOptionsClause_WithMaxValue_IncludesMaxValue()
+    {
+        // Arrange
+        var options = new CouchbaseSequenceOptions
+        {
+            StartWith = 1,
+            IncrementBy = 1,
+            MaxValue = 999999
+        };
+
+        // Act
+        var clause = options.ToSqlOptionsClause();
+
+        // Assert
+        Assert.Contains("MAXVALUE 999999", clause);
+    }
+
+    [Fact]
+    public void ToSqlOptionsClause_WithMinValue_IncludesMinValue()
+    {
+        // Arrange
+        var options = new CouchbaseSequenceOptions
+        {
+            StartWith = 100,
+            IncrementBy = -1,
+            MinValue = 1
+        };
+
+        // Act
+        var clause = options.ToSqlOptionsClause();
+
+        // Assert
+        Assert.Contains("MINVALUE 1", clause);
+    }
+
+    [Fact]
+    public void ToSqlOptionsClause_WithCycle_IncludesCycle()
+    {
+        // Arrange
+        var options = new CouchbaseSequenceOptions
+        {
+            Cycle = true
+        };
+
+        // Act
+        var clause = options.ToSqlOptionsClause();
+
+        // Assert
+        Assert.Contains("CYCLE", clause);
+        Assert.DoesNotContain("NO CYCLE", clause);
+    }
+
+    [Fact]
+    public void ToSqlOptionsClause_WithCacheSize_IncludesCache()
+    {
+        // Arrange
+        var options = new CouchbaseSequenceOptions
+        {
+            CacheSize = 100
+        };
+
+        // Act
+        var clause = options.ToSqlOptionsClause();
+
+        // Assert
+        Assert.Contains("CACHE 100", clause);
+    }
+
+    [Fact]
+    public void ToSqlOptionsClause_WithAllOptions_ReturnsCompleteClause()
+    {
+        // Arrange
+        var options = new CouchbaseSequenceOptions
+        {
+            StartWith = 500,
+            IncrementBy = 5,
+            MaxValue = 10000,
+            MinValue = 100,
+            Cycle = true,
+            CacheSize = 50
+        };
+
+        // Act
+        var clause = options.ToSqlOptionsClause();
+
+        // Assert
+        Assert.Contains("START WITH 500", clause);
+        Assert.Contains("INCREMENT BY 5", clause);
+        Assert.Contains("MAXVALUE 10000", clause);
+        Assert.Contains("MINVALUE 100", clause);
+        Assert.Contains("CYCLE", clause);
+        Assert.Contains("CACHE 50", clause);
+        Assert.DoesNotContain("NO CYCLE", clause);
+    }
+
+    [Fact]
+    public void ToSqlOptionsClause_WithNegativeIncrement_SupportsDescendingSequence()
+    {
+        // Arrange
+        var options = new CouchbaseSequenceOptions
+        {
+            StartWith = 1000,
+            IncrementBy = -1,
+            MinValue = 1
+        };
+
+        // Act
+        var clause = options.ToSqlOptionsClause();
+
+        // Assert
+        Assert.Contains("INCREMENT BY -1", clause);
+    }
+
+    [Fact]
+    public void RecordEquality_SameValues_AreEqual()
+    {
+        // Arrange
+        var options1 = new CouchbaseSequenceOptions { StartWith = 100, IncrementBy = 5 };
+        var options2 = new CouchbaseSequenceOptions { StartWith = 100, IncrementBy = 5 };
+
+        // Act & Assert
+        Assert.Equal(options1, options2);
+    }
+
+    [Fact]
+    public void RecordEquality_DifferentValues_AreNotEqual()
+    {
+        // Arrange
+        var options1 = new CouchbaseSequenceOptions { StartWith = 100 };
+        var options2 = new CouchbaseSequenceOptions { StartWith = 200 };
+
+        // Act & Assert
+        Assert.NotEqual(options1, options2);
+    }
+}

--- a/tests/Couchbase.EntityFrameworkCore.UnitTests/Couchbase/EntityFrameworkCore/ValueGeneration/CouchbaseSequenceValueGeneratorTests.cs
+++ b/tests/Couchbase.EntityFrameworkCore.UnitTests/Couchbase/EntityFrameworkCore/ValueGeneration/CouchbaseSequenceValueGeneratorTests.cs
@@ -1,10 +1,15 @@
+using Couchbase.EntityFrameworkCore.Storage.Internal;
 using Couchbase.EntityFrameworkCore.ValueGeneration;
+using Microsoft.EntityFrameworkCore.Storage;
 using Xunit;
 
 namespace Couchbase.EntityFrameworkCore.UnitTests.Couchbase.EntityFrameworkCore.ValueGeneration;
 
 public class CouchbaseSequenceValueGeneratorTests
 {
+    private readonly ISqlGenerationHelper _sqlGenerationHelper = new CouchbaseSqlGenerationHelper(
+        new RelationalSqlGenerationHelperDependencies());
+
     [Fact]
     public void Constructor_WithValidArguments_Succeeds()
     {
@@ -79,7 +84,7 @@ public class CouchbaseSequenceValueGeneratorTests
     }
 
     [Fact]
-    public void SequenceQuery_ReturnsCorrectSqlPlusPlus()
+    public void BuildSequenceQuery_ReturnsCorrectSqlPlusPlus()
     {
         // Arrange
         var generator = new CouchbaseSequenceValueGenerator<long>(
@@ -88,9 +93,9 @@ public class CouchbaseSequenceValueGeneratorTests
             "myScope");
 
         // Act
-        var query = generator.SequenceQuery;
+        var query = generator.BuildSequenceQuery(_sqlGenerationHelper);
 
-        // Assert - Each part should be separately escaped
+        // Assert - Each part should be separately escaped with backticks
         Assert.Equal("SELECT NEXT VALUE FOR `myBucket`.`myScope`.`order_seq`", query);
     }
 
@@ -108,7 +113,7 @@ public class CouchbaseSequenceValueGeneratorTests
     }
 
     [Fact]
-    public void SequenceQuery_WithSpecialCharactersInNames_EscapesCorrectly()
+    public void BuildSequenceQuery_WithSpecialCharactersInNames_EscapesCorrectly()
     {
         // Arrange - Names that would need escaping
         var generator = new CouchbaseSequenceValueGenerator<long>(
@@ -117,10 +122,28 @@ public class CouchbaseSequenceValueGeneratorTests
             "my-scope");
 
         // Act
-        var query = generator.SequenceQuery;
+        var query = generator.BuildSequenceQuery(_sqlGenerationHelper);
 
         // Assert - Backticks protect special characters
         Assert.Equal("SELECT NEXT VALUE FOR `my-bucket`.`my-scope`.`order-seq`", query);
+    }
+
+    [Fact]
+    public void BuildSequenceQuery_UsesSqlGenerationHelper()
+    {
+        // Arrange
+        var generator = new CouchbaseSequenceValueGenerator<long>(
+            "test_seq",
+            "bucket",
+            "scope");
+
+        // Act
+        var query = generator.BuildSequenceQuery(_sqlGenerationHelper);
+
+        // Assert - Verify the query uses the helper's delimiter format (backticks for Couchbase)
+        Assert.StartsWith("SELECT NEXT VALUE FOR `", query);
+        Assert.Contains("`.`", query); // Helper delimits each part
+        Assert.EndsWith("`", query);
     }
 
     #region Type Support Tests


### PR DESCRIPTION
   ### Primary Key Value Generation (Phases 1-3)

**Purpose:** Enable automatic generation of primary key values (like long Id) using Couchbase's native SEQUENCE feature, similar to how SQL databases use auto-increment
    or sequences.

   **Key Capabilities:**
   •  Automatically fetch next sequence value when inserting new entities
   •  Configure via attribute: [CouchbaseSequence("order_seq")]
   •  Configure via fluent API: .UseSequence("order_seq")
   •  Auto-create sequences on EnsureCreatedAsync()
   •  Support for sequence options (StartWith, IncrementBy, Cycle)

   **Example Usage:**

   ```csharp
     public class Order
     {
         [CouchbaseSequence("order_seq", StartWith = 1000)]
         public long Id { get; set; }

         public string CustomerName { get; set; }
     }

     // On SaveChanges, Id is automatically populated from the sequence
     context.Orders.Add(new Order { CustomerName = "Acme" });
     await context.SaveChangesAsync(); // Id = 1000, 1001, 1002...
```
   **New Files:**
   •  CouchbaseSequenceValueGenerator<T> - Generic value generator using Couchbase sequences
   •  CouchbaseValueGeneratorSelector - Selects appropriate generators based on property annotations
   •  CouchbaseSequenceAttribute - Data annotation for sequence configuration
   •  CouchbaseSequenceOptions - Sequence options (StartWith, IncrementBy, Cycle, etc.)
   •  CouchbaseSequenceConvention - Processes attributes during model building
   •  CouchbasePropertyBuilderExtensions - Fluent API (UseSequence() methods)

   **CouchbaseDatabaseCreator Enhancements**
   •  CreateSequencesAsync() / DropSequencesAsync() for sequence lifecycle
   •  AutoCreateScopes option for multi-scope models
   •  Fixed Bucket/Scope confusion bug in CreateScopeAsync()
   •  Idempotent InitializeAsync() to avoid double-initialization
   •  GetBucketAsync() now has retry limits (10 retries, 500ms delay)
   •  Proper logging instead of Console.WriteLine
   •  Null-safe CollectionsExistsAsync()

   **CouchbaseSqlGenerationHelper**
   •  Added EscapeIdentifier() to properly escape backticks in identifiers (security fix)

   **CouchbaseDbContextOptionsBuilder**
   •  Added AutoCreateScopes property for opt-in scope auto-creation

   **Test Coverage (450 total unit tests)**
   •  CouchbaseDatabaseCreatorTests (15 tests) - Would have caught Bucket/Scope bug
   •  CouchbaseSqlGenerationHelperTests (15 tests) - Backtick escaping
   •  CouchbaseDbContextOptionsBuilderTests (8 tests) - Options builder
   •  CouchbaseSequenceAttributeTests (17 tests) - Attribute properties
   •  BoolAnnotationReadingTests (5 tests) - Boxed bool annotation handling
   •  CouchbasePropertyBuilderExtensionsTests - UseSequence fluent API

   **Bug Fixes**
   •  Scope check used Bucket name instead of Scope name
   •  Backticks in identifiers weren't escaped (SQL injection risk)
   •  Boxed bool annotations read incorrectly with as bool?
   •  Infinite retry loop in GetBucketAsync()
   •  Double initialization in DeleteAsync()
