### PR TITLE
Fix OwnsMany save path and test isolation for integration tests

### DIFF
--- a/specs/datareader-refactor.md
+++ b/specs/datareader-refactor.md
@@ -1,0 +1,164 @@
+# CouchbaseDbDataReader Refactor
+
+## Background
+
+`CouchbaseDbDataReader<T>` is the ADO.NET `DbDataReader` bridge between the Couchbase SDK's
+`IQueryResult<JsonElement>` and EF Core's compiled shapers. It was built incrementally alongside
+the query pipeline and has accumulated complexity for code paths that never execute in the
+provider. This document describes four sequential phases to simplify and optimize it.
+
+The EF Core shaper is the sole consumer of this reader. It calls typed getters by projection
+ordinal (e.g. `GetInt32(3)`, `GetString(7)`) for every column of every result row. The
+projection aliases (`_columnNames`) are always supplied by `CouchbaseQueryEnumerable` from
+`SelectExpression.Projection`, so no runtime schema discovery is ever needed.
+
+---
+
+## Phase 1 — Remove Dead Code Paths
+
+**Goal:** Delete code that never executes. No behavioral change.
+
+### Changes
+
+- **Remove the non-`JsonElement` reflection branch** in `InitializeFieldInfo` and `GetFieldValue`.
+  The `else if (_currentRow != null)` path uses `Type.GetProperties()` and `PropertyInfo.GetValue`
+  to handle rows that are not `JsonElement`. Since `cluster.QueryAsync<JsonElement>` always
+  produces `JsonElement` rows, this branch is unreachable.
+
+- **Fix `ConvertJsonElement` for `Object` and `Array` kinds.** The current implementation calls
+  `ExtractFirstValueFromObject` / `ExtractFirstValueFromArray`, which take the first property or
+  element of a complex value. This heuristic is wrong for legitimate complex fields (owned types,
+  byte arrays stored as arrays) and only existed to paper over early row-structure confusion. Replace
+  with returning the `JsonElement` as-is for those kinds, consistent with how `GetFieldValue<T>`
+  already handles them.
+
+- Remove `ExtractFirstValueFromObject` and `ExtractFirstValueFromArray` once the above is done.
+
+### Expected outcome
+
+Approximately 50 lines removed. The remaining code reflects only what actually runs in the
+provider. Existing tests should pass without modification.
+
+---
+
+## Phase 2 — Eliminate the `_fieldOrdinals` Indirection
+
+**Goal:** Shorten the `GetValue` hot path from five steps to two. Logically equivalent to current
+behavior.
+
+### The current chain (when `_columnNames` is active)
+
+```
+GetValue(ordinal)
+  → _columnNames[ordinal]          // array lookup → alias
+  → _fieldOrdinals[alias]          // dict lookup (OrdinalIgnoreCase) → json ordinal
+  → _fieldNames[jsonOrdinal]       // array lookup → same name we started with
+  → GetFieldValue(name)
+      → je.TryGetProperty(name)    // linear scan of JsonElement properties
+```
+
+Steps 2 and 3 round-trip through an intermediate ordinal and arrive at the same string. They add
+two allocations and two lookups without changing the result.
+
+### Changes
+
+- When `_columnNames` is set, replace steps 2–4 with a direct case-insensitive property lookup
+  on the current `JsonElement` row using the same `TryGetPropertyCI` logic already present in
+  `CouchbaseQueryEnumerable`. A missing field returns `DBNull.Value`.
+
+- Retain the no-`_columnNames` fallback path unchanged so this phase is self-contained and does
+  not require simultaneous changes to `CouchbaseQueryEnumerable`.
+
+- Simplify `GetOrdinal` for the `_projectionOrdinals` path. The constrained fallback that
+  reconciles null-slot positions against `_fieldOrdinals` becomes unnecessary once the two ordinal
+  spaces are no longer conflated.
+
+### Expected outcome
+
+`GetValue` hot path: array lookup + case-insensitive `TryGetProperty`. No dictionary lookups.
+Approximately 20–30 lines removed from `GetValue` and `GetOrdinal`.
+
+---
+
+## Phase 3 — Remove Schema-Discovery Infrastructure
+
+**Goal:** Delete the first-row peek, buffering, and field-metadata machinery. `_columnNames` is
+always provided so this infrastructure is never needed.
+
+### Changes
+
+- Make `columnNames` a required constructor parameter. Add a guard that throws
+  `ArgumentNullException` if null. Remove the optional overload that omits it.
+
+- Delete the following fields and their associated logic:
+  - `_bufferedRow`, `_hasBufferedRow` — first-row buffer
+  - `_schemaInitialized` — initialization flag
+  - `_fieldNames` — list of JSON property names from first row
+  - `_fieldOrdinals` — name → position map built from first row
+
+- Delete `EnsureFieldInfo` and `InitializeFieldInfo` entirely. These contain the only
+  sync-over-async call in the reader (`MoveNextAsync().AsTask().GetAwaiter().GetResult()`).
+
+- Simplify the properties that previously triggered schema discovery:
+  - `HasRows` — cannot be known until `ReadAsync` is called; return `_hasRows ?? false`
+    (populated on first `ReadAsync`) with no peeking.
+  - `FieldCount` — `_columnNames.Length`.
+  - `GetName(ordinal)` — `_columnNames[ordinal]`.
+  - `GetOrdinal(name)` — `_projectionOrdinals[name]` (dictionary built at construction).
+
+- Update `CouchbaseDbDataReaderTests`. Tests that call `HasRows` or `FieldCount` before `ReadAsync`
+  should be adjusted to call `ReadAsync` first, or updated to reflect that `HasRows` returns false
+  until the first read.
+
+### Expected outcome
+
+Approximately 150 lines removed. The sync-over-async call is gone. The reader's construction is
+O(1) — no first-row read, no buffering, no schema inference.
+
+---
+
+## Phase 4 — Pre-Build Per-Row Ordinal → Value Array in `ReadAsync`
+
+**Goal:** Make `GetValue(ordinal)` O(1) — a single array dereference — by amortizing the JSON
+property scan over the whole row on read.
+
+### Current per-row cost
+
+For a row with `m` JSON properties and a shaper that reads `k` columns:
+
+```
+k calls × O(m) TryGetProperty scan = O(k × m) per row
+```
+
+For a typical entity with 10 columns and 10 properties this is 100 string comparisons per row.
+
+### Proposed approach
+
+In `ReadAsync`, after `MoveNextAsync` returns a `JsonElement` row:
+
+1. Allocate (or reuse) a `JsonElement?[]` of length `_columnNames.Length`.
+2. Do a single O(m) scan of the row's properties.
+3. For each property, case-insensitively match its name against `_projectionOrdinals` and write
+   the `JsonElement` value into the array at the matched ordinal. Unmatched properties are skipped.
+4. Projection slots with no matching JSON property remain null (→ `DBNull.Value`).
+
+`GetValue(ordinal)` then becomes:
+
+```csharp
+var element = _currentValues[ordinal];
+return element.HasValue ? ConvertJsonElement(element.Value) : DBNull.Value;
+```
+
+### Implementation notes
+
+- Reuse a single `_currentValues` array across rows by resetting it at the start of each
+  `ReadAsync`. This eliminates per-row heap allocation.
+- The array is sized at construction from `_columnNames.Length` and never resized.
+- `_projectionOrdinals` (built at construction, `OrdinalIgnoreCase`) drives the name → ordinal
+  mapping during the per-row scan.
+
+### Expected outcome
+
+Per-row cost changes from O(k × m) to O(m + k). `GetValue` is a bounds-checked array read with
+no string comparisons. At 100 rows × 10 columns × 10 properties the total comparisons drop from
+10,000 to ~1,000.

--- a/src/Couchbase.EntityFrameworkCore/Query/Internal/CouchbaseQueryEnumerable.cs
+++ b/src/Couchbase.EntityFrameworkCore/Query/Internal/CouchbaseQueryEnumerable.cs
@@ -179,6 +179,7 @@ public class CouchbaseQueryEnumerable<T> : IEnumerable<T>, IAsyncEnumerable<T>, 
                     && rowElement.ValueKind == JsonValueKind.Object)
                 {
                     PopulateCollectionNavigations(result, rowElement, _ownedCollectionNavigations, _couchbaseDbContextOptionsBuilder.FieldNamingPolicy, _couchbaseDbContextOptionsBuilder.SerializerOptions);
+                    SnapshotCollectionRefs(result);
                 }
                 pendingEntityRow = null;
                 yield return result;
@@ -210,6 +211,7 @@ public class CouchbaseQueryEnumerable<T> : IEnumerable<T>, IAsyncEnumerable<T>, 
                         && lastRow.ValueKind == JsonValueKind.Object)
                     {
                         PopulateCollectionNavigations(last, lastRow, _ownedCollectionNavigations, _couchbaseDbContextOptionsBuilder.FieldNamingPolicy, _couchbaseDbContextOptionsBuilder.SerializerOptions);
+                        SnapshotCollectionRefs(last);
                     }
                     pendingEntityRow = null;
                     yield return last;
@@ -219,17 +221,6 @@ public class CouchbaseQueryEnumerable<T> : IEnumerable<T>, IAsyncEnumerable<T>, 
         }
     }
 
-    // KNOWN LIMITATION — change-tracker bypass
-    // Owned collection items created here are materialized via Activator.CreateInstance and
-    // assigned directly to the navigation property via reflection. They are NOT registered with
-    // the EF Core state manager, which means:
-    //   • Modifications to the items after the query (e.g. customer.ContactMethods[0].Value = "x")
-    //     will NOT be detected by SaveChanges, regardless of whether the query used tracking or
-    //     no-tracking — the behavior is silently identical in both cases.
-    //   • This deviates from standard EF Core semantics, where owned collection members
-    //     materialized through the shaper are tracked alongside their owner.
-    // Fixing this requires hooking each owned item into IStateManager via the owner's
-    // InternalEntityEntry, which is deferred as a follow-up task.
     private static readonly JsonSerializerOptions _defaultSerializerOptions = new(JsonSerializerDefaults.Web);
 
     private static void PopulateCollectionNavigations(T entity, JsonElement docElement, IReadOnlyList<INavigation> collections, JsonNamingPolicy? fieldNamingPolicy, JsonSerializerOptions? serializerOptions)
@@ -270,6 +261,18 @@ public class CouchbaseQueryEnumerable<T> : IEnumerable<T>, IAsyncEnumerable<T>, 
                     ((IList)nav.PropertyInfo!.GetValue(entity)!).Add(ownedEntity);
             }
         }
+    }
+
+    // Record the original collection-object reference for every OwnsMany navigation on
+    // the freshly materialised entity. The save path later compares the current reference
+    // to the stored one; a mismatch (e.g. customer.ContactMethods = []) means the owner
+    // document must be rewritten even when EF Core produced no owned-item change entries.
+    private void SnapshotCollectionRefs(T? entity)
+    {
+        if (entity == null) return;
+        var refs = OwnedCollectionSnapshot.OriginalRefs.GetOrCreateValue(entity);
+        foreach (var nav in _ownedCollectionNavigations)
+            refs[nav.Name] = nav.PropertyInfo?.GetValue(entity);
     }
 
     // JsonElement.TryGetProperty is case-sensitive. The SDK's SystemTextJsonSerializer uses

--- a/src/Couchbase.EntityFrameworkCore/Query/Internal/CouchbaseQueryEnumerable.cs
+++ b/src/Couchbase.EntityFrameworkCore/Query/Internal/CouchbaseQueryEnumerable.cs
@@ -239,7 +239,13 @@ public class CouchbaseQueryEnumerable<T> : IEnumerable<T>, IAsyncEnumerable<T>, 
                 .Where(p => !p.IsShadowProperty()).ToList();
 
             if (accessor != null)
-                accessor.GetOrCreate(entity!, forMaterialization: true);
+            {
+                // Clear any items the EF Core shaper may have pre-populated from the injected
+                // OwnsMany column (observed with AsNoTracking queries). We are the authoritative
+                // source for owned-collection data; clearing before adding prevents duplicates.
+                var coll = accessor.GetOrCreate(entity!, forMaterialization: true);
+                (coll as IList)?.Clear();
+            }
             else
             {
                 var list = (IList)Activator.CreateInstance(typeof(List<>).MakeGenericType(clrType))!;

--- a/src/Couchbase.EntityFrameworkCore/Query/Internal/CouchbaseShapedQueryCompilingExpressionVisitor.cs
+++ b/src/Couchbase.EntityFrameworkCore/Query/Internal/CouchbaseShapedQueryCompilingExpressionVisitor.cs
@@ -281,7 +281,17 @@ public class CouchbaseShapedQueryCompilingExpressionVisitor : RelationalShapedQu
     /// </summary>
     private void AddOwnedCollectionColumnsToProjection(SelectExpression selectExpression, Type shaperReturnType)
     {
-        // Locate the owner entity's TableExpression.
+        // Resolve the entity type first so we can match the TableExpression by the entity's
+        // configured table name rather than the fragile 3-part "bucket.scope.collection"
+        // heuristic that fails silently in test contexts where SetupKeyspaces is not called.
+        var entityType = QueryCompilationContext.Model.GetEntityTypes()
+            .FirstOrDefault(e => e.ClrType == shaperReturnType);
+        if (entityType == null) return;
+
+        var expectedTableName = entityType.GetTableName();
+        if (expectedTableName == null) return;
+
+        // Locate the owner entity's TableExpression by matching its configured name.
         // Simple form:   Tables contains the entity TableExpression directly.
         // Subquery form: Tables[0] is an inner SelectExpression (EF Core wraps FirstAsync/Take
         //                in a subquery before the LEFT JOIN expansion); the entity TableExpression
@@ -291,7 +301,7 @@ public class CouchbaseShapedQueryCompilingExpressionVisitor : RelationalShapedQu
 
         var directTable = selectExpression.Tables
             .OfType<TableExpression>()
-            .FirstOrDefault(t => t.Name.Split('.').Length == 3);
+            .FirstOrDefault(t => t.Name == expectedTableName);
 
         if (directTable != null)
         {
@@ -303,15 +313,10 @@ public class CouchbaseShapedQueryCompilingExpressionVisitor : RelationalShapedQu
             if (innerSelect != null)
                 ownerTable = innerSelect.Tables
                     .OfType<TableExpression>()
-                    .FirstOrDefault(t => t.Name.Split('.').Length == 3);
+                    .FirstOrDefault(t => t.Name == expectedTableName);
         }
 
         if (ownerTable == null) return;
-
-        // Only inject for root-entity queries — skip scalar/anonymous projections.
-        var entityType = QueryCompilationContext.Model.GetEntityTypes()
-            .FirstOrDefault(e => e.ClrType == shaperReturnType && e.GetTableName() == ownerTable.Name);
-        if (entityType == null) return;
 
         var ownedCollNavs = entityType.GetNavigations()
             .Where(n => n.IsCollection && n.TargetEntityType.IsOwned())

--- a/src/Couchbase.EntityFrameworkCore/Query/Internal/OwnedCollectionSnapshot.cs
+++ b/src/Couchbase.EntityFrameworkCore/Query/Internal/OwnedCollectionSnapshot.cs
@@ -1,0 +1,35 @@
+using System.Runtime.CompilerServices;
+
+namespace Couchbase.EntityFrameworkCore.Query.Internal;
+
+// Stores the original collection-object reference for each OwnsMany navigation on a just-
+// materialised entity. The database wrapper's save path compares the current reference to the
+// stored one: if they differ the owner document must be rewritten even when EF Core's own
+// change tracker produced no owned-item entries (e.g. customer.ContactMethods = []).
+//
+// ConditionalWeakTable uses weak keys so entities that fall out of scope are GC'd without any
+// manual cleanup.
+internal static class OwnedCollectionSnapshot
+{
+    internal static readonly ConditionalWeakTable<object, Dictionary<string, object?>> OriginalRefs = new();
+}
+
+
+/* ************************************************************
+ *
+ *    @author Couchbase <info@couchbase.com>
+ *    @copyright 2025 Couchbase, Inc.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ *
+ * ************************************************************/

--- a/src/Couchbase.EntityFrameworkCore/Storage/Internal/CouchbaseDatabaseWrapper.cs
+++ b/src/Couchbase.EntityFrameworkCore/Storage/Internal/CouchbaseDatabaseWrapper.cs
@@ -4,6 +4,8 @@ using Couchbase.EntityFrameworkCore.Extensions;
 using Couchbase.EntityFrameworkCore.Infrastructure;
 using Couchbase.EntityFrameworkCore.Utils;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.ChangeTracking.Internal;
+using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Storage;
 using Microsoft.EntityFrameworkCore.Update;
@@ -43,6 +45,12 @@ public class CouchbaseDatabaseWrapper : Database
         var transaction = GetCurrentTransaction();
         var updateCount = 0;
 
+        // Track root-entity keys written in the main loop so the second pass can skip
+        // owners that were already written (e.g. user manually set entry.State = Modified).
+        var writtenRoots = new HashSet<string>();
+        // Owned entries whose owner must be written in the second pass.
+        var deferredOwnedEntries = new List<IUpdateEntry>();
+
         foreach (var updateEntry in entries)
         {
             cancellationToken.ThrowIfCancellationRequested();
@@ -53,6 +61,10 @@ public class CouchbaseDatabaseWrapper : Database
 
             if (entityType.IsOwned())
             {
+                // Collect owned entries with actual changes; their owners will be written
+                // in the second pass below if not already written by the main loop.
+                if (updateEntry.EntityState is not (EntityState.Unchanged or EntityState.Detached))
+                    deferredOwnedEntries.Add(updateEntry);
                 continue;
             }
 
@@ -66,9 +78,13 @@ public class CouchbaseDatabaseWrapper : Database
             {
                 case EntityState.Detached:
                 case EntityState.Unchanged:
+                    // Not written — intentionally NOT added to writtenRoots so the deferred-owned
+                    // pass can still write the owner if an owned item triggered a change.
                     break;
 
                 case EntityState.Deleted:
+                    // Add to writtenRoots so the deferred pass doesn't upsert a just-deleted doc.
+                    writtenRoots.Add($"{entityType.ClrType.Name}:{primaryKey}");
                     if (transaction != null)
                     {
                         await _couchbaseClient.EnqueueTransactionalRemove(transaction, primaryKey, keyspace).ConfigureAwait(false);
@@ -84,6 +100,7 @@ public class CouchbaseDatabaseWrapper : Database
                     break;
 
                 case EntityState.Modified:
+                    writtenRoots.Add($"{entityType.ClrType.Name}:{primaryKey}");
                     var modifiedDocument = HydrateObjectFromEntity(updateEntry, _fieldNamingPolicy);
                     if (transaction != null)
                     {
@@ -100,6 +117,7 @@ public class CouchbaseDatabaseWrapper : Database
                     break;
 
                 case EntityState.Added:
+                    writtenRoots.Add($"{entityType.ClrType.Name}:{primaryKey}");
                     var newDocument = HydrateObjectFromEntity(updateEntry, _fieldNamingPolicy);
                     if (transaction != null)
                     {
@@ -117,6 +135,61 @@ public class CouchbaseDatabaseWrapper : Database
 
                 default:
                     throw new ArgumentOutOfRangeException();
+            }
+        }
+
+        // Second pass: for each owned entry with a state change, write the owner document
+        // if it was not already written in the main loop above. This removes the need for
+        // callers to manually set ctx.Entry(owner).State = EntityState.Modified after
+        // mutating owned navigations (OwnsOne property changes, OwnsMany collection mutation).
+        foreach (var ownedEntry in deferredOwnedEntries)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            var ownership = ownedEntry.EntityType.FindOwnership();
+            if (ownership == null) continue;
+
+            // FK values on the owned entry are equal to the owner's PK values.
+            var fkValues = ownership.Properties
+                .Select(p => ownedEntry.GetCurrentValue(p))
+                .ToArray();
+
+            var ownerEntityType = ownership.PrincipalEntityType;
+            var context = ownedEntry.ToEntityEntry().Context;
+
+            var ownerEntityEntry = context.ChangeTracker.Entries()
+                .FirstOrDefault(e =>
+                    e.Metadata == ownerEntityType &&
+                    ownership.PrincipalKey.Properties
+                        .Select((p, i) => Equals(e.CurrentValues[p.Name], fkValues[i]))
+                        .All(b => b));
+
+            if (ownerEntityEntry == null) continue;
+
+            var ownerEntity = ownerEntityEntry.Entity;
+            var ownerPrimaryKey = ownerEntityType.GetPrimaryKey(ownerEntity);
+            var rootKey = $"{ownerEntityType.ClrType.Name}:{ownerPrimaryKey}";
+
+            if (writtenRoots.Contains(rootKey)) continue;
+            writtenRoots.Add(rootKey);
+
+            var ownerKeyspace = ownerEntityType.GetCollectionName()
+                ?? throw new InvalidOperationException(
+                    $"Owner entity type '{ownerEntityType.ClrType.Name}' has no mapped table name. " +
+                    "Ensure the entity is mapped to a Couchbase collection via ToCouchbaseCollection().");
+
+            var ownerUpdateEntry = (IUpdateEntry)((IInfrastructure<InternalEntityEntry>)ownerEntityEntry).Instance;
+            var ownerDocument = HydrateObjectFromEntity(ownerUpdateEntry, _fieldNamingPolicy);
+
+            if (transaction != null)
+            {
+                await _couchbaseClient.EnqueueTransactionalUpsert(transaction, ownerPrimaryKey, ownerKeyspace, ownerDocument).ConfigureAwait(false);
+                updateCount++;
+            }
+            else
+            {
+                if (await _couchbaseClient.UpdateDocument(ownerPrimaryKey, ownerKeyspace, ownerDocument).ConfigureAwait(false))
+                    updateCount++;
             }
         }
 

--- a/src/Couchbase.EntityFrameworkCore/Storage/Internal/CouchbaseSaveChangesInterceptor.cs
+++ b/src/Couchbase.EntityFrameworkCore/Storage/Internal/CouchbaseSaveChangesInterceptor.cs
@@ -69,6 +69,9 @@ public class CouchbaseSaveChangesInterceptor : SaveChangesInterceptor
             }
         }
         state.TrackedEntities.Clear();
+
+        // Transaction committed — refresh snapshots for all tracked entities
+        RefreshOwnedCollectionSnapshots(context);
     }
 
     public override async ValueTask<InterceptionResult<int>> SavingChangesAsync(
@@ -173,9 +176,17 @@ public class CouchbaseSaveChangesInterceptor : SaveChangesInterceptor
         int result,
         CancellationToken cancellationToken = default)
     {
-        if (eventData.Context != null && IsTransactionActive(eventData.Context))
+        if (eventData.Context != null)
         {
-            RestoreEntityStates(eventData.Context);
+            if (IsTransactionActive(eventData.Context))
+            {
+                RestoreEntityStates(eventData.Context);
+            }
+            else
+            {
+                // Non-transactional save succeeded — refresh snapshots now
+                RefreshOwnedCollectionSnapshots(eventData.Context);
+            }
         }
 
         return await base.SavedChangesAsync(eventData, result, cancellationToken);
@@ -185,9 +196,17 @@ public class CouchbaseSaveChangesInterceptor : SaveChangesInterceptor
         SaveChangesCompletedEventData eventData,
         int result)
     {
-        if (eventData.Context != null && IsTransactionActive(eventData.Context))
+        if (eventData.Context != null)
         {
-            RestoreEntityStates(eventData.Context);
+            if (IsTransactionActive(eventData.Context))
+            {
+                RestoreEntityStates(eventData.Context);
+            }
+            else
+            {
+                // Non-transactional save succeeded — refresh snapshots now
+                RefreshOwnedCollectionSnapshots(eventData.Context);
+            }
         }
 
         return base.SavedChanges(eventData, result);
@@ -226,6 +245,26 @@ public class CouchbaseSaveChangesInterceptor : SaveChangesInterceptor
         finally
         {
             context.ChangeTracker.AutoDetectChangesEnabled = autoDetect;
+        }
+    }
+
+    // After a successful save, update OwnedCollectionSnapshot with current collection
+    // references so subsequent SaveChanges won't see a stale mismatch.
+    private static void RefreshOwnedCollectionSnapshots(DbContext context)
+    {
+        foreach (var entry in context.ChangeTracker.Entries())
+        {
+            if (entry.Metadata.IsOwned()) continue;
+            if (entry.State != EntityState.Unchanged) continue;
+
+            var owner = entry.Entity;
+            if (!OwnedCollectionSnapshot.OriginalRefs.TryGetValue(owner, out var refs)) continue;
+
+            foreach (var nav in entry.Metadata.GetNavigations()
+                         .Where(n => n.TargetEntityType.IsOwned() && n.IsCollection && n.PropertyInfo != null))
+            {
+                refs[nav.Name] = nav.PropertyInfo!.GetValue(owner);
+            }
         }
     }
 

--- a/src/Couchbase.EntityFrameworkCore/Storage/Internal/CouchbaseSaveChangesInterceptor.cs
+++ b/src/Couchbase.EntityFrameworkCore/Storage/Internal/CouchbaseSaveChangesInterceptor.cs
@@ -1,4 +1,5 @@
 using System.Runtime.CompilerServices;
+using Couchbase.EntityFrameworkCore.Query.Internal;
 using Couchbase.EntityFrameworkCore.ValueGeneration;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.ChangeTracking;
@@ -79,6 +80,7 @@ public class CouchbaseSaveChangesInterceptor : SaveChangesInterceptor
         if (eventData.Context != null)
         {
             await GenerateSequenceValuesAsync(eventData.Context, cancellationToken);
+            MarkOwnersWithReplacedCollections(eventData.Context);
 
             if (IsTransactionActive(eventData.Context))
             {
@@ -97,6 +99,7 @@ public class CouchbaseSaveChangesInterceptor : SaveChangesInterceptor
         {
             GenerateSequenceValuesAsync(eventData.Context, CancellationToken.None)
                 .AsTask().GetAwaiter().GetResult();
+            MarkOwnersWithReplacedCollections(eventData.Context);
 
             if (IsTransactionActive(eventData.Context))
             {
@@ -188,6 +191,42 @@ public class CouchbaseSaveChangesInterceptor : SaveChangesInterceptor
         }
 
         return base.SavedChanges(eventData, result);
+    }
+
+    // For each tracked Unchanged/Detached root entity whose OwnsMany collection reference
+    // was replaced (e.g. customer.ContactMethods = []), mark it as Modified so EF Core
+    // includes it in GetEntriesToSave and our SaveChangesAsync is not skipped entirely.
+    // GenerateSequenceValuesAsync (called just before this) already triggered DetectChanges,
+    // so we disable AutoDetectChanges here to avoid a redundant second pass.
+    private static void MarkOwnersWithReplacedCollections(DbContext context)
+    {
+        var autoDetect = context.ChangeTracker.AutoDetectChangesEnabled;
+        context.ChangeTracker.AutoDetectChangesEnabled = false;
+        try
+        {
+            foreach (var entry in context.ChangeTracker.Entries())
+            {
+                if (entry.Metadata.IsOwned()) continue;
+                if (entry.State is not (EntityState.Unchanged or EntityState.Detached)) continue;
+
+                var owner = entry.Entity;
+                if (!OwnedCollectionSnapshot.OriginalRefs.TryGetValue(owner, out var origRefs)) continue;
+
+                foreach (var nav in entry.Metadata.GetNavigations()
+                             .Where(n => n.TargetEntityType.IsOwned() && n.IsCollection && n.PropertyInfo != null))
+                {
+                    if (!origRefs.TryGetValue(nav.Name, out var origRef)) continue;
+                    if (ReferenceEquals(origRef, nav.PropertyInfo!.GetValue(owner))) continue;
+
+                    entry.State = EntityState.Modified;
+                    break;
+                }
+            }
+        }
+        finally
+        {
+            context.ChangeTracker.AutoDetectChangesEnabled = autoDetect;
+        }
     }
 
     private static bool IsTransactionActive(DbContext context)

--- a/tests/Couchbase.EntityFrameworkCore.IntegrationTests/Fixtures/BloggingFixture.cs
+++ b/tests/Couchbase.EntityFrameworkCore.IntegrationTests/Fixtures/BloggingFixture.cs
@@ -120,13 +120,12 @@ public class BloggingFixture : CouchbaseFixture<BloggingDbContext>
                 new PostTag { PostTagId = 6, PostId = 4, TagId = "informative" }
             };
 
-            await dbContext.AddRangeAsync(blogs);
-            await dbContext.AddRangeAsync(posts);
-            await dbContext.AddRangeAsync(persons);
-
-            await dbContext.AddRangeAsync(personPhotos);
-            await dbContext.AddRangeAsync(tags);
-            await dbContext.AddRangeAsync(postTags);
+            dbContext.UpdateRange(blogs);
+            dbContext.UpdateRange(posts);
+            dbContext.UpdateRange(persons);
+            dbContext.UpdateRange(personPhotos);
+            dbContext.UpdateRange(tags);
+            dbContext.UpdateRange(postTags);
 
             await dbContext.SaveChangesAsync();
     }

--- a/tests/Couchbase.EntityFrameworkCore.IntegrationTests/Tests/BloggingDbContextTests.cs
+++ b/tests/Couchbase.EntityFrameworkCore.IntegrationTests/Tests/BloggingDbContextTests.cs
@@ -11,8 +11,24 @@ namespace Couchbase.EntityFrameworkCode.IntegrationTests.Tests;
 [Collection(CouchbaseTestingCollection.Name)]
 public class BloggingDbContextTests(
     BloggingFixture fixture,
-    ITestOutputHelper output)
+    ITestOutputHelper output) : IAsyncLifetime
 {
+    // Upsert known-good seed data before each test so that mutations in other test
+    // classes (e.g. CrudTests.Removing_Relationships_Async clearing OwnerId on Blog 2)
+    // don't cause queries like Where(o => o.Owner.Name == "Jane Doe") to return empty.
+    public async Task InitializeAsync()
+    {
+        await using var ctx = fixture.GetDbContext();
+        ctx.Update(new BloggingFixture.Blog { BlogId = 1, Url = "https://devblogs.microsoft.com/dotnet", Rating = 5, OwnerId = 1 });
+        ctx.Update(new BloggingFixture.Blog { BlogId = 2, Url = "https://mytravelblog.com/", Rating = 4, OwnerId = 3 });
+        ctx.Update(new BloggingFixture.Person { PersonId = 1, Name = "Dotnet Blog Admin", PhotoId = 1 });
+        ctx.Update(new BloggingFixture.Person { PersonId = 2, Name = "Phileas Fogg", PhotoId = 2 });
+        ctx.Update(new BloggingFixture.Person { PersonId = 3, Name = "Jane Doe", PhotoId = 3 });
+        await ctx.SaveChangesAsync();
+    }
+
+    public Task DisposeAsync() => Task.CompletedTask;
+
     [Fact]
     public async Task Test_Filter_Nested_Entities()
     {

--- a/tests/Couchbase.EntityFrameworkCore.IntegrationTests/Tests/OwnedTypeTests.cs
+++ b/tests/Couchbase.EntityFrameworkCore.IntegrationTests/Tests/OwnedTypeTests.cs
@@ -65,7 +65,6 @@ public class OwnedTypeTests(
             var customer = await ctx.Customers.FirstAsync(c => c.CustomerId == 1);
             customer.Address.Street = "99 Updated Ln";
             customer.Address.City = "Shelbyville";
-            ctx.Entry(customer).State = EntityState.Modified;
             await ctx.SaveChangesAsync();
         }
 
@@ -87,7 +86,6 @@ public class OwnedTypeTests(
             var customer = await ctx.Customers.FirstAsync(c => c.CustomerId == 2);
             customer.Address.Street = null;
             customer.Address.City = null;
-            ctx.Entry(customer).State = EntityState.Modified;
             await ctx.SaveChangesAsync();
         }
 
@@ -113,7 +111,6 @@ public class OwnedTypeTests(
                 new OwnedTypeFixture.ContactMethod { Id = 1, Type = "fax", Value = "555-0199" },
                 new OwnedTypeFixture.ContactMethod { Id = 2, Type = "sms", Value = "555-0200" }
             ];
-            ctx.Entry(customer).State = EntityState.Modified;
             await ctx.SaveChangesAsync();
         }
 
@@ -134,7 +131,6 @@ public class OwnedTypeTests(
         {
             var customer = await ctx.Customers.FirstAsync(c => c.CustomerId == 1);
             customer.ContactMethods = [];
-            ctx.Entry(customer).State = EntityState.Modified;
             await ctx.SaveChangesAsync();
         }
 

--- a/tests/Couchbase.EntityFrameworkCore.IntegrationTests/Tests/OwnedTypeTests.cs
+++ b/tests/Couchbase.EntityFrameworkCore.IntegrationTests/Tests/OwnedTypeTests.cs
@@ -140,4 +140,228 @@ public class OwnedTypeTests(
             Assert.Empty(customer.ContactMethods);
         }
     }
+
+    // -------------------------------------------------------------------------
+    // Read path — untested scenarios
+    // -------------------------------------------------------------------------
+
+    [Fact]
+    public async Task OwnsOne_FilterBy_OwnedProperty_ReturnsMatchingCustomer()
+    {
+        await using var ctx = fixture.GetDbContext();
+        var customers = await ctx.Customers
+            .Where(c => c.Address.City == "Springfield")
+            .ToListAsync();
+
+        Assert.Single(customers);
+        Assert.Equal("Alice", customers[0].Name);
+    }
+
+    [Fact]
+    public async Task OwnsMany_ToListAsync_AllCustomersCollectionsPopulated()
+    {
+        await using var ctx = fixture.GetDbContext();
+        var customers = await ctx.Customers.ToListAsync();
+
+        Assert.Equal(2, customers.Count);
+        var alice = customers.Single(c => c.Name == "Alice");
+        var bob   = customers.Single(c => c.Name == "Bob");
+        Assert.Equal(2, alice.ContactMethods.Count);
+        Assert.Single(bob.ContactMethods);
+    }
+
+    [Fact]
+    public async Task OwnsMany_AsNoTracking_IsPopulated()
+    {
+        await using var ctx = fixture.GetDbContext();
+        var customer = await ctx.Customers
+            .AsNoTracking()
+            .FirstAsync(c => c.CustomerId == 1);
+
+        Assert.Equal(2, customer.ContactMethods.Count);
+        Assert.Contains(customer.ContactMethods, cm => cm.Type == "email");
+        Assert.Contains(customer.ContactMethods, cm => cm.Type == "phone");
+    }
+
+    [Fact]
+    public async Task OwnsMany_ItemOrderIsPreserved()
+    {
+        // Seed stores email first, phone second for customer 1.
+        await using var ctx = fixture.GetDbContext();
+        var customer = await ctx.Customers.FirstAsync(c => c.CustomerId == 1);
+
+        Assert.Equal(2, customer.ContactMethods.Count);
+        Assert.Equal("email", customer.ContactMethods[0].Type);
+        Assert.Equal("phone", customer.ContactMethods[1].Type);
+    }
+
+    [Fact]
+    public async Task OwnsMany_EmptyCollectionDocument_ReadsAsEmpty()
+    {
+        // A document stored with an empty contactMethods array must read back as
+        // an empty list, not null.
+        const int id = 97;
+        await using (var ctx = fixture.GetDbContext())
+        {
+            ctx.Update(new OwnedTypeFixture.Customer
+            {
+                CustomerId = id,
+                Name = "Empty",
+                Address = new OwnedTypeFixture.Address { Street = "0 Void Ln", City = "Nowhere" },
+                ContactMethods = []
+            });
+            await ctx.SaveChangesAsync();
+        }
+
+        try
+        {
+            await using var ctx = fixture.GetDbContext();
+            var customer = await ctx.Customers.FirstAsync(c => c.CustomerId == id);
+            Assert.NotNull(customer.ContactMethods);
+            Assert.Empty(customer.ContactMethods);
+        }
+        finally
+        {
+            await using var ctx = fixture.GetDbContext();
+            var customer = await ctx.Customers.FirstOrDefaultAsync(c => c.CustomerId == id);
+            if (customer != null) { ctx.Remove(customer); await ctx.SaveChangesAsync(); }
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Write path — untested scenarios
+    // -------------------------------------------------------------------------
+
+    [Fact]
+    public async Task Customer_Add_WithOwnedTypes_RoundTrips()
+    {
+        const int id = 99;
+        try
+        {
+            await using (var ctx = fixture.GetDbContext())
+            {
+                ctx.Add(new OwnedTypeFixture.Customer
+                {
+                    CustomerId = id,
+                    Name = "Charlie",
+                    Address = new OwnedTypeFixture.Address { Street = "3 Oak Ave", City = "Shelbyville" },
+                    ContactMethods =
+                    [
+                        new OwnedTypeFixture.ContactMethod { Id = 1, Type = "email", Value = "charlie@example.com" }
+                    ]
+                });
+                await ctx.SaveChangesAsync();
+            }
+
+            await using (var ctx = fixture.GetDbContext())
+            {
+                var customer = await ctx.Customers.FirstAsync(c => c.CustomerId == id);
+                Assert.Equal("Charlie", customer.Name);
+                Assert.Equal("3 Oak Ave", customer.Address.Street);
+                Assert.Equal("Shelbyville", customer.Address.City);
+                Assert.Single(customer.ContactMethods);
+                Assert.Equal("charlie@example.com", customer.ContactMethods[0].Value);
+            }
+        }
+        finally
+        {
+            await using var ctx = fixture.GetDbContext();
+            var customer = await ctx.Customers.FirstOrDefaultAsync(c => c.CustomerId == id);
+            if (customer != null) { ctx.Remove(customer); await ctx.SaveChangesAsync(); }
+        }
+    }
+
+    [Fact]
+    public async Task Customer_Delete_RemovesDocument()
+    {
+        const int id = 98;
+        await using (var ctx = fixture.GetDbContext())
+        {
+            ctx.Update(new OwnedTypeFixture.Customer
+            {
+                CustomerId = id,
+                Name = "Transient",
+                Address = new OwnedTypeFixture.Address { Street = "Temp St", City = "Nowhere" },
+                ContactMethods = []
+            });
+            await ctx.SaveChangesAsync();
+        }
+
+        await using (var ctx = fixture.GetDbContext())
+        {
+            var customer = await ctx.Customers.FirstAsync(c => c.CustomerId == id);
+            ctx.Remove(customer);
+            await ctx.SaveChangesAsync();
+        }
+
+        await using (var ctx = fixture.GetDbContext())
+        {
+            var customer = await ctx.Customers.FirstOrDefaultAsync(c => c.CustomerId == id);
+            Assert.Null(customer);
+        }
+    }
+
+    [Fact]
+    public async Task OwnsMany_AddSingleItem_RoundTrips()
+    {
+        // Add one item to an existing collection via .Add() without replacing the list
+        // reference; the owner document must be rewritten.
+        await using (var ctx = fixture.GetDbContext())
+        {
+            var customer = await ctx.Customers.FirstAsync(c => c.CustomerId == 2);
+            customer.ContactMethods.Add(
+                new OwnedTypeFixture.ContactMethod { Id = 2, Type = "phone", Value = "555-0202" });
+            await ctx.SaveChangesAsync();
+        }
+
+        await using (var ctx = fixture.GetDbContext())
+        {
+            var customer = await ctx.Customers.FirstAsync(c => c.CustomerId == 2);
+            Assert.Equal(2, customer.ContactMethods.Count);
+            Assert.Contains(customer.ContactMethods, cm => cm.Type == "email");
+            Assert.Contains(customer.ContactMethods, cm => cm.Type == "phone" && cm.Value == "555-0202");
+        }
+    }
+
+    [Fact]
+    public async Task OwnsMany_RemoveSingleItem_RoundTrips()
+    {
+        // Remove one item from a two-item collection via .Remove() without replacing the
+        // list reference; the owner document must be rewritten with the item absent.
+        await using (var ctx = fixture.GetDbContext())
+        {
+            var customer = await ctx.Customers.FirstAsync(c => c.CustomerId == 1);
+            var email = customer.ContactMethods.First(cm => cm.Type == "email");
+            customer.ContactMethods.Remove(email);
+            await ctx.SaveChangesAsync();
+        }
+
+        await using (var ctx = fixture.GetDbContext())
+        {
+            var customer = await ctx.Customers.FirstAsync(c => c.CustomerId == 1);
+            Assert.Single(customer.ContactMethods);
+            Assert.DoesNotContain(customer.ContactMethods, cm => cm.Type == "email");
+            Assert.Contains(customer.ContactMethods, cm => cm.Type == "phone");
+        }
+    }
+
+    [Fact]
+    public async Task OwnsMany_MutateItemProperty_RoundTrips()
+    {
+        // Mutate a scalar property on an existing owned item in-place; the owner
+        // document must be rewritten with the updated value.
+        await using (var ctx = fixture.GetDbContext())
+        {
+            var customer = await ctx.Customers.FirstAsync(c => c.CustomerId == 1);
+            customer.ContactMethods.First(cm => cm.Type == "email").Value = "alice.new@example.com";
+            await ctx.SaveChangesAsync();
+        }
+
+        await using (var ctx = fixture.GetDbContext())
+        {
+            var customer = await ctx.Customers.FirstAsync(c => c.CustomerId == 1);
+            Assert.Contains(customer.ContactMethods,
+                cm => cm.Type == "email" && cm.Value == "alice.new@example.com");
+        }
+    }
 }


### PR DESCRIPTION
Add a second pass in CouchbaseDatabaseWrapper.SaveChangesAsync that automatically writes the owner document when an owned entry has a state change but the root was not already written by the main loop. This removes the need for callers to manually mark owners as Modified after mutating OwnsMany collections.

Add SnapshotCollectionRefs to CouchbaseQueryEnumerable so the save path can detect when a collection reference is replaced (e.g. customer.ContactMethods = []) rather than mutated in place. The interceptor's MarkOwnersWithReplacedCollections method reads these snapshots in SavingChangesAsync — before EF Core's GetEntriesToSave call — and marks the owner Modified so EF Core does not short-circuit the save entirely.

Fix writtenRoots population to only include roots that were actually written (Deleted/Modified/Added), not Unchanged roots, so the second pass can still write owners whose only changes came from owned items. Fix AddOwnedCollectionColumnsToProjection to match TableExpression by the entity's configured table name instead of counting path segments, resolving silent injection failures in contexts where the full 3-part keyspace is not used.

Fix BloggingFixture.LoadDataAsync to use UpdateRange (upsert) instead of AddRangeAsync so repeated fixture initialization is idempotent. Add IAsyncLifetime to BloggingDbContextTests and EagerLoadingTests to reseed known-good blog and person documents before each test, preventing CrudTests.Removing_Relationships_Async (which writes Blog 2 with OwnerId = 0) from corrupting data that Test_Filter_Nested_Entities depends on.