### PR TITLE
Phase 2: Replace _fieldOrdinals indirection with direct TryGetPropert…

### DIFF
--- a/specs/datareader-refactor.md
+++ b/specs/datareader-refactor.md
@@ -72,9 +72,14 @@ two allocations and two lookups without changing the result.
 
 ### Changes
 
-- When `_columnNames` is set, replace steps 2–4 with a direct case-insensitive property lookup
-  on the current `JsonElement` row using the same `TryGetPropertyCI` logic already present in
-  `CouchbaseQueryEnumerable`. A missing field returns `DBNull.Value`.
+- When `_columnNames` is set, replace the round-trip through steps 2–3 (dict → array → same name)
+  with a two-step fast path:
+  1. `_fieldOrdinals.TryGetValue(alias)` — O(1) OrdinalIgnoreCase lookup to retrieve the
+     canonical JSON property name stored in `_fieldNames[jsonOrd]`.
+  2. `je.TryGetProperty(canonicalName)` — exact (case-sensitive) property read on the live
+     `JsonElement` row.
+  `TryGetPropertyCI` is retained as a fallback for aliases not present in `_fieldOrdinals`
+  (e.g. computed aliases injected after schema discovery). A missing field returns `DBNull.Value`.
 
 - Retain the no-`_columnNames` fallback path unchanged so this phase is self-contained and does
   not require simultaneous changes to `CouchbaseQueryEnumerable`.
@@ -88,9 +93,10 @@ two allocations and two lookups without changing the result.
 
 ### Expected outcome
 
-`GetValue` hot path (non-null `_columnNames` slot): array lookup + `TryGetPropertyCI`. No
-dictionary lookups. Approximately 15–20 lines removed from `GetValue`; `GetOrdinal` is
-comment-only cleanup.
+`GetValue` hot path (non-null `_columnNames` slot): array lookup → `_fieldOrdinals` dict lookup
+→ exact `TryGetProperty`. One dictionary lookup replaces two (dict + array); the O(m) linear scan
+is eliminated for the common case. `TryGetPropertyCI` is the fallback for unknown aliases only.
+Approximately 15–20 lines removed from `GetValue`; `GetOrdinal` is comment-only cleanup.
 
 ---
 

--- a/specs/datareader-refactor.md
+++ b/specs/datareader-refactor.md
@@ -79,14 +79,18 @@ two allocations and two lookups without changing the result.
 - Retain the no-`_columnNames` fallback path unchanged so this phase is self-contained and does
   not require simultaneous changes to `CouchbaseQueryEnumerable`.
 
-- Simplify `GetOrdinal` for the `_projectionOrdinals` path. The constrained fallback that
-  reconciles null-slot positions against `_fieldOrdinals` becomes unnecessary once the two ordinal
-  spaces are no longer conflated.
+- Retain the null-slot fallback in `GetOrdinal` unchanged: the `EnsureFieldInfo()` call, the
+  `_fieldOrdinals` lookup, the bounds check `(uint)jsonOrd < (uint)_columnNames.Length`, and the
+  `_columnNames[jsonOrd] == null` guard must all stay. The bounds check prevents extra JSON fields
+  beyond the projection width from being surfaced via `reader["name"]`, and the null-slot guard
+  ensures non-null aliases that somehow bypass `_projectionOrdinals` are rejected rather than
+  silently returned. Only the stale comment above the block needs updating.
 
 ### Expected outcome
 
-`GetValue` hot path: array lookup + case-insensitive `TryGetProperty`. No dictionary lookups.
-Approximately 20–30 lines removed from `GetValue` and `GetOrdinal`.
+`GetValue` hot path (non-null `_columnNames` slot): array lookup + `TryGetPropertyCI`. No
+dictionary lookups. Approximately 15–20 lines removed from `GetValue`; `GetOrdinal` is
+comment-only cleanup.
 
 ---
 

--- a/src/Couchbase.EntityFrameworkCore/Extensions/JsonElementExtensions.cs
+++ b/src/Couchbase.EntityFrameworkCore/Extensions/JsonElementExtensions.cs
@@ -6,12 +6,17 @@ internal static class JsonElementExtensions
 {
     /// <summary>
     /// Case-insensitive property lookup on a <see cref="JsonElement"/>.
-    /// Tries an exact match first (O(m) but hits immediately when casing matches),
-    /// then falls back to an OrdinalIgnoreCase linear scan.
+    /// Returns false (and <paramref name="value"/> = default) when the element is not an object.
+    /// Tries an exact match first, then falls back to an OrdinalIgnoreCase linear scan.
     /// </summary>
     // CI = Case-Insensitive
     internal static bool TryGetPropertyCI(this JsonElement element, string name, out JsonElement value)
     {
+        if (element.ValueKind != JsonValueKind.Object)
+        {
+            value = default;
+            return false;
+        }
         if (element.TryGetProperty(name, out value)) return true;
         foreach (var prop in element.EnumerateObject())
         {

--- a/src/Couchbase.EntityFrameworkCore/Extensions/JsonElementExtensions.cs
+++ b/src/Couchbase.EntityFrameworkCore/Extensions/JsonElementExtensions.cs
@@ -1,0 +1,25 @@
+using System.Text.Json;
+
+namespace Couchbase.EntityFrameworkCore.Extensions;
+
+internal static class JsonElementExtensions
+{
+    /// <summary>
+    /// Case-insensitive property lookup on a <see cref="JsonElement"/>.
+    /// Tries an exact match first (O(m) but hits immediately when casing matches),
+    /// then falls back to an OrdinalIgnoreCase linear scan.
+    /// </summary>
+    // CI = Case-Insensitive
+    internal static bool TryGetPropertyCI(this JsonElement element, string name, out JsonElement value)
+    {
+        if (element.TryGetProperty(name, out value)) return true;
+        foreach (var prop in element.EnumerateObject())
+        {
+            if (!string.Equals(prop.Name, name, StringComparison.OrdinalIgnoreCase)) continue;
+            value = prop.Value;
+            return true;
+        }
+        value = default;
+        return false;
+    }
+}

--- a/src/Couchbase.EntityFrameworkCore/Query/Internal/CouchbaseQueryEnumerable.cs
+++ b/src/Couchbase.EntityFrameworkCore/Query/Internal/CouchbaseQueryEnumerable.cs
@@ -8,6 +8,7 @@ using Couchbase.Query;
 using Couchbase.EntityFrameworkCore.Infrastructure;
 using Couchbase.EntityFrameworkCore.Metadata;
 using Couchbase.EntityFrameworkCore.Storage.Internal;
+using Couchbase.EntityFrameworkCore.Extensions;
 using Couchbase.EntityFrameworkCore.Utils;
 using Couchbase.Extensions.DependencyInjection;
 using Microsoft.EntityFrameworkCore;
@@ -229,7 +230,7 @@ public class CouchbaseQueryEnumerable<T> : IEnumerable<T>, IAsyncEnumerable<T>, 
         foreach (var nav in collections)
         {
             var fieldName = fieldNamingPolicy?.ConvertName(nav.Name) ?? nav.Name;
-            if (!TryGetPropertyCI(docElement, fieldName, out var arrayElement)
+            if (!docElement.TryGetPropertyCI(fieldName, out var arrayElement)
                 || arrayElement.ValueKind != JsonValueKind.Array)
                 continue;
 
@@ -258,7 +259,7 @@ public class CouchbaseQueryEnumerable<T> : IEnumerable<T>, IAsyncEnumerable<T>, 
                 foreach (var prop in properties)
                 {
                     var jsonKey = fieldNamingPolicy?.ConvertName(prop.Name) ?? prop.Name;
-                    if (TryGetPropertyCI(itemElement, jsonKey, out var propElement))
+                    if (itemElement.TryGetPropertyCI(jsonKey, out var propElement))
                         prop.PropertyInfo?.SetValue(ownedEntity, ConvertJsonValue(propElement, prop.ClrType, options));
                 }
                 if (accessor != null)
@@ -281,21 +282,6 @@ public class CouchbaseQueryEnumerable<T> : IEnumerable<T>, IAsyncEnumerable<T>, 
             refs[nav.Name] = nav.PropertyInfo?.GetValue(entity);
     }
 
-    // JsonElement.TryGetProperty is case-sensitive. The SDK's SystemTextJsonSerializer uses
-    // JsonSerializerDefaults.Web (camelCase), so navigation/property names may vary in case
-    // between what EF Core models use and what appears in the stored document.
-    internal static bool TryGetPropertyCI(JsonElement element, string name, out JsonElement value)
-    {
-        if (element.TryGetProperty(name, out value)) return true;
-        foreach (var prop in element.EnumerateObject())
-        {
-            if (!string.Equals(prop.Name, name, StringComparison.OrdinalIgnoreCase)) continue;
-            value = prop.Value;
-            return true;
-        }
-        value = default;
-        return false;
-    }
 
     private static object? ConvertJsonValue(JsonElement element, Type targetType, JsonSerializerOptions options)
     {

--- a/src/Couchbase.EntityFrameworkCore/Storage/Internal/CouchbaseDbDataReader.cs
+++ b/src/Couchbase.EntityFrameworkCore/Storage/Internal/CouchbaseDbDataReader.cs
@@ -411,12 +411,18 @@ public class CouchbaseDbDataReader<T> : DbDataReader
                 return projOrdinal;
 
             // Fallback for null-slot positions: GetName(i) returns the JSON field name for
-            // a null slot, so GetOrdinal must resolve it back to i. Any name that reaches
-            // here and exists in _fieldOrdinals must correspond to a null slot — non-null
-            // slots have their alias in _projectionOrdinals and are found above.
+            // a null slot, so GetOrdinal must resolve it back to i to keep
+            // GetOrdinal(GetName(i)) == i. Bounds-check against _columnNames.Length so that
+            // extra JSON fields beyond the projection are not surfaced, and verify the slot
+            // is actually null so non-null aliases that somehow bypass _projectionOrdinals
+            // are rejected rather than silently returned.
             EnsureFieldInfo();
-            if (_fieldOrdinals != null && _fieldOrdinals.TryGetValue(name, out var jsonOrd))
+            if (_fieldOrdinals != null && _fieldOrdinals.TryGetValue(name, out var jsonOrd)
+                && (uint)jsonOrd < (uint)_columnNames!.Length
+                && _columnNames[jsonOrd] == null)
+            {
                 return jsonOrd;
+            }
 
             throw new IndexOutOfRangeException($"Field '{name}' not found.");
         }

--- a/src/Couchbase.EntityFrameworkCore/Storage/Internal/CouchbaseDbDataReader.cs
+++ b/src/Couchbase.EntityFrameworkCore/Storage/Internal/CouchbaseDbDataReader.cs
@@ -486,9 +486,10 @@ public class CouchbaseDbDataReader<T> : DbDataReader
         EnsureCurrentRow();
 
         // When the caller supplied column names (projection aliases from the SELECT clause),
-        // look up the JSON property directly by alias using a case-insensitive scan.
-        // This eliminates the _fieldOrdinals → _fieldNames round-trip that previously
-        // translated the alias to a json ordinal and back to the same name.
+        // resolve the alias via _fieldOrdinals (OrdinalIgnoreCase dictionary, built once from
+        // the first row) to obtain the canonical JSON property name, then call TryGetProperty
+        // with that exact name. Only the fallback path (schema not yet built) uses the O(m)
+        // TryGetPropertyCI linear scan.
         if (_columnNames != null && (uint)ordinal < (uint)_columnNames.Length)
         {
             var colName = _columnNames[ordinal];

--- a/src/Couchbase.EntityFrameworkCore/Storage/Internal/CouchbaseDbDataReader.cs
+++ b/src/Couchbase.EntityFrameworkCore/Storage/Internal/CouchbaseDbDataReader.cs
@@ -494,17 +494,23 @@ public class CouchbaseDbDataReader<T> : DbDataReader
             var colName = _columnNames[ordinal];
             if (colName != null)
             {
-                if (_currentRow is JsonElement je && je.ValueKind == JsonValueKind.Object)
-                {
-                    return TryGetPropertyCI(je, colName, out var prop)
+                if (_currentRow is not JsonElement je) return DBNull.Value;
+
+                if (je.ValueKind != JsonValueKind.Object)
+                    return ConvertJsonElement(je); // SELECT RAW scalar
+
+                // Use _fieldOrdinals (OrdinalIgnoreCase, built once from the first row) for
+                // O(1) alias→canonical-name resolution, then call TryGetProperty with the
+                // exact canonical name so the JSON property scan hits on the first comparison.
+                // Falls back to TryGetPropertyCI only if schema discovery hasn't run yet.
+                if (_fieldOrdinals != null && _fieldOrdinals.TryGetValue(colName, out var jsonOrd))
+                    return je.TryGetProperty(_fieldNames![jsonOrd], out var prop)
                         ? ConvertJsonElement(prop)
                         : DBNull.Value;
-                }
-                // Scalar SELECT RAW row: the entire element is the value.
-                if (_currentRow is JsonElement raw)
-                    return ConvertJsonElement(raw);
 
-                return DBNull.Value;
+                return TryGetPropertyCI(je, colName, out var fallbackProp)
+                    ? ConvertJsonElement(fallbackProp)
+                    : DBNull.Value;
             }
             // null slot: no alias for this ordinal — fall through to positional access.
         }

--- a/src/Couchbase.EntityFrameworkCore/Storage/Internal/CouchbaseDbDataReader.cs
+++ b/src/Couchbase.EntityFrameworkCore/Storage/Internal/CouchbaseDbDataReader.cs
@@ -410,18 +410,13 @@ public class CouchbaseDbDataReader<T> : DbDataReader
             if (_projectionOrdinals.TryGetValue(name, out var projOrdinal))
                 return projOrdinal;
 
-            // Constrained fallback for null-slot positions: GetName(i) returns the JSON
-            // field name for a null slot, so GetOrdinal must resolve it back to i to
-            // keep GetOrdinal(GetName(i)) == i.  Only accept the name when it maps to a
-            // null slot — a non-null slot's alias already lives in _projectionOrdinals, so
-            // landing here with that alias would be ambiguous and is correctly rejected.
+            // Fallback for null-slot positions: GetName(i) returns the JSON field name for
+            // a null slot, so GetOrdinal must resolve it back to i. Any name that reaches
+            // here and exists in _fieldOrdinals must correspond to a null slot — non-null
+            // slots have their alias in _projectionOrdinals and are found above.
             EnsureFieldInfo();
-            if (_fieldOrdinals != null && _fieldOrdinals.TryGetValue(name, out var jsonOrd)
-                && (uint)jsonOrd < (uint)_columnNames!.Length
-                && _columnNames[jsonOrd] == null)
-            {
+            if (_fieldOrdinals != null && _fieldOrdinals.TryGetValue(name, out var jsonOrd))
                 return jsonOrd;
-            }
 
             throw new IndexOutOfRangeException($"Field '{name}' not found.");
         }
@@ -484,37 +479,31 @@ public class CouchbaseDbDataReader<T> : DbDataReader
     {
         EnsureCurrentRow();
 
-        // When the caller supplied column names (projection aliases from the SELECT clause), use
-        // _fieldOrdinals to translate each shaper ordinal to the correct JSON property.
-        // N1QL returns response fields in document-storage order, which differs from the SELECT
-        // clause order, so positional access is incorrect without this mapping.
-        // _fieldOrdinals uses OrdinalIgnoreCase, so camelCase aliases match camelCase JSON keys.
+        // When the caller supplied column names (projection aliases from the SELECT clause),
+        // look up the JSON property directly by alias using a case-insensitive scan.
+        // This eliminates the _fieldOrdinals → _fieldNames round-trip that previously
+        // translated the alias to a json ordinal and back to the same name.
         if (_columnNames != null && (uint)ordinal < (uint)_columnNames.Length)
         {
             var colName = _columnNames[ordinal];
-            if (colName != null && _fieldOrdinals != null)
+            if (colName != null)
             {
-                if (_fieldOrdinals.TryGetValue(colName, out var jsonOrdinal))
+                if (_currentRow is JsonElement je && je.ValueKind == JsonValueKind.Object)
                 {
-                    return GetFieldValue(_fieldNames![jsonOrdinal]);
+                    return TryGetPropertyCI(je, colName, out var prop)
+                        ? ConvertJsonElement(prop)
+                        : DBNull.Value;
                 }
-                // Scalar SELECT RAW row: single synthetic "" field answers to any alias,
-                // matching the same special-case in GetOrdinal.
-                if (_fieldNames?.Count == 1 && _fieldNames[0] == string.Empty)
-                {
-                    return GetFieldValue(string.Empty);
-                }
-                // Field genuinely absent from the N1QL response (MISSING) — treat as null.
+                // Scalar SELECT RAW row: the entire element is the value.
+                if (_currentRow is JsonElement raw)
+                    return ConvertJsonElement(raw);
+
                 return DBNull.Value;
             }
-            // null slot in _columnNames means "no alias for this ordinal — use positional
-            // access", as documented on the constructor.  Fall through.
+            // null slot: no alias for this ordinal — fall through to positional access.
         }
 
-        // No column names supplied, or null slot: positional access.
-        // For a null slot (projection active, no alias), a JSON field that doesn't reach
-        // this ordinal is MISSING — return DBNull consistent with non-null alias handling above.
-        // Without a projection mapping, an out-of-range ordinal is programmer error — throw.
+        // No column names supplied, or null slot: positional access via schema discovery.
         var isNullSlot = _columnNames != null && (uint)ordinal < (uint)_columnNames.Length;
         if (isNullSlot && (_fieldNames == null || ordinal >= _fieldNames.Count))
             return DBNull.Value;
@@ -1191,6 +1180,19 @@ public class CouchbaseDbDataReader<T> : DbDataReader
             }
         }
         return DBNull.Value;
+    }
+
+    private static bool TryGetPropertyCI(JsonElement element, string name, out JsonElement value)
+    {
+        if (element.TryGetProperty(name, out value)) return true;
+        foreach (var prop in element.EnumerateObject())
+        {
+            if (!string.Equals(prop.Name, name, StringComparison.OrdinalIgnoreCase)) continue;
+            value = prop.Value;
+            return true;
+        }
+        value = default;
+        return false;
     }
 
     private static object ConvertJsonElement(JsonElement element)

--- a/src/Couchbase.EntityFrameworkCore/Storage/Internal/CouchbaseDbDataReader.cs
+++ b/src/Couchbase.EntityFrameworkCore/Storage/Internal/CouchbaseDbDataReader.cs
@@ -489,8 +489,8 @@ public class CouchbaseDbDataReader<T> : DbDataReader
         // When the caller supplied column names (projection aliases from the SELECT clause),
         // resolve the alias via _fieldOrdinals (OrdinalIgnoreCase dictionary, built once from
         // the first row) to obtain the canonical JSON property name, then call TryGetProperty
-        // with that exact name. Only the fallback path (schema not yet built) uses the O(m)
-        // TryGetPropertyCI linear scan.
+        // with that exact name. The TryGetPropertyCI fallback is used when _fieldOrdinals is
+        // null (schema not yet built) or the alias is absent from _fieldOrdinals.
         if (_columnNames != null && (uint)ordinal < (uint)_columnNames.Length)
         {
             var colName = _columnNames[ordinal];
@@ -504,7 +504,9 @@ public class CouchbaseDbDataReader<T> : DbDataReader
                 // Use _fieldOrdinals (OrdinalIgnoreCase, built once from the first row) for
                 // O(1) alias→canonical-name resolution, then call TryGetProperty with the
                 // exact canonical name so the JSON property scan hits on the first comparison.
-                // Falls back to TryGetPropertyCI only if schema discovery hasn't run yet.
+                // Falls back to TryGetPropertyCI when _fieldOrdinals is null (schema not yet
+                // built) or when the alias is absent from _fieldOrdinals (e.g. an alias
+                // introduced after the first row that was never recorded during schema discovery).
                 if (_fieldOrdinals != null && _fieldOrdinals.TryGetValue(colName, out var jsonOrd))
                     return je.TryGetProperty(_fieldNames![jsonOrd], out var prop)
                         ? ConvertJsonElement(prop)

--- a/src/Couchbase.EntityFrameworkCore/Storage/Internal/CouchbaseDbDataReader.cs
+++ b/src/Couchbase.EntityFrameworkCore/Storage/Internal/CouchbaseDbDataReader.cs
@@ -2,6 +2,7 @@ using System.Collections;
 using System.Data;
 using System.Data.Common;
 using System.Text.Json;
+using Couchbase.EntityFrameworkCore.Extensions;
 using Couchbase.Query;
 
 namespace Couchbase.EntityFrameworkCore.Storage.Internal;
@@ -509,7 +510,7 @@ public class CouchbaseDbDataReader<T> : DbDataReader
                         ? ConvertJsonElement(prop)
                         : DBNull.Value;
 
-                return TryGetPropertyCI(je, colName, out var fallbackProp)
+                return je.TryGetPropertyCI(colName, out var fallbackProp)
                     ? ConvertJsonElement(fallbackProp)
                     : DBNull.Value;
             }
@@ -1193,19 +1194,6 @@ public class CouchbaseDbDataReader<T> : DbDataReader
             }
         }
         return DBNull.Value;
-    }
-
-    private static bool TryGetPropertyCI(JsonElement element, string name, out JsonElement value)
-    {
-        if (element.TryGetProperty(name, out value)) return true;
-        foreach (var prop in element.EnumerateObject())
-        {
-            if (!string.Equals(prop.Name, name, StringComparison.OrdinalIgnoreCase)) continue;
-            value = prop.Value;
-            return true;
-        }
-        value = default;
-        return false;
     }
 
     private static object ConvertJsonElement(JsonElement element)

--- a/tests/Couchbase.EntityFrameworkCore.UnitTests/Couchbase/EntityFrameworkCore/Query/OwnedCollectionInjectionTests.cs
+++ b/tests/Couchbase.EntityFrameworkCore.UnitTests/Couchbase/EntityFrameworkCore/Query/OwnedCollectionInjectionTests.cs
@@ -28,8 +28,8 @@ public class CouchbaseQueryEnumerableTests
     [InlineData("[1,2,3]")]     // Array
     public void TryGetPropertyCI_nonObject_returnsFalse(string json)
     {
-        var element = JsonDocument.Parse(json).RootElement;
-        var found = element.TryGetPropertyCI("anything", out var val);
+        using var doc = JsonDocument.Parse(json);
+        var found = doc.RootElement.TryGetPropertyCI("anything", out var val);
         Assert.False(found);
         Assert.Equal(JsonValueKind.Undefined, val.ValueKind);
     }

--- a/tests/Couchbase.EntityFrameworkCore.UnitTests/Couchbase/EntityFrameworkCore/Query/OwnedCollectionInjectionTests.cs
+++ b/tests/Couchbase.EntityFrameworkCore.UnitTests/Couchbase/EntityFrameworkCore/Query/OwnedCollectionInjectionTests.cs
@@ -19,4 +19,18 @@ public class CouchbaseQueryEnumerableTests
         Assert.Equal(JsonValueKind.Array, val.ValueKind);
         Assert.Equal(1, val.GetArrayLength());
     }
+
+    [Theory]
+    [InlineData("\"hello\"")]   // String
+    [InlineData("42")]          // Number
+    [InlineData("true")]        // Boolean
+    [InlineData("null")]        // Null
+    [InlineData("[1,2,3]")]     // Array
+    public void TryGetPropertyCI_nonObject_returnsFalse(string json)
+    {
+        var element = JsonDocument.Parse(json).RootElement;
+        var found = element.TryGetPropertyCI("anything", out var val);
+        Assert.False(found);
+        Assert.Equal(JsonValueKind.Undefined, val.ValueKind);
+    }
 }

--- a/tests/Couchbase.EntityFrameworkCore.UnitTests/Couchbase/EntityFrameworkCore/Query/OwnedCollectionInjectionTests.cs
+++ b/tests/Couchbase.EntityFrameworkCore.UnitTests/Couchbase/EntityFrameworkCore/Query/OwnedCollectionInjectionTests.cs
@@ -1,5 +1,5 @@
 using System.Text.Json;
-using Couchbase.EntityFrameworkCore.Query.Internal;
+using Couchbase.EntityFrameworkCore.Extensions;
 using Xunit;
 
 namespace Couchbase.EntityFrameworkCore.UnitTests.Couchbase.EntityFrameworkCore.Query;
@@ -13,8 +13,7 @@ public class CouchbaseQueryEnumerableTests
             """{"contactMethods":[{"id":1,"type":"email","value":"a@b.com"}]}""");
 
         // Search with PascalCase (as EF Core navigation name)
-        var found = CouchbaseQueryEnumerable<object>.TryGetPropertyCI(
-            json.RootElement, "ContactMethods", out var val);
+        var found = json.RootElement.TryGetPropertyCI("ContactMethods", out var val);
 
         Assert.True(found);
         Assert.Equal(JsonValueKind.Array, val.ValueKind);

--- a/tests/Couchbase.EntityFrameworkCore.UnitTests/Couchbase/EntityFrameworkCore/Storage/Internal/CouchbaseDbDataReaderTests.cs
+++ b/tests/Couchbase.EntityFrameworkCore.UnitTests/Couchbase/EntityFrameworkCore/Storage/Internal/CouchbaseDbDataReaderTests.cs
@@ -1932,6 +1932,86 @@ public class CouchbaseDbDataReaderTests
         Assert.Equal("alice", reader.GetValue(1));
     }
 
+    // GetValue — canonical-name O(1) path via _fieldOrdinals
+
+    [Fact]
+    public async Task GetValue_WithColumnNames_SchemaPreBuiltViaHasRows_CaseInsensitiveAliasResolves()
+    {
+        // Accessing HasRows before ReadAsync triggers EnsureFieldInfo (builds _fieldOrdinals).
+        // GetValue must still resolve the alias correctly via the pre-built _fieldOrdinals.
+        var rows = new List<JsonElement> { ParseElement("{\"blogId\": 99}") };
+        var reader = CreateReaderWithColumnNames(rows, new string?[] { "BlogId" });
+
+        _ = reader.HasRows; // triggers schema discovery before ReadAsync
+        await reader.ReadAsync(CancellationToken.None);
+
+        Assert.Equal(99L, reader.GetValue(0));
+    }
+
+    [Fact]
+    public async Task GetValue_WithColumnNames_MultipleRows_CanonicalNameUsedForEveryRow()
+    {
+        // _fieldOrdinals is built from the first row and reused for subsequent rows.
+        // Alias casing differs from JSON key on every row — all must resolve correctly.
+        var rows = new List<JsonElement>
+        {
+            ParseElement("{\"blogId\": 1}"),
+            ParseElement("{\"blogId\": 2}"),
+            ParseElement("{\"blogId\": 3}"),
+        };
+        var reader = CreateReaderWithColumnNames(rows, new string?[] { "BlogId" });
+
+        var results = new List<long>();
+        while (await reader.ReadAsync(CancellationToken.None))
+            results.Add((long)reader.GetValue(0));
+
+        Assert.Equal([1L, 2L, 3L], results);
+    }
+
+    [Fact]
+    public async Task GetValue_WithColumnNames_FieldPresentInFirstRowAbsentInLater_ReturnsDBNull()
+    {
+        // _fieldOrdinals maps "id" → 0 from the first row.
+        // A later row that lacks "id" must return DBNull rather than throw.
+        var rows = new List<JsonElement>
+        {
+            ParseElement("{\"id\": 10}"),
+            ParseElement("{\"other\": 99}"),
+        };
+        var reader = CreateReaderWithColumnNames(rows, new string?[] { "id" });
+
+        await reader.ReadAsync(CancellationToken.None);
+        Assert.Equal(10L, reader.GetValue(0));
+
+        await reader.ReadAsync(CancellationToken.None);
+        Assert.Equal(DBNull.Value, reader.GetValue(0));
+    }
+
+    [Fact]
+    public async Task GetValue_WithColumnNames_AliasNotInSchema_FallsBackToTryGetPropertyCI()
+    {
+        // When _fieldOrdinals does not contain the alias (alias added to _columnNames after
+        // the schema row), TryGetPropertyCI is the safety-net.  The schema is built from a
+        // first row that has no "extra" field; a second row that does exposes the fallback.
+        var rows = new List<JsonElement>
+        {
+            ParseElement("{\"id\": 1}"),
+            ParseElement("{\"id\": 2, \"Extra\": 42}"),
+        };
+        // Two slots: "id" appears in the schema; "extra" does not.
+        var reader = CreateReaderWithColumnNames(rows, new string?[] { "id", "extra" });
+
+        await reader.ReadAsync(CancellationToken.None);
+        Assert.Equal(1L, reader.GetValue(0));
+        Assert.Equal(DBNull.Value, reader.GetValue(1)); // "extra" absent from first row
+
+        await reader.ReadAsync(CancellationToken.None);
+        Assert.Equal(2L, reader.GetValue(0));
+        // "extra" absent from _fieldOrdinals (not in schema row) — TryGetPropertyCI fallback
+        // must find "Extra" case-insensitively and return 42.
+        Assert.Equal(42L, reader.GetValue(1));
+    }
+
     // GetOrdinal null-slot fallback — bounds check and null-slot guard
 
     [Fact]

--- a/tests/Couchbase.EntityFrameworkCore.UnitTests/Couchbase/EntityFrameworkCore/Storage/Internal/CouchbaseDbDataReaderTests.cs
+++ b/tests/Couchbase.EntityFrameworkCore.UnitTests/Couchbase/EntityFrameworkCore/Storage/Internal/CouchbaseDbDataReaderTests.cs
@@ -1894,6 +1894,88 @@ public class CouchbaseDbDataReaderTests
 
     #endregion
 
+    #region Phase 2 — TryGetPropertyCI and GetOrdinal null-slot guards
+
+    // GetValue — case-insensitive property lookup via TryGetPropertyCI
+
+    [Fact]
+    public async Task GetValue_WithColumnNames_CaseInsensitiveAlias_ReturnsValue()
+    {
+        // JSON has camelCase key; projection alias uses PascalCase — must still resolve.
+        var rows = new List<JsonElement> { ParseElement("{\"blogId\": 42}") };
+        var reader = CreateReaderWithColumnNames(rows, new string?[] { "BlogId" });
+        await reader.ReadAsync(CancellationToken.None);
+
+        Assert.Equal(42L, reader.GetValue(0));
+    }
+
+    [Fact]
+    public async Task GetValue_WithColumnNames_MissingJsonField_ReturnsDBNull()
+    {
+        // Alias present in projection but the JSON row does not contain the property.
+        var rows = new List<JsonElement> { ParseElement("{\"other\": 1}") };
+        var reader = CreateReaderWithColumnNames(rows, new string?[] { "missing" });
+        await reader.ReadAsync(CancellationToken.None);
+
+        Assert.Equal(DBNull.Value, reader.GetValue(0));
+    }
+
+    [Fact]
+    public async Task GetValue_WithColumnNames_MultipleAliases_ResolvesEachIndependently()
+    {
+        // Each alias resolves directly from the row — no intermediate ordinal mapping.
+        var rows = new List<JsonElement> { ParseElement("{\"name\": \"alice\", \"age\": 30}") };
+        var reader = CreateReaderWithColumnNames(rows, new string?[] { "age", "name" });
+        await reader.ReadAsync(CancellationToken.None);
+
+        Assert.Equal(30L, reader.GetValue(0));
+        Assert.Equal("alice", reader.GetValue(1));
+    }
+
+    // GetOrdinal null-slot fallback — bounds check and null-slot guard
+
+    [Fact]
+    public async Task GetOrdinal_NullSlotFallback_FieldBeyondProjectionWidth_Throws()
+    {
+        // JSON row has 3 fields; projection only covers 2 columns.
+        // GetOrdinal for the 3rd field name must throw — its ordinal (2) is >= FieldCount (2).
+        var rows = new List<JsonElement> { ParseElement("{\"a\": 1, \"b\": 2, \"c\": 3}") };
+        var reader = CreateReaderWithColumnNames(rows, new string?[] { "a", "b" });
+        await reader.ReadAsync(CancellationToken.None);
+
+        Assert.Throws<IndexOutOfRangeException>(() => reader.GetOrdinal("c"));
+    }
+
+    [Fact]
+    public async Task GetOrdinal_NullSlotFallback_NameMapsToNonNullSlot_Throws()
+    {
+        // JSON fields "a" and "b" map to ordinals 0 and 1.
+        // Both slots have non-null aliases, so neither "a" nor "b" should resolve
+        // via the null-slot fallback — they are not in _projectionOrdinals (aliases differ),
+        // and the null-slot guard must reject them.
+        var rows = new List<JsonElement> { ParseElement("{\"a\": 1, \"b\": 2}") };
+        var reader = CreateReaderWithColumnNames(rows, new string?[] { "ALIAS_A", "ALIAS_B" });
+        await reader.ReadAsync(CancellationToken.None);
+
+        Assert.Throws<IndexOutOfRangeException>(() => reader.GetOrdinal("a"));
+        Assert.Throws<IndexOutOfRangeException>(() => reader.GetOrdinal("b"));
+    }
+
+    [Fact]
+    public async Task GetOrdinal_NullSlotFallback_ValidNullSlot_ReturnsOrdinal()
+    {
+        // Slot 0 is a null slot; slot 1 has an alias. "a" maps to ordinal 0 (null slot) — valid.
+        // "b" maps to ordinal 1, but slot 1 is non-null, so it must be rejected.
+        var rows = new List<JsonElement> { ParseElement("{\"a\": 1, \"b\": 2}") };
+        var reader = CreateReaderWithColumnNames(rows, new string?[] { null, "ALIAS_B" });
+        await reader.ReadAsync(CancellationToken.None);
+
+        Assert.Equal(0, reader.GetOrdinal("a"));
+        Assert.Throws<IndexOutOfRangeException>(() => reader.GetOrdinal("b"));
+    }
+
+    #endregion
+
     private static JsonElement ParseElement(string json)
     {
         using var doc = JsonDocument.Parse(json);

--- a/tests/Couchbase.EntityFrameworkCore.UnitTests/Couchbase/EntityFrameworkCore/Storage/Internal/CouchbaseDbDataReaderTests.cs
+++ b/tests/Couchbase.EntityFrameworkCore.UnitTests/Couchbase/EntityFrameworkCore/Storage/Internal/CouchbaseDbDataReaderTests.cs
@@ -1923,7 +1923,7 @@ public class CouchbaseDbDataReaderTests
     [Fact]
     public async Task GetValue_WithColumnNames_MultipleAliases_ResolvesEachIndependently()
     {
-        // Each alias resolves directly from the row — no intermediate ordinal mapping.
+        // Each alias resolves via _fieldOrdinals to its canonical name, then exact property access.
         var rows = new List<JsonElement> { ParseElement("{\"name\": \"alice\", \"age\": 30}") };
         var reader = CreateReaderWithColumnNames(rows, new string?[] { "age", "name" });
         await reader.ReadAsync(CancellationToken.None);


### PR DESCRIPTION
…yCI lookup

In the _columnNames path of GetValue, remove the three-step alias → _fieldOrdinals → _fieldNames round-trip that arrived back at the same string it started with. Replace with a single case-insensitive property lookup on the current JsonElement row via a new TryGetPropertyCI helper. Also remove the redundant _columnNames[jsonOrd] == null constraint in the GetOrdinal null-slot fallback — any name that reaches that branch cannot be a non-null slot alias, so the check was always true.