### PR TITLE
Replace second-pass ChangeTracker scan with StateManager.TryGetEntry

### DIFF
--- a/src/Couchbase.EntityFrameworkCore/Storage/Internal/CouchbaseDatabaseWrapper.cs
+++ b/src/Couchbase.EntityFrameworkCore/Storage/Internal/CouchbaseDatabaseWrapper.cs
@@ -5,7 +5,6 @@ using Couchbase.EntityFrameworkCore.Infrastructure;
 using Couchbase.EntityFrameworkCore.Utils;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.ChangeTracking.Internal;
-using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Storage;
 using Microsoft.EntityFrameworkCore.Update;
@@ -155,18 +154,15 @@ public class CouchbaseDatabaseWrapper : Database
                 .ToArray();
 
             var ownerEntityType = ownership.PrincipalEntityType;
-            var context = ownedEntry.ToEntityEntry().Context;
 
-            var ownerEntityEntry = context.ChangeTracker.Entries()
-                .FirstOrDefault(e =>
-                    e.Metadata == ownerEntityType &&
-                    ownership.PrincipalKey.Properties
-                        .Select((p, i) => Equals(e.CurrentValues[p.Name], fkValues[i]))
-                        .All(b => b));
+            // Use StateManager.TryGetEntry for O(1) owner lookup instead of a linear
+            // ChangeTracker.Entries() scan, and get the InternalEntityEntry directly so
+            // the IInfrastructure<InternalEntityEntry> unwrap is no longer needed.
+            var stateManager = ((InternalEntityEntry)ownedEntry).StateManager;
+            var ownerInternalEntry = stateManager.TryGetEntry(ownership.PrincipalKey, fkValues);
+            if (ownerInternalEntry == null) continue;
 
-            if (ownerEntityEntry == null) continue;
-
-            var ownerEntity = ownerEntityEntry.Entity;
+            var ownerEntity = ownerInternalEntry.Entity;
             var ownerPrimaryKey = ownerEntityType.GetPrimaryKey(ownerEntity);
             var rootKey = $"{ownerEntityType.ClrType.Name}:{ownerPrimaryKey}";
 
@@ -178,8 +174,7 @@ public class CouchbaseDatabaseWrapper : Database
                     $"Owner entity type '{ownerEntityType.ClrType.Name}' has no mapped table name. " +
                     "Ensure the entity is mapped to a Couchbase collection via ToCouchbaseCollection().");
 
-            var ownerUpdateEntry = (IUpdateEntry)((IInfrastructure<InternalEntityEntry>)ownerEntityEntry).Instance;
-            var ownerDocument = HydrateObjectFromEntity(ownerUpdateEntry, _fieldNamingPolicy);
+            var ownerDocument = HydrateObjectFromEntity(ownerInternalEntry, _fieldNamingPolicy);
 
             if (transaction != null)
             {


### PR DESCRIPTION
The deferred-owned second pass in CouchbaseDatabaseWrapper was calling context.ChangeTracker.Entries().FirstOrDefault(...) for every owned entry, producing an O(D×M) scan where D is the number of deferred owned entries and M is the total number of tracked entries. Replace with ((InternalEntityEntry)ownedEntry).StateManager.TryGetEntry( ownership.PrincipalKey, fkValues), which resolves the owner in O(1). InternalEntityEntry implements IUpdateEntry directly, so the IInfrastructure<InternalEntityEntry> unwrap on the ownerUpdateEntry variable is eliminated along with the using directive for Microsoft.EntityFrameworkCore.Infrastructure.