### PR TITLE
Phase 3 — Remove Schema-Discovery Infrastructure

### DIFF
--- a/specs/datareader-refactor.md
+++ b/specs/datareader-refactor.md
@@ -165,7 +165,7 @@ the first `ReadAsync` call. Reader construction is O(1); the single async peek h
 
 ## Post-phase-3 corrections
 
-Four defects were identified and fixed after the phase 3 commit landed.
+Nine defects were identified and fixed after the phase 3 commit landed.
 
 ### 1 — `DbCommand.Cancel()` not propagating to the row enumerator
 
@@ -217,6 +217,55 @@ the existing positional path.
 Fix: change the parameter type to `string?[]?` and make alias setup conditional on non-null,
 leaving `_columnNames` and `_projectionOrdinals` as `null` (positional path) when `null` is
 passed. Replace the `ArgumentNullException` test with one that verifies the positional fallback.
+
+### 5 — Non-`JsonElement` row types surfacing as `DBNull` / `IndexOutOfRangeException`
+
+The class-level remarks documented `NotSupportedException` for non-`JsonElement` rows, but
+`ReadAsync` and `PrimeAsync` assigned `_currentRow = _enumerator.Current` without validating
+the type, so incompatible rows silently flowed through and surfaced as incorrect values later.
+
+Fix: add `private static T ValidateRow(T row)` which throws `NotSupportedException` (with an
+actionable message) when `row` is non-null and not a `JsonElement`. Called at both
+materialization points: `_currentRow = ValidateRow(...)` in `ReadAsync` and
+`_bufferedFirstRow = ValidateRow(...)` in `PrimeAsync`. `null` is allowed (see correction 7).
+
+### 6 — `GetSchemaTable` returning empty table for scalar `SELECT RAW` rows
+
+In the no-column-names path, `GetSchemaTable` only added rows for `JsonValueKind.Object`; a
+non-object scalar `JsonElement` (e.g. `SELECT RAW 5`) produced an empty `DataTable`,
+inconsistent with `FieldCount == 1` and `GetName(0) == ""`.
+
+Fix: restructure the outer condition to `if (je.ValueKind == JsonValueKind.Object) { ... } else { scalar row }`,
+emitting one row (`ColumnName=""`, `ColumnOrdinal=0`) for any non-object result.
+
+### 7 — Null rows (`SELECT RAW null`) treated as zero-column in positional path
+
+`ValidateRow` permits `null` rows (valid for `SELECT RAW null`), but six methods in the
+no-column-names positional path treated a null `_currentRow` as a zero-column row:
+`FieldCount` returned 0, `GetValue`/`GetName`/`GetOrdinal` threw `IndexOutOfRangeException`
+for ordinal 0, `GetValues` computed `fieldCount = 0`, and `GetSchemaTable` returned an empty
+table.
+
+Fix: unify the scalar and null branches in all six methods so a null row behaves identically
+to a non-object scalar `JsonElement`: one column, `GetName(0) = ""`, `GetValue(0) = DBNull.Value`,
+`GetOrdinal(any) = 0`, `FieldCount = 1`, `GetSchemaTable` emits one row.
+
+### 8 — `GetName` null-slot throwing `IndexOutOfRangeException` for scalar/null rows at ordinal 0
+
+In the `_columnNames` + null-slot branch, `GetName` only handled object rows; a scalar or null
+`_currentRow` fell through to `IndexOutOfRangeException` even for ordinal 0, inconsistent with
+`GetValue` (which returned the scalar/`DBNull`) and the no-column-names path (which returned `""`).
+
+Fix: add `else if (ordinal == 0) return string.Empty;` after the object-enumeration block,
+covering both scalar and null rows at null-slot position 0.
+
+### 9 — `GetOrdinal` null-slot throwing `IndexOutOfRangeException` for scalar/null rows
+
+The same gap as correction 8 but in `GetOrdinal`'s null-slot branch: a scalar or null row
+fell through to `IndexOutOfRangeException("Field not found")` rather than returning 0,
+inconsistent with the no-column-names scalar path which maps any name to ordinal 0.
+
+Fix: add `else return 0;` after the object-enumeration block, mirroring correction 8.
 
 ---
 

--- a/specs/datareader-refactor.md
+++ b/specs/datareader-refactor.md
@@ -269,6 +269,97 @@ Fix: add `else return 0;` after the object-enumeration block, mirroring correcti
 
 ---
 
+## Pre-phase-4 code review fixes
+
+Nine additional items were raised in a code review after the post-phase-3 corrections landed.
+
+### 1 — `_queryResult` never disposed
+
+`IQueryResult<T>` (`BlockQueryResult<T>`) holds buffered rows and the underlying HTTP response
+stream. Neither `Close` nor `CloseAsync` released it, leaving the stream open until GC
+finalization.
+
+Fix: dispose the query result after the enumerator in both paths. `CloseAsync` prefers
+`IAsyncDisposable`; `Close` falls back to `IDisposable` via pattern matching.
+
+### 2 — `PrimeAsync` failure leaves enumerator in partially-primed state
+
+If `MoveNextAsync` threw inside `PrimeAsync` (e.g. a cluster error mid-fetch), none of
+`_hasRows`, `_hasBufferedRow`, or `_hasCurrentRow` was set, but `_enumerator` was already
+created. A second `PrimeAsync` call missed the idempotency guard and re-advanced the broken
+enumerator.
+
+Fix: wrap the `MoveNextAsync` body in `try/catch`; set `_hasRows = false` in the catch before
+re-throwing. This poisons the idempotency guard (`_hasRows.HasValue`) so re-entry returns
+immediately. Two new tests cover the failure path.
+
+### 3 — `SetLinkedCts` had no null or double-call guards
+
+A second `SetLinkedCts` call silently leaked the prior `CancellationTokenSource`, retargeting
+`DbCommand.Cancel()` to the wrong source for the remainder of the reader's lifetime.
+
+Fix: add `ArgumentNullException.ThrowIfNull(cts)` and an `InvalidOperationException` on
+double-call. Three tests cover null, double-call, and the happy path.
+
+### 4 — 4-arg constructor accepted but discarded `CancellationToken`
+
+The XML doc admitted "Unused at construction; reserved for future use." Callers
+(`CouchbaseCommand`) passed `linkedCts.Token` at construction expecting it to be used, but
+it was silently ignored — only the token re-passed to `PrimeAsync` actually reached the
+enumerator.
+
+Fix (Option B): store the token in `_cancellationToken` at construction. `EnsureEnumerator`
+uses it as a fallback when called with `CancellationToken.None`, so callers that pass a token
+at construction and later call `ReadAsync(CancellationToken.None)` see correct cancellation
+propagation without needing to re-pass the token. Documented with an `[EnumeratorCancellation]`
+test that verifies the stored token actually reaches the enumerator.
+
+### 5 — `FieldCount` re-walked JSON on every call (positional path)
+
+On the no-column-names positional path, `FieldCount` called `je.EnumerateObject().Count()`
+on every access, re-walking the object each time. Repeated calls per row (e.g. from
+`GetSchemaTable` or user code) each paid the O(m) cost.
+
+Fix: add `_cachedFieldCount` (int, sentinel −1). `FieldCount` populates it lazily on first
+access after each row advance; `ReadAsync` resets it to −1 at the top of every advance attempt.
+The `_columnNames` path (EF Core primary consumer) is unaffected — it returns
+`_columnNames.Length` directly and never reaches the cache.
+
+### 6 — Sync-over-async on `Close()` and `Read()` (documented, not yet fixed)
+
+`Close()` calls `_enumerator?.DisposeAsync().AsTask().GetAwaiter().GetResult()`, and `Read()`
+calls `ReadAsync().GetAwaiter().GetResult()`. Both can deadlock on a UI thread with a captured
+`SynchronizationContext`.
+
+Assessment: `Read()` mirrors the base-class default; EF Core never calls it. `Close()` is
+reachable via `using var reader = ...` (sync `Dispose()`) even in async callers. Routing
+`Close()` through `AsyncHelper.RunSync` (consistent with `CouchbaseCommand`'s sync methods)
+is the recommended fix. Not yet applied; tracked for a follow-up commit.
+
+### 7 — No regression test for `DbCommand.Cancel()` CTS ownership-transfer fix
+
+The headline fix (CTS ownership transfer so `Cancel()` reaches the enumerator for the
+reader's lifetime) had no direct test coverage. The `PrimeAsync_WithCancelledToken_*` tests
+only exercise the reader directly; nothing went through `CouchbaseCommand`.
+
+Fix: `Cancel_AfterExecuteReaderAsync_FaultsNextReadAsync` added to `CouchbaseCommandTests`.
+Uses a `[EnumeratorCancellation]`-annotated async iterator so the token injected via
+`GetAsyncEnumerator(linkedCts.Token)` is actually checked during `MoveNextAsync`. The
+external token is `CancellationToken.None` so the only cancellation source is `command.Cancel()`.
+
+### 8 — No tests for `PrimeAsync` + `Close`/`CloseAsync` without `ReadAsync`
+
+Closing a primed reader without ever calling `ReadAsync` had no coverage — the buffered first
+row and linked CTS cleanup path was untested.
+
+Fix: four tests added to the `PrimeAsync` region:
+- `CloseAsync` leaves `IsClosed = true` with no exception
+- `CloseAsync` → `ReadAsync` returns `false` (closed-reader contract)
+- `Close()` disposes the linked CTS (`Cancel()` on it throws `ObjectDisposedException`)
+- `DisposeAsync()` disposes the linked CTS via the async path
+
+---
+
 ## Phase 4 — Pre-Build Per-Row Ordinal → Value Array in `ReadAsync`
 
 **Goal:** Make `GetValue(ordinal)` O(1) — a single array dereference — by amortizing the JSON
@@ -276,7 +367,8 @@ property scan over the whole row on read.
 
 ### Current per-row cost
 
-After phase 3, `GetValue(ordinal)` on the EF Core path is:
+After phase 3 and the pre-phase-4 code review fixes, `GetValue(ordinal)` on the EF Core path
+(`_columnNames` set) is:
 
 ```
 _columnNames[ordinal]          // O(1) array read → alias string
@@ -291,6 +383,10 @@ k calls × O(m) TryGetPropertyCI scan = O(k × m) per row
 ```
 
 For a typical entity with 10 columns and 10 properties this is 100 string comparisons per row.
+
+Note: `FieldCount` on the positional path (`_columnNames == null`) was improved to O(1) after
+the first call per row via `_cachedFieldCount`. That optimization does not affect the EF Core
+hot path described here, which returns `_columnNames.Length` directly.
 
 ### Proposed approach
 
@@ -317,17 +413,22 @@ return element.HasValue ? ConvertJsonElement(element.Value) : DBNull.Value;
 - `_projectionOrdinals` (built at construction, `OrdinalIgnoreCase`) drives the name → ordinal
   mapping during the per-row scan.
 
-### `GetValues` O(m²) fix
+### `GetValues` O(m²) fix (column-names path)
 
-`GetValues` currently calls `GetValue(i)` in a loop. For the no-column-names (positional) path
-and for null-slot columns in the column-names path, each `GetValue` call re-enumerates the
-`JsonElement` properties from the start, making `GetValues` O(m²) for an object row with `m`
-properties.
+`GetValues` calls `GetValue(i)` in a loop. On the column-names path, each `GetValue` call
+currently re-scans the `JsonElement` properties from the start via `TryGetPropertyCI`, making
+`GetValues` O(k × m) — equivalent to the per-row cost above.
 
 Once `_currentValues` is populated in `ReadAsync`, `GetValue(ordinal)` becomes an O(1) array
 read, so `GetValues` naturally degrades to O(k) with no changes to its own implementation.
 No targeted fix to `GetValues` is needed; the improvement is a free consequence of the
 `_currentValues` array.
+
+Note: the positional path (`_columnNames == null`) is not covered by Phase 4. `GetValues` on
+that path remains O(m²) — each `GetValue(i)` re-walks the JSON properties from the start.
+`FieldCount` is now O(1) after the first call per row (via `_cachedFieldCount`), but individual
+`GetValue` calls still pay the O(m) scan. A future phase could extend `_currentValues` to the
+positional path, but the positional path is not used by EF Core.
 
 ### Expected outcome
 

--- a/specs/datareader-refactor.md
+++ b/specs/datareader-refactor.md
@@ -116,8 +116,9 @@ always provided so this infrastructure is never needed.
 
 ### Changes
 
-- Make `columnNames` a required constructor parameter. Add a guard that throws
-  `ArgumentNullException` if null. Remove the optional overload that omits it.
+- Make `columnNames` an optional parameter on the 2-arg constructor (`string?[]?`). A non-null
+  array sets up the alias mapping; `null` falls through to the raw positional path, identical to
+  using the 4-arg constructor. Remove the optional overload that omits it entirely.
 
 - Delete the following fields and their associated logic:
   - `_bufferedRow`, `_hasBufferedRow` — first-row buffer
@@ -159,6 +160,63 @@ To satisfy the ADO.NET contract without reintroducing the sync-over-async call:
 Approximately 150 lines removed. The sync-over-async call is gone. `HasRows` is accurate before
 the first `ReadAsync` call. Reader construction is O(1); the single async peek happens in
 `PrimeAsync` on the command path. Six `PrimeAsync`-specific tests were added.
+
+---
+
+## Post-phase-3 corrections
+
+Four defects were identified and fixed after the phase 3 commit landed.
+
+### 1 — `DbCommand.Cancel()` not propagating to the row enumerator
+
+`PrimeAsync` was invoked with the caller's external `cancellationToken` rather than
+`linkedCts.Token`, so the enumerator was bound to a token that `Cancel()` could never reach.
+Additionally, `linkedCts` was declared with `using var` in `ExecuteDbDataReaderAsync`, which
+disposed the link between `_cancellationTokenSource` and the enumerator's token as soon as the
+method returned — making the fix incomplete even if the token were corrected.
+
+Fix:
+- Pass `linkedCts.Token` to both the reader constructor and `PrimeAsync`.
+- Drop `using` from `var linkedCts`; transfer ownership to the reader via `SetLinkedCts(cts)`.
+- Reader disposes the linked CTS in `Close` / `CloseAsync`.
+- Guard the setup path so `linkedCts` is always disposed on failure (via the reader if it was
+  created, directly otherwise).
+
+### 2 — `PrimeAsync` not idempotent
+
+A second `PrimeAsync` call advanced the underlying enumerator again and overwrote the buffered
+first row, silently dropping data.
+
+Fix: add an early-return guard at the top of `PrimeAsync`:
+```csharp
+if (_hasRows.HasValue || _hasBufferedRow || _hasCurrentRow)
+    return;
+```
+Two tests cover double-prime and prime-after-read scenarios.
+
+### 3 — `GetName` / `GetOrdinal` null-slot throwing wrong exception before first `Read`
+
+In the column-names path, both methods used `if (_hasCurrentRow && ...)` to gate positional
+resolution. When no row had been read the condition was false and they fell through to
+`IndexOutOfRangeException("... not found")` even when the ordinal/name was in range. The
+correct exception for a missing current row is `InvalidOperationException`.
+
+Fix: replace the `_hasCurrentRow` guard with `EnsureCurrentRow()` in both methods, consistent
+with the no-column-names path and each method's own remarks.
+
+### 4 — 2-arg constructor rejecting `null` `columnNames`
+
+`CouchbaseQueryEnumerable` computes column names as:
+```csharp
+var columnNames = _projectionAliases ?? _readerColumns?.Select(rc => rc?.Name).ToArray();
+```
+When both sources are `null` this produces `null`, which the original constructor rejected with
+`ArgumentNullException`. Null is a legitimate "no alias mapping" state that should route through
+the existing positional path.
+
+Fix: change the parameter type to `string?[]?` and make alias setup conditional on non-null,
+leaving `_columnNames` and `_projectionOrdinals` as `null` (positional path) when `null` is
+passed. Replace the `ArgumentNullException` test with one that verifies the positional fallback.
 
 ---
 

--- a/specs/datareader-refactor.md
+++ b/specs/datareader-refactor.md
@@ -268,8 +268,20 @@ return element.HasValue ? ConvertJsonElement(element.Value) : DBNull.Value;
 - `_projectionOrdinals` (built at construction, `OrdinalIgnoreCase`) drives the name → ordinal
   mapping during the per-row scan.
 
+### `GetValues` O(m²) fix
+
+`GetValues` currently calls `GetValue(i)` in a loop. For the no-column-names (positional) path
+and for null-slot columns in the column-names path, each `GetValue` call re-enumerates the
+`JsonElement` properties from the start, making `GetValues` O(m²) for an object row with `m`
+properties.
+
+Once `_currentValues` is populated in `ReadAsync`, `GetValue(ordinal)` becomes an O(1) array
+read, so `GetValues` naturally degrades to O(k) with no changes to its own implementation.
+No targeted fix to `GetValues` is needed; the improvement is a free consequence of the
+`_currentValues` array.
+
 ### Expected outcome
 
 Per-row cost changes from O(k × m) to O(m + k). `GetValue` is a bounds-checked array read with
-no string comparisons. At 100 rows × 10 columns × 10 properties the total comparisons drop from
-10,000 to ~1,000.
+no string comparisons. `GetValues` drops from O(m²) to O(k). At 100 rows × 10 columns × 10
+properties the total comparisons drop from 10,000 to ~1,000.

--- a/specs/datareader-refactor.md
+++ b/specs/datareader-refactor.md
@@ -6,6 +6,7 @@
 `IQueryResult<JsonElement>` and EF Core's compiled shapers. It was built incrementally alongside
 the query pipeline and has accumulated complexity for code paths that never execute in the
 provider. This document describes four sequential phases to simplify and optimize it.
+Phases 1–3 are complete. Phase 4 is the next planned work.
 
 The EF Core shaper is the sole consumer of this reader. It calls typed getters by projection
 ordinal (e.g. `GetInt32(3)`, `GetString(7)`) for every column of every result row. The
@@ -14,7 +15,9 @@ projection aliases (`_columnNames`) are always supplied by `CouchbaseQueryEnumer
 
 ---
 
-## Phase 1 — Remove Dead Code Paths
+## Phase 1 — Remove Dead Code Paths ✓
+
+**Status: Complete**
 
 **Goal:** Delete code that never executes. No behavioral change.
 
@@ -41,7 +44,7 @@ projection aliases (`_columnNames`) are always supplied by `CouchbaseQueryEnumer
 
 - Remove `ExtractFirstValueFromObject` and `ExtractFirstValueFromArray` once the above is done.
 
-### Expected outcome
+### Actual outcome
 
 Approximately 50 lines removed. The remaining code reflects only what actually runs in the
 provider. Five tests required updates: the `IsType<CouchbaseDbDataReader<object>>` assertions
@@ -51,7 +54,9 @@ test also needed its N1QL query corrected from an invalid subquery alias to `UNI
 
 ---
 
-## Phase 2 — Eliminate the `_fieldOrdinals` Indirection
+## Phase 2 — Eliminate the `_fieldOrdinals` Indirection ✓
+
+**Status: Complete**
 
 **Goal:** Shorten the `GetValue` hot path from five steps to two. Logically equivalent to current
 behavior.
@@ -91,16 +96,20 @@ two allocations and two lookups without changing the result.
   ensures non-null aliases that somehow bypass `_projectionOrdinals` are rejected rather than
   silently returned. Only the stale comment above the block needs updating.
 
-### Expected outcome
+### Actual outcome
 
-`GetValue` hot path (non-null `_columnNames` slot): array lookup → `_fieldOrdinals` dict lookup
-→ exact `TryGetProperty`. One dictionary lookup replaces two (dict + array); the O(m) linear scan
-is eliminated for the common case. `TryGetPropertyCI` is the fallback for unknown aliases only.
-Approximately 15–20 lines removed from `GetValue`; `GetOrdinal` is comment-only cleanup.
+The intermediate phase 2 fast path (array lookup → `_fieldOrdinals` dict → exact `TryGetProperty`)
+was implemented and then superseded when phase 3 removed `_fieldOrdinals` and `_fieldNames`
+entirely. The final hot path is: `_columnNames[ordinal]` → `je.TryGetPropertyCI(colName)` →
+`ConvertJsonElement`. `TryGetPropertyCI` (extracted to `JsonElementExtensions`) handles
+case-insensitive matching directly on the alias, eliminating the round-trip through the old
+ordinal maps. Approximately 15–20 lines removed; `GetOrdinal` received comment-only cleanup.
 
 ---
 
-## Phase 3 — Remove Schema-Discovery Infrastructure
+## Phase 3 — Remove Schema-Discovery Infrastructure ✓
+
+**Status: Complete**
 
 **Goal:** Delete the first-row peek, buffering, and field-metadata machinery. `_columnNames` is
 always provided so this infrastructure is never needed.
@@ -120,20 +129,36 @@ always provided so this infrastructure is never needed.
   sync-over-async call in the reader (`MoveNextAsync().AsTask().GetAwaiter().GetResult()`).
 
 - Simplify the properties that previously triggered schema discovery:
-  - `HasRows` — cannot be known until `ReadAsync` is called; return `_hasRows ?? false`
-    (populated on first `ReadAsync`) with no peeking.
+  - `HasRows` — see deviation note below.
   - `FieldCount` — `_columnNames.Length`.
   - `GetName(ordinal)` — `_columnNames[ordinal]`.
   - `GetOrdinal(name)` — `_projectionOrdinals[name]` (dictionary built at construction).
 
-- Update `CouchbaseDbDataReaderTests`. Tests that call `HasRows` or `FieldCount` before `ReadAsync`
-  should be adjusted to call `ReadAsync` first, or updated to reflect that `HasRows` returns false
-  until the first read.
+- Update `CouchbaseDbDataReaderTests`. Tests that previously relied on `HasRows` before
+  `ReadAsync` were updated for the new `PrimeAsync` contract (see deviation below).
 
-### Expected outcome
+### Deviation: `HasRows` and `PrimeAsync`
 
-Approximately 150 lines removed. The sync-over-async call is gone. The reader's construction is
-O(1) — no first-row read, no buffering, no schema inference.
+The spec called for `HasRows` to return `_hasRows ?? false` until the first `ReadAsync` call.
+In practice EF Core reads `HasRows` immediately after `ExecuteReaderAsync` returns, before
+calling `ReadAsync`, so returning `false` caused silent empty-result materialisation.
+
+To satisfy the ADO.NET contract without reintroducing the sync-over-async call:
+
+- `internal Task PrimeAsync(CancellationToken)` was added to the reader. It eagerly advances
+  the enumerator to the first row, stores the row in `_bufferedFirstRow`, sets `_hasBufferedRow`,
+  and records `_hasRows = true/false`.
+- `CouchbaseCommand.ExecuteDbDataReaderAsync` calls `PrimeAsync` immediately after constructing
+  the reader, before returning it.
+- `ReadAsync` checks `_hasBufferedRow` first; if set it drains the buffer (returns the buffered
+  row, clears the fields) rather than calling `MoveNextAsync` again. This ensures the first row
+  is never skipped.
+
+### Actual outcome
+
+Approximately 150 lines removed. The sync-over-async call is gone. `HasRows` is accurate before
+the first `ReadAsync` call. Reader construction is O(1); the single async peek happens in
+`PrimeAsync` on the command path. Six `PrimeAsync`-specific tests were added.
 
 ---
 
@@ -144,10 +169,18 @@ property scan over the whole row on read.
 
 ### Current per-row cost
 
+After phase 3, `GetValue(ordinal)` on the EF Core path is:
+
+```
+_columnNames[ordinal]          // O(1) array read → alias string
+je.TryGetPropertyCI(alias)     // O(m) linear scan of JsonElement properties
+ConvertJsonElement(prop)       // O(1)
+```
+
 For a row with `m` JSON properties and a shaper that reads `k` columns:
 
 ```
-k calls × O(m) TryGetProperty scan = O(k × m) per row
+k calls × O(m) TryGetPropertyCI scan = O(k × m) per row
 ```
 
 For a typical entity with 10 columns and 10 properties this is 100 string comparisons per row.

--- a/src/Couchbase.EntityFrameworkCore/Storage/Internal/CouchbaseCommand.cs
+++ b/src/Couchbase.EntityFrameworkCore/Storage/Internal/CouchbaseCommand.cs
@@ -184,15 +184,29 @@ public class CouchbaseCommand : DbCommand
         CommandBehavior behavior,
         CancellationToken cancellationToken)
     {
-        using var linkedCts = CreateLinkedTokenSource(cancellationToken);
-        var options = BuildQueryOptions(linkedCts.Token);
+        // linkedCts is not disposed here — ownership transfers to the reader so that
+        // Cancel() keeps propagating to the enumerator for the reader's full lifetime.
+        var linkedCts = CreateLinkedTokenSource(cancellationToken);
+        CouchbaseDbDataReader<JsonElement>? reader = null;
+        try
+        {
+            var options = BuildQueryOptions(linkedCts.Token);
+            var cluster = ResolveCluster();
+            var queryResult = await cluster.QueryAsync<JsonElement>(CommandText, options).ConfigureAwait(false);
 
-        var cluster = ResolveCluster();
-        var queryResult = await cluster.QueryAsync<JsonElement>(CommandText, options).ConfigureAwait(false);
-
-        var reader = new CouchbaseDbDataReader<JsonElement>(queryResult, DbConnection, behavior, cancellationToken);
-        await reader.PrimeAsync(cancellationToken).ConfigureAwait(false);
-        return reader;
+            reader = new CouchbaseDbDataReader<JsonElement>(queryResult, DbConnection, behavior, linkedCts.Token);
+            reader.SetLinkedCts(linkedCts);
+            await reader.PrimeAsync(linkedCts.Token).ConfigureAwait(false);
+            return reader;
+        }
+        catch
+        {
+            if (reader != null)
+                await reader.DisposeAsync().ConfigureAwait(false); // also disposes linkedCts
+            else
+                linkedCts.Dispose();
+            throw;
+        }
     }
 
     protected override void Dispose(bool disposing)

--- a/src/Couchbase.EntityFrameworkCore/Storage/Internal/CouchbaseCommand.cs
+++ b/src/Couchbase.EntityFrameworkCore/Storage/Internal/CouchbaseCommand.cs
@@ -190,7 +190,9 @@ public class CouchbaseCommand : DbCommand
         var cluster = ResolveCluster();
         var queryResult = await cluster.QueryAsync<JsonElement>(CommandText, options).ConfigureAwait(false);
 
-        return new CouchbaseDbDataReader<JsonElement>(queryResult, DbConnection, behavior, cancellationToken);
+        var reader = new CouchbaseDbDataReader<JsonElement>(queryResult, DbConnection, behavior, cancellationToken);
+        await reader.PrimeAsync(cancellationToken).ConfigureAwait(false);
+        return reader;
     }
 
     protected override void Dispose(bool disposing)

--- a/src/Couchbase.EntityFrameworkCore/Storage/Internal/CouchbaseDbDataReader.cs
+++ b/src/Couchbase.EntityFrameworkCore/Storage/Internal/CouchbaseDbDataReader.cs
@@ -381,8 +381,9 @@ public class CouchbaseDbDataReader<T> : DbDataReader
 
         if (_columnNames != null)
         {
-            // Null-slot fallback: find a JSON field with this name at a null-slot position.
-            if (_hasCurrentRow && _currentRow is JsonElement je && je.ValueKind == JsonValueKind.Object)
+            // Null-slot fallback: positional resolution requires a current row.
+            EnsureCurrentRow();
+            if (_currentRow is JsonElement je && je.ValueKind == JsonValueKind.Object)
             {
                 var i = 0;
                 foreach (var prop in je.EnumerateObject())

--- a/src/Couchbase.EntityFrameworkCore/Storage/Internal/CouchbaseDbDataReader.cs
+++ b/src/Couchbase.EntityFrameworkCore/Storage/Internal/CouchbaseDbDataReader.cs
@@ -222,6 +222,11 @@ public class CouchbaseDbDataReader<T> : DbDataReader
     {
         if (_enumerator == null)
         {
+            // The token is bound at GetAsyncEnumerator() time and cannot be retargeted.
+            // All callers must pass the same long-lived token (e.g. linkedCts.Token from
+            // CouchbaseCommand) so that CancellationToken bindings remain consistent for
+            // the reader's lifetime.  Tokens passed to subsequent ReadAsync calls only
+            // affect the upfront ThrowIfCancellationRequested check, not in-flight MoveNextAsync.
             _cancellationToken = cancellationToken;
             _enumerator = _queryResult.Rows.GetAsyncEnumerator(_cancellationToken);
         }
@@ -233,6 +238,13 @@ public class CouchbaseDbDataReader<T> : DbDataReader
     /// ADO.NET <see cref="DbDataReader.HasRows"/> contract.  Called by <see cref="CouchbaseCommand"/>
     /// immediately after constructing the reader.
     /// </summary>
+    /// <remarks>
+    /// The token passed here binds the underlying enumerator for the reader's lifetime (see
+    /// <c>EnsureEnumerator</c>).  <see cref="CouchbaseCommand"/> passes <c>linkedCts.Token</c>,
+    /// which combines the external caller token with the command's internal cancellation source,
+    /// ensuring <c>DbCommand.Cancel()</c> and external cancellation both propagate correctly.
+    /// Future callers must pass the same or an equivalent long-lived token.
+    /// </remarks>
     internal async Task PrimeAsync(CancellationToken cancellationToken)
     {
         cancellationToken.ThrowIfCancellationRequested();

--- a/src/Couchbase.EntityFrameworkCore/Storage/Internal/CouchbaseDbDataReader.cs
+++ b/src/Couchbase.EntityFrameworkCore/Storage/Internal/CouchbaseDbDataReader.cs
@@ -130,8 +130,18 @@ public class CouchbaseDbDataReader<T> : DbDataReader
     /// Gets a value indicating whether the result set contains one or more rows.
     /// </summary>
     /// <remarks>
-    /// Returns <c>false</c> before the first <see cref="Read"/> call. Set to <c>true</c> on the
-    /// first successful read and remains constant thereafter.
+    /// <para>
+    /// <b>Primed path (<see cref="CouchbaseCommand"/>):</b> <see cref="CouchbaseCommand"/>
+    /// calls <see cref="PrimeAsync"/> immediately after constructing the reader, which advances
+    /// to the first row and sets this property before the reader is returned to the caller.
+    /// <c>HasRows</c> is therefore accurate before the first <see cref="Read"/> call.
+    /// </para>
+    /// <para>
+    /// <b>Unprimed path (direct construction):</b> When the reader is constructed without a
+    /// subsequent <see cref="PrimeAsync"/> call, <c>HasRows</c> returns <c>false</c> until the
+    /// first <see cref="ReadAsync"/> call populates it.
+    /// </para>
+    /// Once set, the value does not change.
     /// </remarks>
     public override bool HasRows => _hasRows ?? false;
 

--- a/src/Couchbase.EntityFrameworkCore/Storage/Internal/CouchbaseDbDataReader.cs
+++ b/src/Couchbase.EntityFrameworkCore/Storage/Internal/CouchbaseDbDataReader.cs
@@ -251,16 +251,27 @@ public class CouchbaseDbDataReader<T> : DbDataReader
         if (_hasRows.HasValue || _hasBufferedRow || _hasCurrentRow)
             return;
         EnsureEnumerator(cancellationToken);
-        var hasMore = await _enumerator!.MoveNextAsync().ConfigureAwait(false);
-        if (hasMore)
+        try
         {
-            _bufferedFirstRow = ValidateRow(_enumerator.Current);
-            _hasBufferedRow = true;
-            _hasRows = true;
+            var hasMore = await _enumerator!.MoveNextAsync().ConfigureAwait(false);
+            if (hasMore)
+            {
+                _bufferedFirstRow = ValidateRow(_enumerator.Current);
+                _hasBufferedRow = true;
+                _hasRows = true;
+            }
+            else
+            {
+                _hasRows = false;
+            }
         }
-        else
+        catch
         {
+            // Poison the idempotency guard so a second PrimeAsync call cannot re-advance
+            // the enumerator on a broken stream.  HasRows == false is accurate: no rows
+            // are readable from a result whose first fetch threw.
             _hasRows = false;
+            throw;
         }
     }
 

--- a/src/Couchbase.EntityFrameworkCore/Storage/Internal/CouchbaseDbDataReader.cs
+++ b/src/Couchbase.EntityFrameworkCore/Storage/Internal/CouchbaseDbDataReader.cs
@@ -65,24 +65,27 @@ public class CouchbaseDbDataReader<T> : DbDataReader
     private bool _isClosed;
 
     /// <summary>
-    /// Initializes a new instance of the <see cref="CouchbaseDbDataReader{T}"/> class with a
-    /// column-name mapping. The <paramref name="columnNames"/> array must contain the SELECT-clause
-    /// alias for each EF Core <c>readerColumn</c> in order; <c>null</c> elements use positional
-    /// mapping (resolved from the current row after <see cref="ReadAsync"/>).
+    /// Initializes a new instance of the <see cref="CouchbaseDbDataReader{T}"/> class with an
+    /// optional column-name mapping. When <paramref name="columnNames"/> is non-null it must
+    /// contain the SELECT-clause alias for each EF Core <c>readerColumn</c> in order; <c>null</c>
+    /// elements within the array use positional mapping (resolved from the current row after
+    /// <see cref="ReadAsync"/>).  When <paramref name="columnNames"/> itself is <c>null</c> the
+    /// reader operates in the raw positional path (same behaviour as the 4-argument constructor).
     /// </summary>
-    /// <exception cref="ArgumentNullException">
-    /// Thrown when <paramref name="queryResult"/> or <paramref name="columnNames"/> is null.
-    /// </exception>
-    public CouchbaseDbDataReader(IQueryResult<T> queryResult, string?[] columnNames)
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="queryResult"/> is null.</exception>
+    public CouchbaseDbDataReader(IQueryResult<T> queryResult, string?[]? columnNames)
         : this(queryResult, null, CommandBehavior.Default, CancellationToken.None)
     {
-        _columnNames = columnNames ?? throw new ArgumentNullException(nameof(columnNames));
-        _projectionOrdinals = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
-        for (var i = 0; i < columnNames.Length; i++)
+        if (columnNames != null)
         {
-            var alias = columnNames[i];
-            if (alias != null)
-                _projectionOrdinals.TryAdd(alias, i);
+            _columnNames = columnNames;
+            _projectionOrdinals = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
+            for (var i = 0; i < columnNames.Length; i++)
+            {
+                var alias = columnNames[i];
+                if (alias != null)
+                    _projectionOrdinals.TryAdd(alias, i);
+            }
         }
     }
 

--- a/src/Couchbase.EntityFrameworkCore/Storage/Internal/CouchbaseDbDataReader.cs
+++ b/src/Couchbase.EntityFrameworkCore/Storage/Internal/CouchbaseDbDataReader.cs
@@ -49,6 +49,9 @@ public class CouchbaseDbDataReader<T> : DbDataReader
     private IAsyncEnumerator<T>? _enumerator;
     private CancellationToken _cancellationToken;
     private T? _currentRow;
+    // First-row buffer populated by PrimeAsync so HasRows is accurate before ReadAsync.
+    private T? _bufferedFirstRow;
+    private bool _hasBufferedRow;
 
     /// <summary>
     /// Gets the current row as read by the last <see cref="ReadAsync"/> call.
@@ -169,6 +172,17 @@ public class CouchbaseDbDataReader<T> : DbDataReader
             return false;
 
         cancellationToken.ThrowIfCancellationRequested();
+
+        // If PrimeAsync buffered the first row, return it without re-advancing the enumerator.
+        if (_hasBufferedRow)
+        {
+            _currentRow = _bufferedFirstRow!;
+            _bufferedFirstRow = default;
+            _hasBufferedRow = false;
+            _hasCurrentRow = true;
+            return true;
+        }
+
         EnsureEnumerator(cancellationToken);
 
         var hasMore = await _enumerator!.MoveNextAsync().ConfigureAwait(false);
@@ -194,6 +208,29 @@ public class CouchbaseDbDataReader<T> : DbDataReader
         {
             _cancellationToken = cancellationToken;
             _enumerator = _queryResult.Rows.GetAsyncEnumerator(_cancellationToken);
+        }
+    }
+
+    /// <summary>
+    /// Asynchronously advances to the first row and buffers it so that <see cref="HasRows"/>
+    /// returns the correct value before the first <see cref="ReadAsync"/> call, satisfying the
+    /// ADO.NET <see cref="DbDataReader.HasRows"/> contract.  Called by <see cref="CouchbaseCommand"/>
+    /// immediately after constructing the reader.
+    /// </summary>
+    internal async Task PrimeAsync(CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        EnsureEnumerator(cancellationToken);
+        var hasMore = await _enumerator!.MoveNextAsync().ConfigureAwait(false);
+        if (hasMore)
+        {
+            _bufferedFirstRow = _enumerator.Current;
+            _hasBufferedRow = true;
+            _hasRows = true;
+        }
+        else
+        {
+            _hasRows = false;
         }
     }
 

--- a/src/Couchbase.EntityFrameworkCore/Storage/Internal/CouchbaseDbDataReader.cs
+++ b/src/Couchbase.EntityFrameworkCore/Storage/Internal/CouchbaseDbDataReader.cs
@@ -15,21 +15,25 @@ namespace Couchbase.EntityFrameworkCore.Storage.Internal;
 /// This reader wraps an <see cref="IQueryResult{T}"/> and provides ADO.NET-compatible access to query results.
 /// Rows must be <see cref="JsonElement"/> instances (i.e. the query must be executed with
 /// <c>cluster.QueryAsync&lt;JsonElement&gt;()</c>); any other row type throws
-/// <see cref="NotSupportedException"/> when the first row is materialized — which may occur
-/// during an explicit <see cref="ReadAsync"/> call or earlier during schema discovery triggered
-/// by accessing <see cref="FieldCount"/>, <see cref="HasRows"/>, or <see cref="GetOrdinal"/>.
+/// <see cref="NotSupportedException"/> when a row is materialized via <see cref="ReadAsync"/>.
 /// </para>
 /// <para>
-/// <b>Schema Discovery:</b> Field metadata (names and ordinals) is captured from the first row and reused for all
-/// subsequent rows. If the first row has fields <c>["id", "name"]</c>, those become ordinals 0 and 1 respectively.
-/// Later rows with missing fields return <see cref="DBNull.Value"/> for those ordinals; extra fields are
-/// inaccessible by ordinal.
+/// <b>Column names:</b> When <paramref name="columnNames"/> is supplied the reader maps each
+/// projection alias to its shaper ordinal at construction time. Field-name lookup and
+/// <see cref="FieldCount"/> are O(1) and work before the first <see cref="ReadAsync"/> call.
+/// Null slots in <paramref name="columnNames"/> indicate positional (unaliased) columns; those
+/// resolve against the current row's JSON property order and therefore require a prior
+/// <see cref="ReadAsync"/> call.
 /// </para>
 /// <para>
-/// <b>Value Extraction:</b> Scalar JSON values (string, number, boolean, null) are converted to their CLR
-/// equivalents by <see cref="GetValue"/>. JSON objects and arrays are returned as a raw <see cref="JsonElement"/>
-/// — no unwrapping is performed. Use <see cref="GetFieldValue{T}"/> with <see cref="JsonElement"/> to work with
-/// the raw structure, or with a target CLR type to deserialize it via <see cref="System.Text.Json"/>.
+/// When <paramref name="columnNames"/> is not supplied (raw ADO.NET path via
+/// <see cref="CouchbaseCommand"/>), field-name and ordinal access resolve positionally from the
+/// current row and also require a prior <see cref="ReadAsync"/> call.
+/// </para>
+/// <para>
+/// <b>Value Extraction:</b> Scalar JSON values (string, number, boolean, null) are converted to
+/// their CLR equivalents by <see cref="GetValue"/>. JSON objects and arrays are returned as a raw
+/// <see cref="JsonElement"/> — no unwrapping is performed.
 /// </para>
 /// </remarks>
 /// <typeparam name="T">The type of rows in the query result. Must be <see cref="JsonElement"/>.</typeparam>
@@ -38,12 +42,9 @@ public class CouchbaseDbDataReader<T> : DbDataReader
     private readonly IQueryResult<T> _queryResult;
     private readonly DbConnection? _connection;
     private readonly CommandBehavior _behavior;
-    private readonly CancellationToken _initialCancellationToken;
     // Ordered SELECT projection aliases supplied by the caller (one per shaper ordinal).
-    // Used in GetValue to translate shaper ordinal → JSON property via _fieldOrdinals.
     private readonly string?[]? _columnNames;
     // Reverse map of _columnNames: alias (case-insensitive) → projection ordinal.
-    // Built eagerly at construction so GetOrdinal needs no schema discovery when active.
     private readonly Dictionary<string, int>? _projectionOrdinals;
     private IAsyncEnumerator<T>? _enumerator;
     private CancellationToken _cancellationToken;
@@ -53,68 +54,54 @@ public class CouchbaseDbDataReader<T> : DbDataReader
     /// Gets the current row as read by the last <see cref="ReadAsync"/> call.
     /// </summary>
     public T? CurrentRow => _currentRow;
-    private T? _bufferedRow;
-    private bool _hasBufferedRow;
     private bool _hasCurrentRow;
     private bool? _hasRows;
-    private List<string>? _fieldNames;
-    private Dictionary<string, int>? _fieldOrdinals;
     private bool _isClosed;
-    private bool _schemaInitialized;
 
     /// <summary>
-    /// Initializes a new instance of the <see cref="CouchbaseDbDataReader{T}"/> class.
+    /// Initializes a new instance of the <see cref="CouchbaseDbDataReader{T}"/> class with a
+    /// column-name mapping. The <paramref name="columnNames"/> array must contain the SELECT-clause
+    /// alias for each EF Core <c>readerColumn</c> in order; <c>null</c> elements use positional
+    /// mapping (resolved from the current row after <see cref="ReadAsync"/>).
     /// </summary>
-    /// <param name="queryResult">The Couchbase query result to read from.</param>
-    /// <exception cref="ArgumentNullException">Thrown when <paramref name="queryResult"/> is null.</exception>
-    public CouchbaseDbDataReader(IQueryResult<T> queryResult)
+    /// <exception cref="ArgumentNullException">
+    /// Thrown when <paramref name="queryResult"/> or <paramref name="columnNames"/> is null.
+    /// </exception>
+    public CouchbaseDbDataReader(IQueryResult<T> queryResult, string?[] columnNames)
         : this(queryResult, null, CommandBehavior.Default, CancellationToken.None)
     {
-    }
-
-    /// <summary>
-    /// Initializes a new instance of the <see cref="CouchbaseDbDataReader{T}"/> class with a column-name mapping.
-    /// The <paramref name="columnNames"/> array should contain the SELECT-clause alias for each EF Core
-    /// <c>readerColumn</c> in order; <c>null</c> elements fall back to positional mapping.
-    /// </summary>
-    public CouchbaseDbDataReader(IQueryResult<T> queryResult, string?[]? columnNames)
-        : this(queryResult, null, CommandBehavior.Default, CancellationToken.None)
-    {
-        _columnNames = columnNames;
-        if (columnNames != null)
+        _columnNames = columnNames ?? throw new ArgumentNullException(nameof(columnNames));
+        _projectionOrdinals = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
+        for (var i = 0; i < columnNames.Length; i++)
         {
-            _projectionOrdinals = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
-            for (var i = 0; i < columnNames.Length; i++)
-            {
-                var alias = columnNames[i];
-                if (alias != null)
-                    _projectionOrdinals.TryAdd(alias, i);
-            }
+            var alias = columnNames[i];
+            if (alias != null)
+                _projectionOrdinals.TryAdd(alias, i);
         }
     }
 
     /// <summary>
-    /// Initializes a new instance of the <see cref="CouchbaseDbDataReader{T}"/> class with connection and behavior options.
+    /// Initializes a new instance of the <see cref="CouchbaseDbDataReader{T}"/> class with
+    /// connection and behavior options (raw ADO.NET path — no column-name mapping).
     /// </summary>
     /// <param name="queryResult">The Couchbase query result to read from.</param>
-    /// <param name="connection">The connection to close when the reader is closed (if <see cref="CommandBehavior.CloseConnection"/> is specified).</param>
+    /// <param name="connection">The connection to close when <see cref="CommandBehavior.CloseConnection"/> is set.</param>
     /// <param name="behavior">The command behavior flags.</param>
-    /// <param name="cancellationToken">The cancellation token used for schema discovery and initial row iteration.</param>
+    /// <param name="cancellationToken">Unused at construction; reserved for future use.</param>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="queryResult"/> is null.</exception>
     public CouchbaseDbDataReader(IQueryResult<T> queryResult, DbConnection? connection, CommandBehavior behavior, CancellationToken cancellationToken)
     {
         _queryResult = queryResult ?? throw new ArgumentNullException(nameof(queryResult));
         _connection = connection;
         _behavior = behavior;
-        _initialCancellationToken = cancellationToken;
     }
 
     /// <summary>
     /// Gets the number of fields in the current row.
     /// </summary>
     /// <remarks>
-    /// Accessing this property before calling <see cref="Read"/> will trigger schema discovery,
-    /// which reads and buffers the first row. The buffered row is returned on the next <see cref="Read"/> call.
+    /// When column names were supplied at construction this returns the projection length and
+    /// does not require a prior <see cref="Read"/> call. Otherwise a current row is required.
     /// </remarks>
     public override int FieldCount
     {
@@ -122,47 +109,26 @@ public class CouchbaseDbDataReader<T> : DbDataReader
         {
             if (_columnNames != null)
                 return _columnNames.Length;
-            EnsureFieldInfo();
-            return _fieldNames?.Count ?? 0;
+            EnsureCurrentRow();
+            if (_currentRow is JsonElement je)
+                return je.ValueKind == JsonValueKind.Object ? je.EnumerateObject().Count() : 1;
+            return 0;
         }
     }
 
     /// <summary>
     /// Gets the number of rows changed, inserted, or deleted. Always returns -1 for Couchbase queries.
     /// </summary>
-    /// <remarks>
-    /// For SELECT queries, this always returns -1. Use <see cref="CouchbaseCommand.ExecuteNonQueryAsync"/>
-    /// to get mutation counts for INSERT, UPDATE, DELETE, UPSERT, and MERGE statements.
-    /// </remarks>
     public override int RecordsAffected => -1;
 
     /// <summary>
     /// Gets a value indicating whether the result set contains one or more rows.
     /// </summary>
     /// <remarks>
-    /// <para>
-    /// Accessing this property before calling <see cref="Read"/> will trigger schema discovery,
-    /// which peeks at the first row to determine availability. The peeked row is buffered and
-    /// returned on the next <see cref="Read"/> call, so no data is lost.
-    /// </para>
-    /// <para>
-    /// Once determined, the value is cached and remains constant even after all rows are read.
-    /// </para>
+    /// Returns <c>false</c> before the first <see cref="Read"/> call. Set to <c>true</c> on the
+    /// first successful read and remains constant thereafter.
     /// </remarks>
-    public override bool HasRows
-    {
-        get
-        {
-            if (_hasRows.HasValue)
-            {
-                return _hasRows.Value;
-            }
-
-            // Peek at first row to determine if there are any rows
-            EnsureFieldInfo();
-            return _hasRows ?? false;
-        }
-    }
+    public override bool HasRows => _hasRows ?? false;
 
     /// <summary>
     /// Gets a value indicating whether the reader is closed.
@@ -177,21 +143,16 @@ public class CouchbaseDbDataReader<T> : DbDataReader
     /// <summary>
     /// Gets the value of the specified column by ordinal.
     /// </summary>
-    /// <param name="ordinal">The zero-based column ordinal.</param>
-    /// <returns>The value of the column.</returns>
     public override object this[int ordinal] => GetValue(ordinal);
 
     /// <summary>
     /// Gets the value of the specified column by name.
     /// </summary>
-    /// <param name="name">The column name (case-insensitive).</param>
-    /// <returns>The value of the column.</returns>
     public override object this[string name] => GetValue(GetOrdinal(name));
 
     /// <summary>
     /// Advances the reader to the next row synchronously.
     /// </summary>
-    /// <returns><c>true</c> if there are more rows; otherwise, <c>false</c>.</returns>
     public override bool Read()
     {
         return ReadAsync(CancellationToken.None).GetAwaiter().GetResult();
@@ -200,37 +161,14 @@ public class CouchbaseDbDataReader<T> : DbDataReader
     /// <summary>
     /// Asynchronously advances the reader to the next row.
     /// </summary>
-    /// <remarks>
-    /// <para>
-    /// If schema discovery (via <see cref="FieldCount"/>, <see cref="HasRows"/>, etc.) has already buffered
-    /// the first row, that row is returned immediately without advancing the underlying enumerator.
-    /// </para>
-    /// <para>
-    /// The cancellation token is checked before each iteration. If the enumerator was created during
-    /// schema discovery, it uses the initial cancellation token provided to the constructor.
-    /// </para>
-    /// </remarks>
     /// <param name="cancellationToken">A token to cancel the asynchronous operation.</param>
     /// <returns><c>true</c> if there are more rows; otherwise, <c>false</c>.</returns>
     public override async Task<bool> ReadAsync(CancellationToken cancellationToken)
     {
         if (_isClosed)
-        {
             return false;
-        }
 
         cancellationToken.ThrowIfCancellationRequested();
-
-        // If we have a buffered row from schema discovery, return it first
-        if (_hasBufferedRow)
-        {
-            _currentRow = _bufferedRow;
-            _bufferedRow = default;
-            _hasBufferedRow = false;
-            _hasCurrentRow = true;
-            return true;
-        }
-
         EnsureEnumerator(cancellationToken);
 
         var hasMore = await _enumerator!.MoveNextAsync().ConfigureAwait(false);
@@ -238,32 +176,18 @@ public class CouchbaseDbDataReader<T> : DbDataReader
         {
             _currentRow = _enumerator.Current;
             _hasCurrentRow = true;
-
-            // Set _hasRows on first successful read if not already set
             _hasRows ??= true;
-
-            if (!_schemaInitialized)
-            {
-                _schemaInitialized = true;
-                InitializeFieldInfo();
-            }
         }
         else
         {
             _currentRow = default;
             _hasCurrentRow = false;
-
-            // If this is the first read and it returned false, there are no rows
             _hasRows ??= false;
         }
 
         return hasMore;
     }
 
-    /// <summary>
-    /// Lazily creates the enumerator on first use, capturing the cancellation token.
-    /// This allows cancellation to abort row iteration.
-    /// </summary>
     private void EnsureEnumerator(CancellationToken cancellationToken)
     {
         if (_enumerator == null)
@@ -276,36 +200,16 @@ public class CouchbaseDbDataReader<T> : DbDataReader
     /// <summary>
     /// Advances the reader to the next result set. Always returns <c>false</c> for Couchbase.
     /// </summary>
-    /// <remarks>
-    /// Couchbase N1QL queries return a single result set. This method always returns <c>false</c>.
-    /// </remarks>
-    /// <returns>Always <c>false</c>.</returns>
-    public override bool NextResult()
-    {
-        // Couchbase queries return a single result set
-        return false;
-    }
+    public override bool NextResult() => false;
 
     /// <summary>
     /// Asynchronously advances the reader to the next result set. Always returns <c>false</c> for Couchbase.
     /// </summary>
-    /// <remarks>
-    /// Couchbase N1QL queries return a single result set. This method always returns <c>false</c>.
-    /// </remarks>
-    /// <param name="cancellationToken">Ignored. Couchbase does not support multiple result sets.</param>
-    /// <returns>Always <c>false</c>.</returns>
-    public override Task<bool> NextResultAsync(CancellationToken cancellationToken)
-    {
-        return Task.FromResult(false);
-    }
+    public override Task<bool> NextResultAsync(CancellationToken cancellationToken) => Task.FromResult(false);
 
     /// <summary>
     /// Closes the reader and releases resources.
     /// </summary>
-    /// <remarks>
-    /// If <see cref="CommandBehavior.CloseConnection"/> was specified when creating the reader,
-    /// the associated connection is also closed.
-    /// </remarks>
     public override void Close()
     {
         if (!_isClosed)
@@ -313,45 +217,31 @@ public class CouchbaseDbDataReader<T> : DbDataReader
             _isClosed = true;
             _enumerator?.DisposeAsync().AsTask().GetAwaiter().GetResult();
 
-            // Honor CloseConnection behavior
             if ((_behavior & CommandBehavior.CloseConnection) != 0 && _connection != null)
-            {
                 _connection.Close();
-            }
         }
     }
 
     /// <summary>
     /// Asynchronously closes the reader and releases resources.
     /// </summary>
-    /// <remarks>
-    /// If <see cref="CommandBehavior.CloseConnection"/> was specified when creating the reader,
-    /// the associated connection is also closed asynchronously.
-    /// </remarks>
     public override async Task CloseAsync()
     {
         if (!_isClosed)
         {
             _isClosed = true;
             if (_enumerator != null)
-            {
                 await _enumerator.DisposeAsync().ConfigureAwait(false);
-            }
 
-            // Honor CloseConnection behavior
             if ((_behavior & CommandBehavior.CloseConnection) != 0 && _connection != null)
-            {
                 await _connection.CloseAsync().ConfigureAwait(false);
-            }
         }
     }
 
     protected override void Dispose(bool disposing)
     {
         if (disposing)
-        {
             Close();
-        }
         base.Dispose(disposing);
     }
 
@@ -365,11 +255,10 @@ public class CouchbaseDbDataReader<T> : DbDataReader
     /// Gets the name of the field at the specified ordinal.
     /// </summary>
     /// <remarks>
-    /// Field names are captured from the first row during schema discovery. Accessing this method
-    /// before calling <see cref="Read"/> will trigger schema discovery.
+    /// When a non-null column alias exists for the ordinal it is returned immediately. For null-slot
+    /// positions, or when no column names were supplied, the JSON field name is read from the current
+    /// row and a prior <see cref="Read"/> call is required.
     /// </remarks>
-    /// <param name="ordinal">The zero-based column ordinal.</param>
-    /// <returns>The name of the field.</returns>
     /// <exception cref="IndexOutOfRangeException">Thrown when <paramref name="ordinal"/> is out of range.</exception>
     public override string GetName(int ordinal)
     {
@@ -380,23 +269,41 @@ public class CouchbaseDbDataReader<T> : DbDataReader
             var alias = _columnNames[ordinal];
             if (alias != null)
                 return alias;
-            // null slot: fall back to the JSON field name at the same position
+            // null slot: read field name from current row at this position
+            if (_hasCurrentRow && _currentRow is JsonElement je && je.ValueKind == JsonValueKind.Object)
+            {
+                var i = 0;
+                foreach (var prop in je.EnumerateObject())
+                    if (i++ == ordinal) return prop.Name;
+            }
+            throw new IndexOutOfRangeException($"Ordinal {ordinal} is out of range. FieldCount: {_columnNames.Length}");
         }
 
-        EnsureFieldInfo();
-        ValidateOrdinal(ordinal);
-        return _fieldNames![ordinal];
+        // No column names: positional from current row.
+        EnsureCurrentRow();
+        if (_currentRow is JsonElement jePos)
+        {
+            if (jePos.ValueKind == JsonValueKind.Object)
+            {
+                var i = 0;
+                foreach (var prop in jePos.EnumerateObject())
+                    if (i++ == ordinal) return prop.Name;
+                throw new IndexOutOfRangeException($"Ordinal {ordinal} is out of range.");
+            }
+            if (ordinal == 0)
+                return string.Empty;
+        }
+        throw new IndexOutOfRangeException($"Ordinal {ordinal} is out of range.");
     }
 
     /// <summary>
     /// Gets the ordinal of the field with the specified name.
     /// </summary>
     /// <remarks>
-    /// Field name lookup is case-insensitive. Accessing this method before calling <see cref="Read"/>
-    /// will trigger schema discovery.
+    /// Field name lookup is case-insensitive. When column names were supplied at construction,
+    /// non-null aliases resolve via an O(1) dictionary without requiring a prior <see cref="Read"/>
+    /// call. Null-slot names and the no-column-names path require a current row.
     /// </remarks>
-    /// <param name="name">The name of the field.</param>
-    /// <returns>The zero-based ordinal of the field.</returns>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="name"/> is null.</exception>
     /// <exception cref="IndexOutOfRangeException">Thrown when the field is not found.</exception>
     public override int GetOrdinal(string name)
@@ -404,51 +311,54 @@ public class CouchbaseDbDataReader<T> : DbDataReader
         if (name == null)
             throw new ArgumentNullException(nameof(name));
 
-        // When projection aliases are active, resolve against them to return the
-        // projection ordinal that GetValue/GetName expect.  No schema discovery needed.
-        if (_projectionOrdinals != null)
+        // Non-null projection aliases resolve immediately.
+        if (_projectionOrdinals != null && _projectionOrdinals.TryGetValue(name, out var projOrdinal))
+            return projOrdinal;
+
+        if (_columnNames != null)
         {
-            if (_projectionOrdinals.TryGetValue(name, out var projOrdinal))
-                return projOrdinal;
-
-            // Fallback for null-slot positions: GetName(i) returns the JSON field name for
-            // a null slot, so GetOrdinal must resolve it back to i to keep
-            // GetOrdinal(GetName(i)) == i. Bounds-check against _columnNames.Length so that
-            // extra JSON fields beyond the projection are not surfaced, and verify the slot
-            // is actually null so non-null aliases that somehow bypass _projectionOrdinals
-            // are rejected rather than silently returned.
-            EnsureFieldInfo();
-            if (_fieldOrdinals != null && _fieldOrdinals.TryGetValue(name, out var jsonOrd)
-                && (uint)jsonOrd < (uint)_columnNames!.Length
-                && _columnNames[jsonOrd] == null)
+            // Null-slot fallback: find a JSON field with this name at a null-slot position.
+            if (_hasCurrentRow && _currentRow is JsonElement je && je.ValueKind == JsonValueKind.Object)
             {
-                return jsonOrd;
+                var i = 0;
+                foreach (var prop in je.EnumerateObject())
+                {
+                    if ((uint)i < (uint)_columnNames.Length
+                        && _columnNames[i] == null
+                        && StringComparer.OrdinalIgnoreCase.Equals(prop.Name, name))
+                        return i;
+                    i++;
+                }
             }
-
             throw new IndexOutOfRangeException($"Field '{name}' not found.");
         }
 
-        EnsureFieldInfo();
-        if (_fieldOrdinals != null && _fieldOrdinals.TryGetValue(name, out var ordinal))
-            return ordinal;
-
-        // For scalar SELECT RAW results the single synthetic field has an empty name.
-        // Any column name lookup on a scalar result maps to ordinal 0.
-        if (_fieldNames?.Count == 1 && _fieldNames[0] == string.Empty)
-            return 0;
-
+        // No column names: positional scan of current row.
+        EnsureCurrentRow();
+        if (_currentRow is JsonElement jePos)
+        {
+            if (jePos.ValueKind == JsonValueKind.Object)
+            {
+                var i = 0;
+                foreach (var prop in jePos.EnumerateObject())
+                {
+                    if (StringComparer.OrdinalIgnoreCase.Equals(prop.Name, name))
+                        return i;
+                    i++;
+                }
+            }
+            else
+            {
+                // Scalar SELECT RAW: any name maps to ordinal 0.
+                return 0;
+            }
+        }
         throw new IndexOutOfRangeException($"Field '{name}' not found.");
     }
 
     /// <summary>
     /// Gets the data type name of the field at the specified ordinal.
     /// </summary>
-    /// <remarks>
-    /// Returns the CLR type name of the current value. Since Couchbase is schemaless,
-    /// the type may vary between rows for the same field.
-    /// </remarks>
-    /// <param name="ordinal">The zero-based column ordinal.</param>
-    /// <returns>The CLR type name of the value, or "Object" if null.</returns>
     public override string GetDataTypeName(int ordinal)
     {
         var value = GetValue(ordinal);
@@ -458,12 +368,6 @@ public class CouchbaseDbDataReader<T> : DbDataReader
     /// <summary>
     /// Gets the CLR type of the field at the specified ordinal.
     /// </summary>
-    /// <remarks>
-    /// Returns the runtime type of the current value. Since Couchbase is schemaless,
-    /// the type may vary between rows for the same field.
-    /// </remarks>
-    /// <param name="ordinal">The zero-based column ordinal.</param>
-    /// <returns>The CLR type of the value, or <see cref="object"/> if null.</returns>
     public override Type GetFieldType(int ordinal)
     {
         var value = GetValue(ordinal);
@@ -475,71 +379,76 @@ public class CouchbaseDbDataReader<T> : DbDataReader
     /// </summary>
     /// <remarks>
     /// Scalar JSON values (string, number, boolean, null) are returned as their CLR equivalents.
-    /// JSON objects and arrays are returned as a raw <see cref="JsonElement"/> — no unwrapping is
-    /// performed. Use <see cref="GetFieldValue{T}"/> with a target type to deserialize complex values.
+    /// JSON objects and arrays are returned as a raw <see cref="JsonElement"/>.
     /// </remarks>
-    /// <param name="ordinal">The zero-based column ordinal.</param>
-    /// <returns>The value of the field, or <see cref="DBNull.Value"/> if null.</returns>
     /// <exception cref="InvalidOperationException">Thrown when no current row exists (call <see cref="Read"/> first).</exception>
     /// <exception cref="IndexOutOfRangeException">Thrown when <paramref name="ordinal"/> is out of range.</exception>
     public override object GetValue(int ordinal)
     {
         EnsureCurrentRow();
 
-        // When the caller supplied column names (projection aliases from the SELECT clause),
-        // resolve the alias via _fieldOrdinals (OrdinalIgnoreCase dictionary, built once from
-        // the first row) to obtain the canonical JSON property name, then call TryGetProperty
-        // with that exact name. The TryGetPropertyCI fallback is used when _fieldOrdinals is
-        // null (schema not yet built) or the alias is absent from _fieldOrdinals.
-        if (_columnNames != null && (uint)ordinal < (uint)_columnNames.Length)
+        if (_columnNames != null)
         {
+            if ((uint)ordinal >= (uint)_columnNames.Length)
+                throw new IndexOutOfRangeException($"Ordinal {ordinal} is out of range. FieldCount: {_columnNames.Length}");
+
             var colName = _columnNames[ordinal];
             if (colName != null)
             {
                 if (_currentRow is not JsonElement je) return DBNull.Value;
-
                 if (je.ValueKind != JsonValueKind.Object)
                     return ConvertJsonElement(je); // SELECT RAW scalar
-
-                // Use _fieldOrdinals (OrdinalIgnoreCase, built once from the first row) for
-                // O(1) alias→canonical-name resolution, then call TryGetProperty with the
-                // exact canonical name so the JSON property scan hits on the first comparison.
-                // Falls back to TryGetPropertyCI when _fieldOrdinals is null (schema not yet
-                // built) or when the alias is absent from _fieldOrdinals (e.g. an alias
-                // introduced after the first row that was never recorded during schema discovery).
-                if (_fieldOrdinals != null && _fieldOrdinals.TryGetValue(colName, out var jsonOrd))
-                    return je.TryGetProperty(_fieldNames![jsonOrd], out var prop)
-                        ? ConvertJsonElement(prop)
-                        : DBNull.Value;
-
-                return je.TryGetPropertyCI(colName, out var fallbackProp)
-                    ? ConvertJsonElement(fallbackProp)
+                return je.TryGetPropertyCI(colName, out var prop)
+                    ? ConvertJsonElement(prop)
                     : DBNull.Value;
             }
-            // null slot: no alias for this ordinal — fall through to positional access.
+
+            // null slot: positional access from current row
+            if (_currentRow is JsonElement jePos)
+            {
+                if (jePos.ValueKind == JsonValueKind.Object)
+                {
+                    var i = 0;
+                    foreach (var p in jePos.EnumerateObject())
+                    {
+                        if (i == ordinal) return ConvertJsonElement(p.Value);
+                        i++;
+                    }
+                }
+                else if (ordinal == 0)
+                    return ConvertJsonElement(jePos); // scalar SELECT RAW at null slot 0
+            }
+            return DBNull.Value;
         }
 
-        // No column names supplied, or null slot: positional access via schema discovery.
-        var isNullSlot = _columnNames != null && (uint)ordinal < (uint)_columnNames.Length;
-        if (isNullSlot && (_fieldNames == null || ordinal >= _fieldNames.Count))
-            return DBNull.Value;
-        ValidateOrdinal(ordinal);
-        return GetFieldValue(_fieldNames![ordinal]);
+        // No column names: positional access from current row.
+        if (_currentRow is JsonElement jeFallback)
+        {
+            if (jeFallback.ValueKind == JsonValueKind.Object)
+            {
+                var i = 0;
+                foreach (var p in jeFallback.EnumerateObject())
+                {
+                    if (i == ordinal) return ConvertJsonElement(p.Value);
+                    i++;
+                }
+                throw new IndexOutOfRangeException($"Ordinal {ordinal} is out of range.");
+            }
+            if (ordinal == 0)
+                return ConvertJsonElement(jeFallback);
+        }
+        throw new IndexOutOfRangeException($"Ordinal {ordinal} is out of range.");
     }
 
     /// <summary>
     /// Populates an array with the values of all fields in the current row.
     /// </summary>
-    /// <param name="values">The array to populate with field values.</param>
-    /// <returns>The number of values copied (minimum of array length and field count).</returns>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="values"/> is null.</exception>
     /// <exception cref="InvalidOperationException">Thrown when no current row exists.</exception>
     public override int GetValues(object[] values)
     {
         if (values == null)
-        {
             throw new ArgumentNullException(nameof(values));
-        }
 
         EnsureCurrentRow();
 
@@ -548,26 +457,24 @@ public class CouchbaseDbDataReader<T> : DbDataReader
         {
             fieldCount = _columnNames.Length;
         }
+        else if (_currentRow is JsonElement je && je.ValueKind == JsonValueKind.Object)
+        {
+            fieldCount = je.EnumerateObject().Count();
+        }
         else
         {
-            EnsureFieldInfo();
-            fieldCount = _fieldNames!.Count;
+            fieldCount = _currentRow is JsonElement ? 1 : 0;
         }
 
         var count = Math.Min(values.Length, fieldCount);
         for (var i = 0; i < count; i++)
-        {
             values[i] = GetValue(i);
-        }
-
         return count;
     }
 
     /// <summary>
     /// Determines whether the field at the specified ordinal is null or <see cref="DBNull.Value"/>.
     /// </summary>
-    /// <param name="ordinal">The zero-based column ordinal.</param>
-    /// <returns><c>true</c> if the field is null or DBNull; otherwise, <c>false</c>.</returns>
     public override bool IsDBNull(int ordinal)
     {
         var value = GetValue(ordinal);
@@ -577,20 +484,12 @@ public class CouchbaseDbDataReader<T> : DbDataReader
     /// <summary>
     /// Asynchronously determines whether the field at the specified ordinal is null.
     /// </summary>
-    /// <param name="ordinal">The zero-based column ordinal.</param>
-    /// <param name="cancellationToken">Ignored. The operation is synchronous.</param>
-    /// <returns><c>true</c> if the field is null or DBNull; otherwise, <c>false</c>.</returns>
     public override async Task<bool> IsDBNullAsync(int ordinal, CancellationToken cancellationToken)
     {
         return IsDBNull(ordinal);
     }
 
-    /// <summary>
-    /// Gets the boolean value of the field at the specified ordinal.
-    /// </summary>
-    /// <param name="ordinal">The zero-based column ordinal.</param>
-    /// <returns>The boolean value of the field.</returns>
-    /// <exception cref="InvalidCastException">Thrown when the value cannot be converted to boolean.</exception>
+    /// <summary>Gets the boolean value of the field at the specified ordinal.</summary>
     public override bool GetBoolean(int ordinal)
     {
         var value = GetValue(ordinal);
@@ -604,13 +503,7 @@ public class CouchbaseDbDataReader<T> : DbDataReader
         };
     }
 
-    /// <summary>
-    /// Gets the byte value of the field at the specified ordinal.
-    /// </summary>
-    /// <param name="ordinal">The zero-based column ordinal.</param>
-    /// <returns>The byte value of the field.</returns>
-    /// <exception cref="InvalidCastException">Thrown when the value cannot be converted to byte.</exception>
-    /// <exception cref="OverflowException">Thrown when the value is outside the byte range (0-255).</exception>
+    /// <summary>Gets the byte value of the field at the specified ordinal.</summary>
     public override byte GetByte(int ordinal)
     {
         var value = GetValue(ordinal);
@@ -629,28 +522,13 @@ public class CouchbaseDbDataReader<T> : DbDataReader
     /// Reads bytes from the field at the specified ordinal into a buffer.
     /// </summary>
     /// <remarks>
-    /// <para>
     /// The field value must be a byte array or a base64-encoded string. If <paramref name="buffer"/>
     /// is null, returns the total length of the byte data without copying.
-    /// </para>
-    /// <para>
-    /// If <paramref name="dataOffset"/> is beyond the source data length, returns 0 (ADO.NET behavior).
-    /// </para>
     /// </remarks>
-    /// <param name="ordinal">The zero-based column ordinal.</param>
-    /// <param name="dataOffset">The offset within the source data to start reading from.</param>
-    /// <param name="buffer">The buffer to copy bytes into, or null to query the total length.</param>
-    /// <param name="bufferOffset">The offset within the buffer to start writing to.</param>
-    /// <param name="length">The maximum number of bytes to copy.</param>
-    /// <returns>The number of bytes copied, or the total length if buffer is null.</returns>
-    /// <exception cref="ArgumentOutOfRangeException">Thrown for negative offsets or lengths, or buffer overflow.</exception>
-    /// <exception cref="InvalidCastException">Thrown when the value cannot be converted to bytes.</exception>
     public override long GetBytes(int ordinal, long dataOffset, byte[]? buffer, int bufferOffset, int length)
     {
         if (dataOffset < 0)
-        {
             throw new ArgumentOutOfRangeException(nameof(dataOffset), dataOffset, "Data offset cannot be negative.");
-        }
 
         var value = GetValue(ordinal);
         byte[] bytes = value switch
@@ -661,55 +539,29 @@ public class CouchbaseDbDataReader<T> : DbDataReader
             _ => throw new InvalidCastException($"Cannot convert {value?.GetType().Name} to byte array.")
         };
 
-        // If buffer is null, return total length (used to query size)
         if (buffer == null)
-        {
             return bytes.Length;
-        }
 
         if (bufferOffset < 0)
-        {
             throw new ArgumentOutOfRangeException(nameof(bufferOffset), bufferOffset, "Buffer offset cannot be negative.");
-        }
 
         if (bufferOffset > buffer.Length)
-        {
             throw new ArgumentOutOfRangeException(nameof(bufferOffset), bufferOffset, "Buffer offset exceeds buffer length.");
-        }
 
         if (length < 0)
-        {
             throw new ArgumentOutOfRangeException(nameof(length), length, "Length cannot be negative.");
-        }
 
-        // If dataOffset is at or beyond the source data, return 0 (ADO.NET behavior)
         if (dataOffset >= bytes.Length)
-        {
             return 0;
-        }
 
         var sourceOffset = (int)dataOffset;
-        var availableBytes = bytes.Length - sourceOffset;
-        var availableBuffer = buffer.Length - bufferOffset;
-        var bytesToCopy = Math.Min(length, Math.Min(availableBytes, availableBuffer));
-
+        var bytesToCopy = Math.Min(length, Math.Min(bytes.Length - sourceOffset, buffer.Length - bufferOffset));
         if (bytesToCopy > 0)
-        {
             Array.Copy(bytes, sourceOffset, buffer, bufferOffset, bytesToCopy);
-        }
-
         return bytesToCopy;
     }
 
-    /// <summary>
-    /// Gets the character value of the field at the specified ordinal.
-    /// </summary>
-    /// <remarks>
-    /// For string values, returns the first character. Throws if the string is empty.
-    /// </remarks>
-    /// <param name="ordinal">The zero-based column ordinal.</param>
-    /// <returns>The character value of the field.</returns>
-    /// <exception cref="InvalidCastException">Thrown when the value cannot be converted to char.</exception>
+    /// <summary>Gets the character value of the field at the specified ordinal.</summary>
     public override char GetChar(int ordinal)
     {
         var value = GetValue(ordinal);
@@ -726,79 +578,38 @@ public class CouchbaseDbDataReader<T> : DbDataReader
     /// Reads characters from the field at the specified ordinal into a buffer.
     /// </summary>
     /// <remarks>
-    /// <para>
     /// If <paramref name="buffer"/> is null, returns the total length of the string without copying.
-    /// </para>
-    /// <para>
-    /// If <paramref name="dataOffset"/> is beyond the source string length, returns 0 (ADO.NET behavior).
-    /// </para>
     /// </remarks>
-    /// <param name="ordinal">The zero-based column ordinal.</param>
-    /// <param name="dataOffset">The offset within the source string to start reading from.</param>
-    /// <param name="buffer">The buffer to copy characters into, or null to query the total length.</param>
-    /// <param name="bufferOffset">The offset within the buffer to start writing to.</param>
-    /// <param name="length">The maximum number of characters to copy.</param>
-    /// <returns>The number of characters copied, or the total length if buffer is null.</returns>
-    /// <exception cref="ArgumentOutOfRangeException">Thrown for negative offsets or lengths, or buffer overflow.</exception>
     public override long GetChars(int ordinal, long dataOffset, char[]? buffer, int bufferOffset, int length)
     {
         if (dataOffset < 0)
-        {
             throw new ArgumentOutOfRangeException(nameof(dataOffset), dataOffset, "Data offset cannot be negative.");
-        }
 
         var str = GetString(ordinal);
 
-        // If buffer is null, return total length (used to query size)
         if (buffer == null)
-        {
             return str.Length;
-        }
 
         if (bufferOffset < 0)
-        {
             throw new ArgumentOutOfRangeException(nameof(bufferOffset), bufferOffset, "Buffer offset cannot be negative.");
-        }
 
         if (bufferOffset > buffer.Length)
-        {
             throw new ArgumentOutOfRangeException(nameof(bufferOffset), bufferOffset, "Buffer offset exceeds buffer length.");
-        }
 
         if (length < 0)
-        {
             throw new ArgumentOutOfRangeException(nameof(length), length, "Length cannot be negative.");
-        }
 
-        // If dataOffset is at or beyond the source data, return 0 (ADO.NET behavior)
         if (dataOffset >= str.Length)
-        {
             return 0;
-        }
 
         var sourceOffset = (int)dataOffset;
-        var availableChars = str.Length - sourceOffset;
-        var availableBuffer = buffer.Length - bufferOffset;
-        var charsToCopy = Math.Min(length, Math.Min(availableChars, availableBuffer));
-
+        var charsToCopy = Math.Min(length, Math.Min(str.Length - sourceOffset, buffer.Length - bufferOffset));
         if (charsToCopy > 0)
-        {
             str.CopyTo(sourceOffset, buffer, bufferOffset, charsToCopy);
-        }
-
         return charsToCopy;
     }
 
-    /// <summary>
-    /// Gets the DateTime value of the field at the specified ordinal.
-    /// </summary>
-    /// <remarks>
-    /// Supports ISO 8601 date strings, <see cref="DateTime"/>, and <see cref="DateTimeOffset"/> values.
-    /// </remarks>
-    /// <param name="ordinal">The zero-based column ordinal.</param>
-    /// <returns>The DateTime value of the field.</returns>
-    /// <exception cref="InvalidCastException">Thrown when the value cannot be converted to DateTime.</exception>
-    /// <exception cref="FormatException">Thrown when a string value is not a valid date format.</exception>
+    /// <summary>Gets the DateTime value of the field at the specified ordinal.</summary>
     public override DateTime GetDateTime(int ordinal)
     {
         var value = GetValue(ordinal);
@@ -812,13 +623,7 @@ public class CouchbaseDbDataReader<T> : DbDataReader
         };
     }
 
-    /// <summary>
-    /// Gets the decimal value of the field at the specified ordinal.
-    /// </summary>
-    /// <param name="ordinal">The zero-based column ordinal.</param>
-    /// <returns>The decimal value of the field.</returns>
-    /// <exception cref="InvalidCastException">Thrown when the value cannot be converted to decimal.</exception>
-    /// <exception cref="OverflowException">Thrown when the value is outside the decimal range.</exception>
+    /// <summary>Gets the decimal value of the field at the specified ordinal.</summary>
     public override decimal GetDecimal(int ordinal)
     {
         var value = GetValue(ordinal);
@@ -834,12 +639,7 @@ public class CouchbaseDbDataReader<T> : DbDataReader
         };
     }
 
-    /// <summary>
-    /// Gets the double value of the field at the specified ordinal.
-    /// </summary>
-    /// <param name="ordinal">The zero-based column ordinal.</param>
-    /// <returns>The double value of the field.</returns>
-    /// <exception cref="InvalidCastException">Thrown when the value cannot be converted to double.</exception>
+    /// <summary>Gets the double value of the field at the specified ordinal.</summary>
     public override double GetDouble(int ordinal)
     {
         var value = GetValue(ordinal);
@@ -854,15 +654,7 @@ public class CouchbaseDbDataReader<T> : DbDataReader
         };
     }
 
-    /// <summary>
-    /// Gets the float value of the field at the specified ordinal.
-    /// </summary>
-    /// <remarks>
-    /// Values exceeding float range may return <see cref="float.PositiveInfinity"/> or <see cref="float.NegativeInfinity"/>.
-    /// </remarks>
-    /// <param name="ordinal">The zero-based column ordinal.</param>
-    /// <returns>The float value of the field.</returns>
-    /// <exception cref="InvalidCastException">Thrown when the value cannot be converted to float.</exception>
+    /// <summary>Gets the float value of the field at the specified ordinal.</summary>
     public override float GetFloat(int ordinal)
     {
         var value = GetValue(ordinal);
@@ -878,16 +670,7 @@ public class CouchbaseDbDataReader<T> : DbDataReader
         };
     }
 
-    /// <summary>
-    /// Gets the GUID value of the field at the specified ordinal.
-    /// </summary>
-    /// <remarks>
-    /// Supports GUID strings in standard formats (e.g., "d85b1407-351d-4694-9392-03acc5870eb1").
-    /// </remarks>
-    /// <param name="ordinal">The zero-based column ordinal.</param>
-    /// <returns>The GUID value of the field.</returns>
-    /// <exception cref="InvalidCastException">Thrown when the value cannot be converted to GUID.</exception>
-    /// <exception cref="FormatException">Thrown when a string value is not a valid GUID format.</exception>
+    /// <summary>Gets the GUID value of the field at the specified ordinal.</summary>
     public override Guid GetGuid(int ordinal)
     {
         var value = GetValue(ordinal);
@@ -900,13 +683,7 @@ public class CouchbaseDbDataReader<T> : DbDataReader
         };
     }
 
-    /// <summary>
-    /// Gets the 16-bit signed integer value of the field at the specified ordinal.
-    /// </summary>
-    /// <param name="ordinal">The zero-based column ordinal.</param>
-    /// <returns>The Int16 value of the field.</returns>
-    /// <exception cref="InvalidCastException">Thrown when the value cannot be converted to Int16.</exception>
-    /// <exception cref="OverflowException">Thrown when the value is outside the Int16 range (-32768 to 32767).</exception>
+    /// <summary>Gets the 16-bit signed integer value of the field at the specified ordinal.</summary>
     public override short GetInt16(int ordinal)
     {
         var value = GetValue(ordinal);
@@ -921,13 +698,7 @@ public class CouchbaseDbDataReader<T> : DbDataReader
         };
     }
 
-    /// <summary>
-    /// Gets the 32-bit signed integer value of the field at the specified ordinal.
-    /// </summary>
-    /// <param name="ordinal">The zero-based column ordinal.</param>
-    /// <returns>The Int32 value of the field.</returns>
-    /// <exception cref="InvalidCastException">Thrown when the value cannot be converted to Int32.</exception>
-    /// <exception cref="OverflowException">Thrown when the value is outside the Int32 range.</exception>
+    /// <summary>Gets the 32-bit signed integer value of the field at the specified ordinal.</summary>
     public override int GetInt32(int ordinal)
     {
         var value = GetValue(ordinal);
@@ -941,13 +712,7 @@ public class CouchbaseDbDataReader<T> : DbDataReader
         };
     }
 
-    /// <summary>
-    /// Gets the 64-bit signed integer value of the field at the specified ordinal.
-    /// </summary>
-    /// <param name="ordinal">The zero-based column ordinal.</param>
-    /// <returns>The Int64 value of the field.</returns>
-    /// <exception cref="InvalidCastException">Thrown when the value cannot be converted to Int64.</exception>
-    /// <exception cref="OverflowException">Thrown when the value is outside the Int64 range.</exception>
+    /// <summary>Gets the 64-bit signed integer value of the field at the specified ordinal.</summary>
     public override long GetInt64(int ordinal)
     {
         var value = GetValue(ordinal);
@@ -961,15 +726,7 @@ public class CouchbaseDbDataReader<T> : DbDataReader
         };
     }
 
-    /// <summary>
-    /// Gets the string value of the field at the specified ordinal.
-    /// </summary>
-    /// <remarks>
-    /// For non-string JSON values, returns the raw JSON text representation.
-    /// </remarks>
-    /// <param name="ordinal">The zero-based column ordinal.</param>
-    /// <returns>The string value of the field.</returns>
-    /// <exception cref="InvalidCastException">Thrown when the value is null.</exception>
+    /// <summary>Gets the string value of the field at the specified ordinal.</summary>
     public override string GetString(int ordinal)
     {
         var value = GetValue(ordinal);
@@ -978,47 +735,24 @@ public class CouchbaseDbDataReader<T> : DbDataReader
             string s => s,
             JsonElement je when je.ValueKind == JsonValueKind.String => je.GetString()!,
             JsonElement je => je.GetRawText(),
-            // EF Core's ShapedQueryCompilingExpressionVisitor emits materializer lambdas that
-            // call GetString directly (no IsDBNull guard) for non-nullable string properties,
-            // even when those properties are mapped from optional N1QL columns that can be
-            // absent/null. Returning null! here lets those materializers propagate the absence
-            // as a CLR null; callers that need strict ADO.NET semantics must call IsDBNull first.
+            // EF Core materializer lambdas call GetString without IsDBNull for non-nullable
+            // string properties on optional columns; returning null lets those round-trips work.
             DBNull => null!,
             null => throw new InvalidCastException("Cannot convert null to string."),
             _ => value.ToString()!
         };
     }
 
-    /// <summary>
-    /// Gets the value of the field at the specified ordinal as the specified type.
-    /// </summary>
-    /// <remarks>
-    /// <para>
-    /// This method can deserialize JSON objects and arrays to complex types using <see cref="System.Text.Json"/>.
-    /// Use this to access nested document structures that would otherwise be extracted/flattened by <see cref="GetValue"/>.
-    /// </para>
-    /// <para>
-    /// Example: <c>reader.GetFieldValue&lt;JsonElement&gt;(0)</c> returns the raw JSON element,
-    /// or <c>reader.GetFieldValue&lt;MyClass&gt;(0)</c> deserializes to a custom type.
-    /// </para>
-    /// </remarks>
-    /// <typeparam name="T1">The type to return.</typeparam>
-    /// <param name="ordinal">The zero-based column ordinal.</param>
-    /// <returns>The value cast or deserialized to the specified type.</returns>
-    /// <exception cref="InvalidCastException">Thrown when conversion fails.</exception>
+    /// <summary>Gets the value of the field at the specified ordinal as the specified type.</summary>
     public override T1 GetFieldValue<T1>(int ordinal)
     {
         var value = GetValue(ordinal);
 
         if (value is T1 typedValue)
-        {
             return typedValue;
-        }
 
         if (value is JsonElement je)
-        {
             return je.Deserialize<T1>()!;
-        }
 
         return (T1)Convert.ChangeType(value, typeof(T1))!;
     }
@@ -1027,15 +761,10 @@ public class CouchbaseDbDataReader<T> : DbDataReader
     /// Returns a <see cref="DataTable"/> that describes the column metadata of the result set.
     /// </summary>
     /// <remarks>
-    /// <para>
-    /// The schema is derived from the first row. Since Couchbase is schemaless, all columns are
-    /// reported as <see cref="object"/> type with <c>AllowDBNull = true</c>.
-    /// </para>
-    /// <para>
-    /// Accessing this method before calling <see cref="Read"/> will trigger schema discovery.
-    /// </para>
+    /// When column names were supplied at construction they are used directly. Otherwise the
+    /// schema is derived from the current row and a prior <see cref="Read"/> call is required.
+    /// All columns are reported as <see cref="object"/> type with <c>AllowDBNull = true</c>.
     /// </remarks>
-    /// <returns>A DataTable with ColumnName, ColumnOrdinal, DataType, and AllowDBNull columns.</returns>
     public override DataTable GetSchemaTable()
     {
         var schemaTable = new DataTable("SchemaTable");
@@ -1058,144 +787,31 @@ public class CouchbaseDbDataReader<T> : DbDataReader
             return schemaTable;
         }
 
-        EnsureFieldInfo();
-        if (_fieldNames != null)
+        // No column names: build from current row.
+        EnsureCurrentRow();
+        if (_currentRow is JsonElement je && je.ValueKind == JsonValueKind.Object)
         {
-            for (var i = 0; i < _fieldNames.Count; i++)
+            var i = 0;
+            foreach (var prop in je.EnumerateObject())
             {
                 var row = schemaTable.NewRow();
-                row["ColumnName"] = _fieldNames[i];
-                row["ColumnOrdinal"] = i;
+                row["ColumnName"] = prop.Name;
+                row["ColumnOrdinal"] = i++;
                 row["DataType"] = typeof(object);
                 row["AllowDBNull"] = true;
                 schemaTable.Rows.Add(row);
             }
         }
-
         return schemaTable;
     }
 
-    /// <summary>
-    /// Returns an enumerator that iterates through the rows of the result set.
-    /// </summary>
-    /// <returns>An <see cref="IEnumerator"/> for the rows.</returns>
-    public override IEnumerator GetEnumerator()
-    {
-        return new DbEnumerator(this, closeReader: false);
-    }
+    /// <summary>Returns an enumerator that iterates through the rows of the result set.</summary>
+    public override IEnumerator GetEnumerator() => new DbEnumerator(this, closeReader: false);
 
     private void EnsureCurrentRow()
     {
         if (!_hasCurrentRow)
-        {
             throw new InvalidOperationException("No current row. Call Read() first.");
-        }
-    }
-
-    /// <summary>
-    /// Ensures field metadata is available, reading and buffering the first row if necessary.
-    /// The buffered row will be returned on the next explicit Read() call, so no data is lost.
-    /// Also sets _hasRows to indicate whether at least one row exists.
-    /// </summary>
-    private void EnsureFieldInfo()
-    {
-        if (_schemaInitialized || _isClosed)
-        {
-            return;
-        }
-
-        // Check for cancellation before starting schema discovery
-        _initialCancellationToken.ThrowIfCancellationRequested();
-
-        // Create enumerator using initial cancellation token so schema discovery can be cancelled
-        EnsureEnumerator(_initialCancellationToken);
-
-        // Read the first row to discover schema, but buffer it so it's not lost
-        var hasRow = _enumerator!.MoveNextAsync().AsTask().GetAwaiter().GetResult();
-        _hasRows = hasRow;
-
-        if (hasRow)
-        {
-            _bufferedRow = _enumerator.Current;
-            _hasBufferedRow = true;
-            _currentRow = _bufferedRow; // Set current row so InitializeFieldInfo can access it
-            _schemaInitialized = true;
-            InitializeFieldInfo();
-            _currentRow = default; // Clear current row - caller must call Read() to access data
-        }
-        else
-        {
-            // No rows - initialize empty schema
-            _schemaInitialized = true;
-            _fieldNames = new List<string>();
-            _fieldOrdinals = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
-        }
-    }
-
-    /// <summary>
-    /// Initializes field metadata (names and ordinals) from the first row.
-    /// 
-    /// LIMITATION: Field schema is captured once from the first row and reused for all subsequent rows.
-    /// This means:
-    /// - If later rows have MISSING fields, GetValue returns DBNull.Value for those ordinals
-    /// - If later rows have EXTRA fields, they are inaccessible (not in the ordinal mapping)
-    /// - If later rows have DIFFERENT field order, ordinal-based access still uses the first row's order
-    /// 
-    /// This behavior is consistent with ADO.NET's expectation of a stable schema per result set,
-    /// but may not suit heterogeneous document collections where each document has a different shape.
-    /// For such cases, consider using name-based access (reader["fieldName"]) and checking IsDBNull.
-    /// </summary>
-    private void InitializeFieldInfo()
-    {
-        _fieldNames = new List<string>();
-        _fieldOrdinals = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
-
-        if (_currentRow is JsonElement je && je.ValueKind == JsonValueKind.Object)
-        {
-            var ordinal = 0;
-            foreach (var property in je.EnumerateObject())
-            {
-                _fieldNames.Add(property.Name);
-                _fieldOrdinals[property.Name] = ordinal++;
-            }
-        }
-        else if (_currentRow is JsonElement)
-        {
-            // Non-object scalar from SELECT RAW (e.g. COUNT result) — single synthetic field at ordinal 0
-            _fieldNames.Add(string.Empty);
-            _fieldOrdinals[string.Empty] = 0;
-        }
-        else if (_currentRow != null)
-        {
-            throw new NotSupportedException(
-                $"CouchbaseDbDataReader<T> requires rows of type JsonElement but received {_currentRow.GetType().FullName}. " +
-                "Use cluster.QueryAsync<JsonElement>() to produce a compatible result.");
-        }
-    }
-
-    private void ValidateOrdinal(int ordinal)
-    {
-        if (_fieldNames == null || ordinal < 0 || ordinal >= _fieldNames.Count)
-        {
-            throw new IndexOutOfRangeException($"Ordinal {ordinal} is out of range. FieldCount: {_fieldNames?.Count ?? 0}");
-        }
-    }
-
-    private object GetFieldValue(string fieldName)
-    {
-        if (_currentRow is JsonElement je)
-        {
-            if (je.ValueKind == JsonValueKind.Object && je.TryGetProperty(fieldName, out var property))
-            {
-                return ConvertJsonElement(property);
-            }
-            // For RAW queries, the entire element is the value
-            if (_fieldNames?.Count == 1)
-            {
-                return ConvertJsonElement(je);
-            }
-        }
-        return DBNull.Value;
     }
 
     private static object ConvertJsonElement(JsonElement element)

--- a/src/Couchbase.EntityFrameworkCore/Storage/Internal/CouchbaseDbDataReader.cs
+++ b/src/Couchbase.EntityFrameworkCore/Storage/Internal/CouchbaseDbDataReader.cs
@@ -204,7 +204,7 @@ public class CouchbaseDbDataReader<T> : DbDataReader
         var hasMore = await _enumerator!.MoveNextAsync().ConfigureAwait(false);
         if (hasMore)
         {
-            _currentRow = _enumerator.Current;
+            _currentRow = ValidateRow(_enumerator.Current);
             _hasCurrentRow = true;
             _hasRows ??= true;
         }
@@ -242,7 +242,7 @@ public class CouchbaseDbDataReader<T> : DbDataReader
         var hasMore = await _enumerator!.MoveNextAsync().ConfigureAwait(false);
         if (hasMore)
         {
-            _bufferedFirstRow = _enumerator.Current;
+            _bufferedFirstRow = ValidateRow(_enumerator.Current);
             _hasBufferedRow = true;
             _hasRows = true;
         }
@@ -880,6 +880,15 @@ public class CouchbaseDbDataReader<T> : DbDataReader
     {
         if (!_hasCurrentRow)
             throw new InvalidOperationException("No current row. Call Read() first.");
+    }
+
+    private static T ValidateRow(T row)
+    {
+        if (row is not null and not JsonElement)
+            throw new NotSupportedException(
+                $"Row type '{row.GetType().Name}' is not supported. " +
+                "The query must be executed with cluster.QueryAsync<JsonElement>().");
+        return row;
     }
 
     private static object ConvertJsonElement(JsonElement element)

--- a/src/Couchbase.EntityFrameworkCore/Storage/Internal/CouchbaseDbDataReader.cs
+++ b/src/Couchbase.EntityFrameworkCore/Storage/Internal/CouchbaseDbDataReader.cs
@@ -343,6 +343,8 @@ public class CouchbaseDbDataReader<T> : DbDataReader
                 foreach (var prop in je.EnumerateObject())
                     if (i++ == ordinal) return prop.Name;
             }
+            else if (ordinal == 0)
+                return string.Empty; // scalar or null row (SELECT RAW scalar/null) at null slot 0
             throw new IndexOutOfRangeException($"Ordinal {ordinal} is out of range. FieldCount: {_columnNames.Length}");
         }
 

--- a/src/Couchbase.EntityFrameworkCore/Storage/Internal/CouchbaseDbDataReader.cs
+++ b/src/Couchbase.EntityFrameworkCore/Storage/Internal/CouchbaseDbDataReader.cs
@@ -15,7 +15,8 @@ namespace Couchbase.EntityFrameworkCore.Storage.Internal;
 /// This reader wraps an <see cref="IQueryResult{T}"/> and provides ADO.NET-compatible access to query results.
 /// Rows must be <see cref="JsonElement"/> instances (i.e. the query must be executed with
 /// <c>cluster.QueryAsync&lt;JsonElement&gt;()</c>); any other row type throws
-/// <see cref="NotSupportedException"/> when a row is materialized via <see cref="ReadAsync"/>.
+/// <see cref="NotSupportedException"/> when a row is materialized via <see cref="PrimeAsync"/>
+/// or <see cref="ReadAsync"/>.
 /// </para>
 /// <para>
 /// <b>Column names:</b> When <paramref name="columnNames"/> is supplied the reader maps each
@@ -331,8 +332,9 @@ public class CouchbaseDbDataReader<T> : DbDataReader
             var alias = _columnNames[ordinal];
             if (alias != null)
                 return alias;
-            // null slot: read field name from current row at this position
-            if (_hasCurrentRow && _currentRow is JsonElement je && je.ValueKind == JsonValueKind.Object)
+            // null slot: positional resolution requires a current row
+            EnsureCurrentRow();
+            if (_currentRow is JsonElement je && je.ValueKind == JsonValueKind.Object)
             {
                 var i = 0;
                 foreach (var prop in je.EnumerateObject())

--- a/src/Couchbase.EntityFrameworkCore/Storage/Internal/CouchbaseDbDataReader.cs
+++ b/src/Couchbase.EntityFrameworkCore/Storage/Internal/CouchbaseDbDataReader.cs
@@ -48,6 +48,8 @@ public class CouchbaseDbDataReader<T> : DbDataReader
     private readonly Dictionary<string, int>? _projectionOrdinals;
     private IAsyncEnumerator<T>? _enumerator;
     private CancellationToken _cancellationToken;
+    // Owned linked CTS transferred from CouchbaseCommand so Cancel() propagates for the reader's lifetime.
+    private CancellationTokenSource? _linkedCts;
     private T? _currentRow;
     // First-row buffer populated by PrimeAsync so HasRows is accurate before ReadAsync.
     private T? _bufferedFirstRow;
@@ -235,6 +237,13 @@ public class CouchbaseDbDataReader<T> : DbDataReader
     }
 
     /// <summary>
+    /// Transfers ownership of the linked <see cref="CancellationTokenSource"/> created by
+    /// <see cref="CouchbaseCommand"/> so that <c>DbCommand.Cancel()</c> propagates to the
+    /// enumerator for the reader's full lifetime.  The source is disposed when the reader closes.
+    /// </summary>
+    internal void SetLinkedCts(CancellationTokenSource cts) => _linkedCts = cts;
+
+    /// <summary>
     /// Advances the reader to the next result set. Always returns <c>false</c> for Couchbase.
     /// </summary>
     public override bool NextResult() => false;
@@ -253,6 +262,8 @@ public class CouchbaseDbDataReader<T> : DbDataReader
         {
             _isClosed = true;
             _enumerator?.DisposeAsync().AsTask().GetAwaiter().GetResult();
+            _linkedCts?.Dispose();
+            _linkedCts = null;
 
             if ((_behavior & CommandBehavior.CloseConnection) != 0 && _connection != null)
                 _connection.Close();
@@ -269,6 +280,8 @@ public class CouchbaseDbDataReader<T> : DbDataReader
             _isClosed = true;
             if (_enumerator != null)
                 await _enumerator.DisposeAsync().ConfigureAwait(false);
+            _linkedCts?.Dispose();
+            _linkedCts = null;
 
             if ((_behavior & CommandBehavior.CloseConnection) != 0 && _connection != null)
                 await _connection.CloseAsync().ConfigureAwait(false);

--- a/src/Couchbase.EntityFrameworkCore/Storage/Internal/CouchbaseDbDataReader.cs
+++ b/src/Couchbase.EntityFrameworkCore/Storage/Internal/CouchbaseDbDataReader.cs
@@ -235,9 +235,9 @@ public class CouchbaseDbDataReader<T> : DbDataReader
     /// </summary>
     internal async Task PrimeAsync(CancellationToken cancellationToken)
     {
+        cancellationToken.ThrowIfCancellationRequested();
         if (_hasRows.HasValue || _hasBufferedRow || _hasCurrentRow)
             return;
-        cancellationToken.ThrowIfCancellationRequested();
         EnsureEnumerator(cancellationToken);
         var hasMore = await _enumerator!.MoveNextAsync().ConfigureAwait(false);
         if (hasMore)

--- a/src/Couchbase.EntityFrameworkCore/Storage/Internal/CouchbaseDbDataReader.cs
+++ b/src/Couchbase.EntityFrameworkCore/Storage/Internal/CouchbaseDbDataReader.cs
@@ -280,7 +280,13 @@ public class CouchbaseDbDataReader<T> : DbDataReader
     /// <see cref="CouchbaseCommand"/> so that <c>DbCommand.Cancel()</c> propagates to the
     /// enumerator for the reader's full lifetime.  The source is disposed when the reader closes.
     /// </summary>
-    internal void SetLinkedCts(CancellationTokenSource cts) => _linkedCts = cts;
+    internal void SetLinkedCts(CancellationTokenSource cts)
+    {
+        ArgumentNullException.ThrowIfNull(cts);
+        if (_linkedCts is not null)
+            throw new InvalidOperationException("A linked CancellationTokenSource is already set. SetLinkedCts may only be called once.");
+        _linkedCts = cts;
+    }
 
     /// <summary>
     /// Advances the reader to the next result set. Always returns <c>false</c> for Couchbase.

--- a/src/Couchbase.EntityFrameworkCore/Storage/Internal/CouchbaseDbDataReader.cs
+++ b/src/Couchbase.EntityFrameworkCore/Storage/Internal/CouchbaseDbDataReader.cs
@@ -121,7 +121,7 @@ public class CouchbaseDbDataReader<T> : DbDataReader
             EnsureCurrentRow();
             if (_currentRow is JsonElement je)
                 return je.ValueKind == JsonValueKind.Object ? je.EnumerateObject().Count() : 1;
-            return 0;
+            return 1; // null row (SELECT RAW null) — one column, value is DBNull
         }
     }
 
@@ -348,18 +348,16 @@ public class CouchbaseDbDataReader<T> : DbDataReader
 
         // No column names: positional from current row.
         EnsureCurrentRow();
-        if (_currentRow is JsonElement jePos)
+        if (_currentRow is JsonElement jePos && jePos.ValueKind == JsonValueKind.Object)
         {
-            if (jePos.ValueKind == JsonValueKind.Object)
-            {
-                var i = 0;
-                foreach (var prop in jePos.EnumerateObject())
-                    if (i++ == ordinal) return prop.Name;
-                throw new IndexOutOfRangeException($"Ordinal {ordinal} is out of range.");
-            }
-            if (ordinal == 0)
-                return string.Empty;
+            var i = 0;
+            foreach (var prop in jePos.EnumerateObject())
+                if (i++ == ordinal) return prop.Name;
+            throw new IndexOutOfRangeException($"Ordinal {ordinal} is out of range.");
         }
+        // Scalar (non-object JsonElement) or null row (SELECT RAW null): one column at ordinal 0.
+        if (ordinal == 0)
+            return string.Empty;
         throw new IndexOutOfRangeException($"Ordinal {ordinal} is out of range.");
     }
 
@@ -403,25 +401,19 @@ public class CouchbaseDbDataReader<T> : DbDataReader
 
         // No column names: positional scan of current row.
         EnsureCurrentRow();
-        if (_currentRow is JsonElement jePos)
+        if (_currentRow is JsonElement jePos && jePos.ValueKind == JsonValueKind.Object)
         {
-            if (jePos.ValueKind == JsonValueKind.Object)
+            var i = 0;
+            foreach (var prop in jePos.EnumerateObject())
             {
-                var i = 0;
-                foreach (var prop in jePos.EnumerateObject())
-                {
-                    if (StringComparer.OrdinalIgnoreCase.Equals(prop.Name, name))
-                        return i;
-                    i++;
-                }
+                if (StringComparer.OrdinalIgnoreCase.Equals(prop.Name, name))
+                    return i;
+                i++;
             }
-            else
-            {
-                // Scalar SELECT RAW: any name maps to ordinal 0.
-                return 0;
-            }
+            throw new IndexOutOfRangeException($"Field '{name}' not found.");
         }
-        throw new IndexOutOfRangeException($"Field '{name}' not found.");
+        // Scalar (non-object JsonElement) or null row (SELECT RAW null): any name maps to ordinal 0.
+        return 0;
     }
 
     /// <summary>
@@ -505,6 +497,8 @@ public class CouchbaseDbDataReader<T> : DbDataReader
             if (ordinal == 0)
                 return ConvertJsonElement(jeFallback);
         }
+        else if (_currentRow == null && ordinal == 0)
+            return DBNull.Value; // null row (SELECT RAW null)
         throw new IndexOutOfRangeException($"Ordinal {ordinal} is out of range.");
     }
 
@@ -531,7 +525,7 @@ public class CouchbaseDbDataReader<T> : DbDataReader
         }
         else
         {
-            fieldCount = _currentRow is JsonElement ? 1 : 0;
+            fieldCount = 1; // scalar JsonElement or null row (SELECT RAW null)
         }
 
         var count = Math.Min(values.Length, fieldCount);
@@ -857,31 +851,29 @@ public class CouchbaseDbDataReader<T> : DbDataReader
 
         // No column names: build from current row.
         EnsureCurrentRow();
-        if (_currentRow is JsonElement je)
+        if (_currentRow is JsonElement je && je.ValueKind == JsonValueKind.Object)
         {
-            if (je.ValueKind == JsonValueKind.Object)
+            var i = 0;
+            foreach (var prop in je.EnumerateObject())
             {
-                var i = 0;
-                foreach (var prop in je.EnumerateObject())
-                {
-                    var row = schemaTable.NewRow();
-                    row["ColumnName"] = prop.Name;
-                    row["ColumnOrdinal"] = i++;
-                    row["DataType"] = typeof(object);
-                    row["AllowDBNull"] = true;
-                    schemaTable.Rows.Add(row);
-                }
-            }
-            else
-            {
-                // Scalar SELECT RAW: consistent with FieldCount==1 and GetName(0)=="".
                 var row = schemaTable.NewRow();
-                row["ColumnName"] = string.Empty;
-                row["ColumnOrdinal"] = 0;
+                row["ColumnName"] = prop.Name;
+                row["ColumnOrdinal"] = i++;
                 row["DataType"] = typeof(object);
                 row["AllowDBNull"] = true;
                 schemaTable.Rows.Add(row);
             }
+        }
+        else
+        {
+            // Scalar (non-object JsonElement) or null row (SELECT RAW null):
+            // one column, consistent with FieldCount==1 and GetName(0)=="".
+            var row = schemaTable.NewRow();
+            row["ColumnName"] = string.Empty;
+            row["ColumnOrdinal"] = 0;
+            row["DataType"] = typeof(object);
+            row["AllowDBNull"] = true;
+            schemaTable.Rows.Add(row);
         }
         return schemaTable;
     }

--- a/src/Couchbase.EntityFrameworkCore/Storage/Internal/CouchbaseDbDataReader.cs
+++ b/src/Couchbase.EntityFrameworkCore/Storage/Internal/CouchbaseDbDataReader.cs
@@ -231,6 +231,8 @@ public class CouchbaseDbDataReader<T> : DbDataReader
     /// </summary>
     internal async Task PrimeAsync(CancellationToken cancellationToken)
     {
+        if (_hasRows.HasValue || _hasBufferedRow || _hasCurrentRow)
+            return;
         cancellationToken.ThrowIfCancellationRequested();
         EnsureEnumerator(cancellationToken);
         var hasMore = await _enumerator!.MoveNextAsync().ConfigureAwait(false);

--- a/src/Couchbase.EntityFrameworkCore/Storage/Internal/CouchbaseDbDataReader.cs
+++ b/src/Couchbase.EntityFrameworkCore/Storage/Internal/CouchbaseDbDataReader.cs
@@ -355,8 +355,8 @@ public class CouchbaseDbDataReader<T> : DbDataReader
                 foreach (var prop in je.EnumerateObject())
                     if (i++ == ordinal) return prop.Name;
             }
-            else if (ordinal == 0)
-                return string.Empty; // scalar or null row (SELECT RAW scalar/null) at null slot 0
+            else
+                return string.Empty; // scalar or null row: all in-range null slots report ""
             throw new IndexOutOfRangeException($"Ordinal {ordinal} is out of range. FieldCount: {_columnNames.Length}");
         }
 

--- a/src/Couchbase.EntityFrameworkCore/Storage/Internal/CouchbaseDbDataReader.cs
+++ b/src/Couchbase.EntityFrameworkCore/Storage/Internal/CouchbaseDbDataReader.cs
@@ -290,6 +290,7 @@ public class CouchbaseDbDataReader<T> : DbDataReader
         {
             _isClosed = true;
             _enumerator?.DisposeAsync().AsTask().GetAwaiter().GetResult();
+            _queryResult.Dispose();
             _linkedCts?.Dispose();
             _linkedCts = null;
 
@@ -308,6 +309,10 @@ public class CouchbaseDbDataReader<T> : DbDataReader
             _isClosed = true;
             if (_enumerator != null)
                 await _enumerator.DisposeAsync().ConfigureAwait(false);
+            if (_queryResult is IAsyncDisposable asyncDisposable)
+                await asyncDisposable.DisposeAsync().ConfigureAwait(false);
+            else 
+                _queryResult.Dispose();
             _linkedCts?.Dispose();
             _linkedCts = null;
 

--- a/src/Couchbase.EntityFrameworkCore/Storage/Internal/CouchbaseDbDataReader.cs
+++ b/src/Couchbase.EntityFrameworkCore/Storage/Internal/CouchbaseDbDataReader.cs
@@ -96,13 +96,19 @@ public class CouchbaseDbDataReader<T> : DbDataReader
     /// <param name="queryResult">The Couchbase query result to read from.</param>
     /// <param name="connection">The connection to close when <see cref="CommandBehavior.CloseConnection"/> is set.</param>
     /// <param name="behavior">The command behavior flags.</param>
-    /// <param name="cancellationToken">Unused at construction; reserved for future use.</param>
+    /// <param name="cancellationToken">
+    /// The default cancellation token bound to the underlying row enumerator. Used when
+    /// <see cref="PrimeAsync"/> or <see cref="ReadAsync"/> are called with
+    /// <see cref="CancellationToken.None"/>. Typically <c>linkedCts.Token</c> from
+    /// <see cref="CouchbaseCommand"/> so that <c>DbCommand.Cancel()</c> propagates correctly.
+    /// </param>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="queryResult"/> is null.</exception>
     public CouchbaseDbDataReader(IQueryResult<T> queryResult, DbConnection? connection, CommandBehavior behavior, CancellationToken cancellationToken)
     {
         _queryResult = queryResult ?? throw new ArgumentNullException(nameof(queryResult));
         _connection = connection;
         _behavior = behavior;
+        _cancellationToken = cancellationToken;
     }
 
     /// <summary>
@@ -223,11 +229,14 @@ public class CouchbaseDbDataReader<T> : DbDataReader
         if (_enumerator == null)
         {
             // The token is bound at GetAsyncEnumerator() time and cannot be retargeted.
-            // All callers must pass the same long-lived token (e.g. linkedCts.Token from
-            // CouchbaseCommand) so that CancellationToken bindings remain consistent for
-            // the reader's lifetime.  Tokens passed to subsequent ReadAsync calls only
-            // affect the upfront ThrowIfCancellationRequested check, not in-flight MoveNextAsync.
-            _cancellationToken = cancellationToken;
+            // A non-None call-time token (e.g. linkedCts.Token from PrimeAsync) overrides
+            // the construction-time default; CancellationToken.None falls back to the token
+            // stored at construction so that callers using the 4-arg constructor do not need
+            // to re-pass the same token to every ReadAsync call.
+            // Tokens passed to subsequent ReadAsync calls only affect the upfront
+            // ThrowIfCancellationRequested check, not in-flight MoveNextAsync.
+            if (cancellationToken != CancellationToken.None)
+                _cancellationToken = cancellationToken;
             _enumerator = _queryResult.Rows.GetAsyncEnumerator(_cancellationToken);
         }
     }

--- a/src/Couchbase.EntityFrameworkCore/Storage/Internal/CouchbaseDbDataReader.cs
+++ b/src/Couchbase.EntityFrameworkCore/Storage/Internal/CouchbaseDbDataReader.cs
@@ -398,6 +398,8 @@ public class CouchbaseDbDataReader<T> : DbDataReader
                     i++;
                 }
             }
+            else
+                return 0; // scalar or null row (SELECT RAW scalar/null) at null slot — any name maps to 0
             throw new IndexOutOfRangeException($"Field '{name}' not found.");
         }
 

--- a/src/Couchbase.EntityFrameworkCore/Storage/Internal/CouchbaseDbDataReader.cs
+++ b/src/Couchbase.EntityFrameworkCore/Storage/Internal/CouchbaseDbDataReader.cs
@@ -20,11 +20,11 @@ namespace Couchbase.EntityFrameworkCore.Storage.Internal;
 /// </para>
 /// <para>
 /// <b>Column names:</b> When <paramref name="columnNames"/> is supplied the reader maps each
-/// projection alias to its shaper ordinal at construction time. Field-name lookup and
-/// <see cref="FieldCount"/> are O(1) and work before the first <see cref="ReadAsync"/> call.
-/// Null slots in <paramref name="columnNames"/> indicate positional (unaliased) columns; those
-/// resolve against the current row's JSON property order and therefore require a prior
-/// <see cref="ReadAsync"/> call.
+/// projection alias to its shaper ordinal at construction time. <see cref="FieldCount"/> is
+/// always O(1). Non-null alias slots resolve field names and ordinals in O(1) without a prior
+/// <see cref="ReadAsync"/> call. Null slots indicate positional (unaliased) columns; those
+/// resolve against the current row's JSON property order (O(m) scan) and therefore require a
+/// prior <see cref="ReadAsync"/> call.
 /// </para>
 /// <para>
 /// When <paramref name="columnNames"/> is not supplied (raw ADO.NET path via

--- a/src/Couchbase.EntityFrameworkCore/Storage/Internal/CouchbaseDbDataReader.cs
+++ b/src/Couchbase.EntityFrameworkCore/Storage/Internal/CouchbaseDbDataReader.cs
@@ -857,14 +857,27 @@ public class CouchbaseDbDataReader<T> : DbDataReader
 
         // No column names: build from current row.
         EnsureCurrentRow();
-        if (_currentRow is JsonElement je && je.ValueKind == JsonValueKind.Object)
+        if (_currentRow is JsonElement je)
         {
-            var i = 0;
-            foreach (var prop in je.EnumerateObject())
+            if (je.ValueKind == JsonValueKind.Object)
             {
+                var i = 0;
+                foreach (var prop in je.EnumerateObject())
+                {
+                    var row = schemaTable.NewRow();
+                    row["ColumnName"] = prop.Name;
+                    row["ColumnOrdinal"] = i++;
+                    row["DataType"] = typeof(object);
+                    row["AllowDBNull"] = true;
+                    schemaTable.Rows.Add(row);
+                }
+            }
+            else
+            {
+                // Scalar SELECT RAW: consistent with FieldCount==1 and GetName(0)=="".
                 var row = schemaTable.NewRow();
-                row["ColumnName"] = prop.Name;
-                row["ColumnOrdinal"] = i++;
+                row["ColumnName"] = string.Empty;
+                row["ColumnOrdinal"] = 0;
                 row["DataType"] = typeof(object);
                 row["AllowDBNull"] = true;
                 schemaTable.Rows.Add(row);

--- a/src/Couchbase.EntityFrameworkCore/Storage/Internal/CouchbaseDbDataReader.cs
+++ b/src/Couchbase.EntityFrameworkCore/Storage/Internal/CouchbaseDbDataReader.cs
@@ -63,6 +63,9 @@ public class CouchbaseDbDataReader<T> : DbDataReader
     private bool _hasCurrentRow;
     private bool? _hasRows;
     private bool _isClosed;
+    // Cached field count for the positional (no-_columnNames) path; -1 means not yet computed.
+    // Invalidated on every ReadAsync so it is recomputed from the new row.
+    private int _cachedFieldCount = -1;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="CouchbaseDbDataReader{T}"/> class with an
@@ -125,9 +128,13 @@ public class CouchbaseDbDataReader<T> : DbDataReader
             if (_columnNames != null)
                 return _columnNames.Length;
             EnsureCurrentRow();
+            if (_cachedFieldCount >= 0)
+                return _cachedFieldCount;
             if (_currentRow is JsonElement je)
-                return je.ValueKind == JsonValueKind.Object ? je.EnumerateObject().Count() : 1;
-            return 1; // null row (SELECT RAW null) — one column, value is DBNull
+                return _cachedFieldCount = je.ValueKind == JsonValueKind.Object
+                    ? je.EnumerateObject().Count()
+                    : 1;
+            return _cachedFieldCount = 1; // null row (SELECT RAW null) — one column, value is DBNull
         }
     }
 
@@ -193,6 +200,7 @@ public class CouchbaseDbDataReader<T> : DbDataReader
         if (_isClosed)
             return false;
 
+        _cachedFieldCount = -1; // invalidate per-row cache on every advance attempt
         cancellationToken.ThrowIfCancellationRequested();
 
         // If PrimeAsync buffered the first row, return it without re-advancing the enumerator.

--- a/tests/Couchbase.EntityFrameworkCore.UnitTests/Couchbase/EntityFrameworkCore/Storage/Internal/CouchbaseCommandTests.cs
+++ b/tests/Couchbase.EntityFrameworkCore.UnitTests/Couchbase/EntityFrameworkCore/Storage/Internal/CouchbaseCommandTests.cs
@@ -1,5 +1,6 @@
 using System.Data;
 using System.Data.Common;
+using System.Runtime.CompilerServices;
 using System.Text.Json;
 using Couchbase.EntityFrameworkCore.Infrastructure;
 using Couchbase.EntityFrameworkCore.Storage.Internal;
@@ -670,6 +671,88 @@ public class CouchbaseCommandTests
         // Should not throw even with CloseConnection and no connection
         var exception = await Record.ExceptionAsync(async () => await reader.CloseAsync());
         Assert.Null(exception);
+    }
+
+    /// <summary>
+    /// Proves the linked-CTS ownership-transfer fix: <see cref="CouchbaseCommand.Cancel"/> must
+    /// propagate to the in-flight enumerator for the full lifetime of the reader.
+    ///
+    /// Before the fix, <c>PrimeAsync</c> was called with the external <c>cancellationToken</c>
+    /// rather than <c>linkedCts.Token</c>, so the enumerator was bound to a token that
+    /// <c>DbCommand.Cancel()</c> could never reach.  The external token here is
+    /// <see cref="CancellationToken.None"/>, so the only source of cancellation is the internal
+    /// command CTS — exactly the path the fix enables.
+    /// </summary>
+    [Fact]
+    public async Task Cancel_AfterExecuteReaderAsync_FaultsNextReadAsync()
+    {
+        var rows = new List<JsonElement>
+        {
+            ParseElement("{\"id\": 1}"),
+            ParseElement("{\"id\": 2}"),
+            ParseElement("{\"id\": 3}")
+        };
+
+        // CancellableEnumerable uses [EnumeratorCancellation] so the token injected via
+        // GetAsyncEnumerator(token) is checked on each MoveNextAsync — unlike
+        // List.ToAsyncEnumerable() which ignores the token entirely.
+        var mockQueryResult = CreateMockQueryResultWithCancellableRows(rows);
+        _mockCluster.Setup(c => c.QueryAsync<JsonElement>(It.IsAny<string>(), It.IsAny<QueryOptions>()))
+            .ReturnsAsync(mockQueryResult);
+
+        var command = new CouchbaseCommand
+        {
+            Cluster = _mockCluster.Object,
+            CommandText = "SELECT * FROM bucket"
+        };
+
+        // ExecuteReaderAsync calls PrimeAsync(linkedCts.Token), binding the enumerator to
+        // a token that command.Cancel() can reach.  The external token is None so it
+        // contributes nothing — if the CTS transfer regressed, Cancel() would be a no-op.
+        var reader = await command.ExecuteReaderAsync(CancellationToken.None);
+
+        // Drain the PrimeAsync-buffered first row.
+        Assert.True(await reader.ReadAsync(CancellationToken.None));
+        Assert.Equal(1L, reader.GetValue(0));
+
+        // Cancel the command mid-stream.
+        command.Cancel();
+
+        // The next ReadAsync must fault because the enumerator's token is now cancelled.
+        // ReadAsync is called with CancellationToken.None to confirm that cancellation
+        // comes solely from command.Cancel(), not from the caller's token.
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(
+            () => reader.ReadAsync(CancellationToken.None));
+    }
+
+    private static IQueryResult<JsonElement> CreateMockQueryResultWithCancellableRows(
+        List<JsonElement> rows)
+    {
+        var mockResult = new Mock<IQueryResult<JsonElement>>();
+        mockResult.Setup(r => r.Rows).Returns(CancellableEnumerable(rows));
+        mockResult.Setup(r => r.MetaData).Returns((QueryMetaData?)null);
+        return mockResult.Object;
+    }
+
+    // [EnumeratorCancellation] causes the compiler to inject the token passed to
+    // GetAsyncEnumerator(token) into the cancellationToken parameter, so each
+    // MoveNextAsync actually observes cancellation — unlike List.ToAsyncEnumerable().
+    private static async IAsyncEnumerable<JsonElement> CancellableEnumerable(
+        IEnumerable<JsonElement> rows,
+        [EnumeratorCancellation] CancellationToken cancellationToken = default)
+    {
+        foreach (var row in rows)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            await Task.Yield();
+            yield return row;
+        }
+    }
+
+    private static JsonElement ParseElement(string json)
+    {
+        using var doc = JsonDocument.Parse(json);
+        return doc.RootElement.Clone();
     }
 
     private static IQueryResult<T> CreateMockQueryResultWithRows<T>(List<T> rows)

--- a/tests/Couchbase.EntityFrameworkCore.UnitTests/Couchbase/EntityFrameworkCore/Storage/Internal/CouchbaseDbDataReaderTests.cs
+++ b/tests/Couchbase.EntityFrameworkCore.UnitTests/Couchbase/EntityFrameworkCore/Storage/Internal/CouchbaseDbDataReaderTests.cs
@@ -1443,13 +1443,18 @@ public class CouchbaseDbDataReaderTests
     }
 
     [Fact]
-    public async Task GetName_NullSlot_ScalarRow_OrdinalNonZero_ThrowsIndexOutOfRangeException()
+    public async Task GetName_NullSlot_ScalarRow_AllInRangeOrdinalsReturnEmptyString()
     {
+        // A scalar row with multiple null slots: GetName must return "" for all in-range
+        // ordinals, symmetric with GetValue which returns DBNull.Value for the same ordinals.
         var rows = new List<JsonElement> { ParseElement("42") };
-        var reader = CreateReaderWithColumnNames(rows, new string?[] { null, null });
+        var reader = CreateReaderWithColumnNames(rows, new string?[] { null, null, null });
         await reader.ReadAsync(CancellationToken.None);
 
-        Assert.Throws<IndexOutOfRangeException>(() => reader.GetName(1));
+        Assert.Equal(string.Empty, reader.GetName(0));
+        Assert.Equal(string.Empty, reader.GetName(1));
+        Assert.Equal(string.Empty, reader.GetName(2));
+        Assert.Throws<IndexOutOfRangeException>(() => reader.GetName(3));
     }
 
     [Fact]

--- a/tests/Couchbase.EntityFrameworkCore.UnitTests/Couchbase/EntityFrameworkCore/Storage/Internal/CouchbaseDbDataReaderTests.cs
+++ b/tests/Couchbase.EntityFrameworkCore.UnitTests/Couchbase/EntityFrameworkCore/Storage/Internal/CouchbaseDbDataReaderTests.cs
@@ -1764,6 +1764,97 @@ public class CouchbaseDbDataReaderTests
 
     #endregion
 
+    #region PrimeAsync — HasRows and buffered-first-row via PrimeAsync
+
+    [Fact]
+    public async Task PrimeAsync_WithRows_HasRowsIsTrueBeforeReadAsync()
+    {
+        // Simulates the ExecuteReaderAsync path: PrimeAsync is called after construction,
+        // and HasRows must return true before any ReadAsync call.
+        var rows = new List<JsonElement> { ParseElement("{\"id\": 1}") };
+        var reader = CreateReader(rows);
+
+        await reader.PrimeAsync(CancellationToken.None);
+
+        Assert.True(reader.HasRows);
+    }
+
+    [Fact]
+    public async Task PrimeAsync_WithNoRows_HasRowsIsFalseBeforeReadAsync()
+    {
+        var reader = CreateReader(new List<JsonElement>());
+
+        await reader.PrimeAsync(CancellationToken.None);
+
+        Assert.False(reader.HasRows);
+    }
+
+    [Fact]
+    public async Task PrimeAsync_FirstReadAsyncReturnsBufferedRow()
+    {
+        // After PrimeAsync, the first ReadAsync must return the buffered first row
+        // without skipping it (no row consumed by the prime peek is lost).
+        var rows = new List<JsonElement>
+        {
+            ParseElement("{\"id\": 1}"),
+            ParseElement("{\"id\": 2}")
+        };
+        var reader = CreateReader(rows);
+
+        await reader.PrimeAsync(CancellationToken.None);
+
+        Assert.True(await reader.ReadAsync(CancellationToken.None));
+        Assert.Equal(1L, reader.GetInt64(0));
+
+        Assert.True(await reader.ReadAsync(CancellationToken.None));
+        Assert.Equal(2L, reader.GetInt64(0));
+
+        Assert.False(await reader.ReadAsync(CancellationToken.None));
+    }
+
+    [Fact]
+    public async Task PrimeAsync_WithNoRows_ReadAsyncReturnsFalse()
+    {
+        var reader = CreateReader(new List<JsonElement>());
+
+        await reader.PrimeAsync(CancellationToken.None);
+
+        Assert.False(await reader.ReadAsync(CancellationToken.None));
+    }
+
+    [Fact]
+    public async Task PrimeAsync_WithCancelledToken_ThrowsOperationCanceledException()
+    {
+        var rows = new List<JsonElement> { ParseElement("{\"id\": 1}") };
+        var reader = CreateReader(rows);
+
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+
+        // PrimeAsync calls EnsureEnumerator then MoveNextAsync; the enumerator
+        // created via GetAsyncEnumerator(cancelledToken) should propagate cancellation.
+        // (The exact throw point is implementation-defined, but cancellation must surface.)
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(
+            () => reader.PrimeAsync(cts.Token));
+    }
+
+    [Fact]
+    public async Task PrimeAsync_FieldAccessAfterBufferedRead_WorksCorrectly()
+    {
+        // After PrimeAsync + ReadAsync, all field accessors must see the buffered row.
+        var rows = new List<JsonElement> { ParseElement("{\"id\": 99, \"name\": \"alice\"}") };
+        var reader = CreateReaderWithColumnNames(rows, new string?[] { "id", "name" });
+
+        await reader.PrimeAsync(CancellationToken.None);
+        Assert.True(reader.HasRows);
+
+        Assert.True(await reader.ReadAsync(CancellationToken.None));
+        Assert.Equal(99L, reader.GetInt64(0));
+        Assert.Equal("alice", reader.GetString(1));
+    }
+
+    #endregion
+
     #region Phase 2 — TryGetPropertyCI and GetOrdinal null-slot guards
 
     // GetValue — case-insensitive property lookup via TryGetPropertyCI

--- a/tests/Couchbase.EntityFrameworkCore.UnitTests/Couchbase/EntityFrameworkCore/Storage/Internal/CouchbaseDbDataReaderTests.cs
+++ b/tests/Couchbase.EntityFrameworkCore.UnitTests/Couchbase/EntityFrameworkCore/Storage/Internal/CouchbaseDbDataReaderTests.cs
@@ -1564,6 +1564,30 @@ public class CouchbaseDbDataReaderTests
     }
 
     [Fact]
+    public async Task GetOrdinal_NullSlot_ScalarRow_AnyName_ReturnsZero()
+    {
+        // Scalar (non-object) row at a null slot — any name maps to ordinal 0,
+        // consistent with the no-column-names scalar path.
+        var rows = new List<JsonElement> { ParseElement("42") };
+        var reader = CreateReaderWithColumnNames(rows, new string?[] { null });
+        await reader.ReadAsync(CancellationToken.None);
+
+        Assert.Equal(0, reader.GetOrdinal("anything"));
+    }
+
+    [Fact]
+    public async Task GetOrdinal_NullSlot_NullRow_AnyName_ReturnsZero()
+    {
+        // Null row (SELECT RAW null) at a null slot — any name maps to ordinal 0.
+        var mockQueryResult = new Mock<IQueryResult<object?>>();
+        mockQueryResult.Setup(q => q.Rows).Returns(new object?[] { null }.ToAsyncEnumerable());
+        var reader = new CouchbaseDbDataReader<object?>(mockQueryResult.Object!, (string?[]?)new string?[] { null });
+        await reader.ReadAsync(CancellationToken.None);
+
+        Assert.Equal(0, reader.GetOrdinal("anything"));
+    }
+
+    [Fact]
     public async Task GetOrdinal_NullSlot_AliasNameInNonNullSlotIsNotResolvedViaFallback()
     {
         // "name" is already a non-null alias at slot 1.  If someone asks for ordinal

--- a/tests/Couchbase.EntityFrameworkCore.UnitTests/Couchbase/EntityFrameworkCore/Storage/Internal/CouchbaseDbDataReaderTests.cs
+++ b/tests/Couchbase.EntityFrameworkCore.UnitTests/Couchbase/EntityFrameworkCore/Storage/Internal/CouchbaseDbDataReaderTests.cs
@@ -2327,6 +2327,36 @@ public class CouchbaseDbDataReaderTests
 
     #endregion
 
+    #region SetLinkedCts guards
+
+    [Fact]
+    public void SetLinkedCts_WithNullCts_ThrowsArgumentNullException()
+    {
+        var reader = CreateReader(new List<JsonElement>());
+        Assert.Throws<ArgumentNullException>(() => reader.SetLinkedCts(null!));
+    }
+
+    [Fact]
+    public void SetLinkedCts_CalledTwice_ThrowsInvalidOperationException()
+    {
+        var reader = CreateReader(new List<JsonElement>());
+        using var cts1 = new CancellationTokenSource();
+        using var cts2 = new CancellationTokenSource();
+
+        reader.SetLinkedCts(cts1); // first call is fine
+        Assert.Throws<InvalidOperationException>(() => reader.SetLinkedCts(cts2));
+    }
+
+    [Fact]
+    public void SetLinkedCts_CalledOnce_DoesNotThrow()
+    {
+        var reader = CreateReader(new List<JsonElement>());
+        using var cts = new CancellationTokenSource();
+        reader.SetLinkedCts(cts); // must not throw
+    }
+
+    #endregion
+
     private static JsonElement ParseElement(string json)
     {
         using var doc = JsonDocument.Parse(json);

--- a/tests/Couchbase.EntityFrameworkCore.UnitTests/Couchbase/EntityFrameworkCore/Storage/Internal/CouchbaseDbDataReaderTests.cs
+++ b/tests/Couchbase.EntityFrameworkCore.UnitTests/Couchbase/EntityFrameworkCore/Storage/Internal/CouchbaseDbDataReaderTests.cs
@@ -1510,6 +1510,17 @@ public class CouchbaseDbDataReaderTests
     }
 
     [Fact]
+    public void GetOrdinal_NullSlot_NoCurrentRow_ThrowsInvalidOperationException()
+    {
+        // Null-slot resolution requires a current row. Before ReadAsync is called the
+        // exception must be InvalidOperationException, not IndexOutOfRangeException.
+        var rows = new List<JsonElement> { ParseElement("{\"id\": 1}") };
+        var reader = CreateReaderWithColumnNames(rows, new string?[] { null });
+
+        Assert.Throws<InvalidOperationException>(() => reader.GetOrdinal("id"));
+    }
+
+    [Fact]
     public async Task GetOrdinal_NullSlot_AliasNameInNonNullSlotIsNotResolvedViaFallback()
     {
         // "name" is already a non-null alias at slot 1.  If someone asks for ordinal

--- a/tests/Couchbase.EntityFrameworkCore.UnitTests/Couchbase/EntityFrameworkCore/Storage/Internal/CouchbaseDbDataReaderTests.cs
+++ b/tests/Couchbase.EntityFrameworkCore.UnitTests/Couchbase/EntityFrameworkCore/Storage/Internal/CouchbaseDbDataReaderTests.cs
@@ -12,7 +12,16 @@ public class CouchbaseDbDataReaderTests
     [Fact]
     public void Constructor_WithNullQueryResult_ThrowsArgumentNullException()
     {
-        Assert.Throws<ArgumentNullException>(() => new CouchbaseDbDataReader<object>(null!));
+        Assert.Throws<ArgumentNullException>(() =>
+            new CouchbaseDbDataReader<object>(null!, Array.Empty<string?>()));
+    }
+
+    [Fact]
+    public void Constructor_WithNullColumnNames_ThrowsArgumentNullException()
+    {
+        var mockQueryResult = new Mock<IQueryResult<object>>();
+        Assert.Throws<ArgumentNullException>(() =>
+            new CouchbaseDbDataReader<object>(mockQueryResult.Object, null!));
     }
 
     [Fact]
@@ -154,7 +163,6 @@ public class CouchbaseDbDataReaderTests
     {
         var reader = CreateReader(new List<JsonElement>());
 
-        // GetValue requires a current row, which requires calling Read() first
         Assert.Throws<InvalidOperationException>(() => reader.GetValue(0));
     }
 
@@ -422,11 +430,14 @@ public class CouchbaseDbDataReaderTests
     }
 
     [Fact]
-    public void HasRows_WithRows_ReturnsTrue()
+    public async Task HasRows_WithRows_ReturnsTrue()
     {
         var rows = new List<JsonElement> { ParseElement("{\"id\": 1}") };
         var reader = CreateReader(rows);
 
+        // After Phase 3: HasRows is false before ReadAsync (no peeking).
+        Assert.False(reader.HasRows);
+        Assert.True(await reader.ReadAsync(CancellationToken.None));
         Assert.True(reader.HasRows);
     }
 
@@ -444,11 +455,9 @@ public class CouchbaseDbDataReaderTests
         var rows = new List<JsonElement> { ParseElement("{\"id\": 1}") };
         var reader = CreateReader(rows);
 
-        // Read and exhaust all rows
         Assert.True(await reader.ReadAsync(CancellationToken.None));
         Assert.False(await reader.ReadAsync(CancellationToken.None));
 
-        // HasRows should still be true (it reflects whether there were rows, not current state)
         Assert.True(reader.HasRows);
     }
 
@@ -462,11 +471,12 @@ public class CouchbaseDbDataReaderTests
         };
         var reader = CreateReader(rows);
 
-        // Check HasRows first
-        Assert.True(reader.HasRows);
+        // After Phase 3: HasRows returns false before ReadAsync (no peeking).
+        Assert.False(reader.HasRows);
 
-        // First row should still be readable
+        // All rows remain readable.
         Assert.True(await reader.ReadAsync(CancellationToken.None));
+        Assert.True(reader.HasRows);
         Assert.Equal(1L, reader.GetInt64(0));
 
         Assert.True(await reader.ReadAsync(CancellationToken.None));
@@ -602,8 +612,9 @@ public class CouchbaseDbDataReaderTests
     }
 
     [Fact]
-    public async Task FieldCount_BeforeRead_DoesNotSkipFirstRow()
+    public async Task FieldCount_AfterFirstRead_ReturnsCorrectCount()
     {
+        // After Phase 3: without column names, FieldCount requires a current row.
         var rows = new List<JsonElement>
         {
             ParseElement("{\"id\": 1}"),
@@ -611,25 +622,20 @@ public class CouchbaseDbDataReaderTests
         };
         var reader = CreateReader(rows);
 
-        // Access FieldCount before Read() - this triggers schema discovery
-        var fieldCount = reader.FieldCount;
-        Assert.Equal(1, fieldCount);
-
-        // First Read() should return the first row, not skip it
         Assert.True(await reader.ReadAsync(CancellationToken.None));
+        Assert.Equal(1, reader.FieldCount);
         Assert.Equal(1L, reader.GetInt64(0));
 
-        // Second Read() should return the second row
         Assert.True(await reader.ReadAsync(CancellationToken.None));
         Assert.Equal(2L, reader.GetInt64(0));
 
-        // No more rows
         Assert.False(await reader.ReadAsync(CancellationToken.None));
     }
 
     [Fact]
-    public async Task GetName_BeforeRead_DoesNotSkipFirstRow()
+    public async Task GetName_AfterFirstRead_ReturnsFieldName()
     {
+        // After Phase 3: without column names, GetName resolves positionally from the current row.
         var rows = new List<JsonElement>
         {
             ParseElement("{\"name\": \"first\"}"),
@@ -637,54 +643,45 @@ public class CouchbaseDbDataReaderTests
         };
         var reader = CreateReader(rows);
 
-        // Access GetName before Read() - this triggers schema discovery
-        var name = reader.GetName(0);
-        Assert.Equal("name", name);
-
-        // First Read() should return the first row
         Assert.True(await reader.ReadAsync(CancellationToken.None));
+        Assert.Equal("name", reader.GetName(0));
         Assert.Equal("first", reader.GetString(0));
 
-        // Second Read() should return the second row
         Assert.True(await reader.ReadAsync(CancellationToken.None));
         Assert.Equal("second", reader.GetString(0));
     }
 
     [Fact]
-    public async Task GetOrdinal_BeforeRead_DoesNotSkipFirstRow()
+    public async Task GetOrdinal_AfterFirstRead_ReturnsCorrectOrdinal()
     {
+        // After Phase 3: without column names, GetOrdinal resolves positionally from the current row.
         var rows = new List<JsonElement>
         {
             ParseElement("{\"value\": 100}")
         };
         var reader = CreateReader(rows);
 
-        // Access GetOrdinal before Read()
-        var ordinal = reader.GetOrdinal("value");
-        Assert.Equal(0, ordinal);
-
-        // First Read() should still return the first (and only) row
         Assert.True(await reader.ReadAsync(CancellationToken.None));
+        Assert.Equal(0, reader.GetOrdinal("value"));
         Assert.Equal(100L, reader.GetInt64(0));
 
         Assert.False(await reader.ReadAsync(CancellationToken.None));
     }
 
     [Fact]
-    public async Task GetSchemaTable_BeforeRead_DoesNotSkipFirstRow()
+    public async Task GetSchemaTable_AfterFirstRead_ReflectsColumnNames()
     {
+        // After Phase 3: without column names, GetSchemaTable derives schema from the current row.
         var rows = new List<JsonElement>
         {
             ParseElement("{\"col1\": 1, \"col2\": 2}")
         };
         var reader = CreateReader(rows);
 
-        // Access schema before Read()
+        Assert.True(await reader.ReadAsync(CancellationToken.None));
         var schema = reader.GetSchemaTable();
         Assert.Equal(2, schema.Rows.Count);
 
-        // First Read() should return the first row
-        Assert.True(await reader.ReadAsync(CancellationToken.None));
         Assert.Equal(1L, reader.GetInt64(0));
         Assert.Equal(2L, reader.GetInt64(1));
     }
@@ -694,7 +691,7 @@ public class CouchbaseDbDataReaderTests
     [Fact]
     public void GetValue_BeforeAnyRead_ThrowsInvalidOperationException()
     {
-        // JsonElement is a value type - this tests that we track row availability
+        // JsonElement is a value type — this tests that we track row availability
         // with a boolean flag, not by checking _currentRow == null
         var rows = new List<JsonElement> { ParseElement("{\"id\": 1}") };
         var reader = CreateReader(rows);
@@ -712,9 +709,9 @@ public class CouchbaseDbDataReaderTests
         var reader = CreateReader(rows);
 
         Assert.True(await reader.ReadAsync(CancellationToken.None));
-        Assert.Equal(1L, reader.GetValue(0)); // This should work
+        Assert.Equal(1L, reader.GetValue(0));
 
-        Assert.False(await reader.ReadAsync(CancellationToken.None)); // No more rows
+        Assert.False(await reader.ReadAsync(CancellationToken.None));
 
         var ex = Assert.Throws<InvalidOperationException>(() => reader.GetValue(0));
         Assert.Contains("No current row", ex.Message);
@@ -830,22 +827,17 @@ public class CouchbaseDbDataReaderTests
         };
         var reader = CreateReader(rows);
 
-        // Before first read - no current row
         Assert.Throws<InvalidOperationException>(() => reader.GetValue(0));
 
-        // Read row 1
         Assert.True(await reader.ReadAsync(CancellationToken.None));
         Assert.Equal(1L, reader.GetInt64(0));
 
-        // Read row 2
         Assert.True(await reader.ReadAsync(CancellationToken.None));
         Assert.Equal(2L, reader.GetInt64(0));
 
-        // Read row 3
         Assert.True(await reader.ReadAsync(CancellationToken.None));
         Assert.Equal(3L, reader.GetInt64(0));
 
-        // No more rows - should throw again
         Assert.False(await reader.ReadAsync(CancellationToken.None));
         Assert.Throws<InvalidOperationException>(() => reader.GetValue(0));
     }
@@ -879,14 +871,11 @@ public class CouchbaseDbDataReaderTests
 
         using var cts = new CancellationTokenSource();
 
-        // First read should succeed
         Assert.True(await reader.ReadAsync(cts.Token));
         Assert.Equal(1L, reader.GetInt64(0));
 
-        // Cancel after first read
         cts.Cancel();
 
-        // Next read should throw
         await Assert.ThrowsAsync<OperationCanceledException>(
             () => reader.ReadAsync(cts.Token));
     }
@@ -903,12 +892,8 @@ public class CouchbaseDbDataReaderTests
 
         using var cts = new CancellationTokenSource();
 
-        // First read captures the token
         Assert.True(await reader.ReadAsync(cts.Token));
-
-        // Subsequent reads with different token still work (enumerator already created)
         Assert.True(await reader.ReadAsync(CancellationToken.None));
-
         Assert.False(await reader.ReadAsync(CancellationToken.None));
     }
 
@@ -1033,7 +1018,6 @@ public class CouchbaseDbDataReaderTests
     [Fact]
     public async Task GetFloat_WithValueExceedingFloatRange_ReturnsInfinity()
     {
-        // Values exceeding float range return infinity rather than throwing
         var rows = new List<JsonElement> { ParseElement("{\"val\": 3.5E+38}") };
         var reader = CreateReader(rows);
 
@@ -1046,7 +1030,6 @@ public class CouchbaseDbDataReaderTests
     [Fact]
     public async Task GetDecimal_WithValueExceedingDecimalRange_ThrowsOverflowException()
     {
-        // double.MaxValue exceeds decimal range
         var rows = new List<JsonElement> { ParseElement("{\"val\": 1.8E+308}") };
         var reader = CreateReader(rows);
 
@@ -1062,7 +1045,7 @@ public class CouchbaseDbDataReaderTests
     [Fact]
     public async Task GetBytes_WithNegativeDataOffset_ThrowsArgumentOutOfRangeException()
     {
-        var rows = new List<JsonElement> { ParseElement("{\"data\": \"SGVsbG8=\"}") }; // "Hello" in base64
+        var rows = new List<JsonElement> { ParseElement("{\"data\": \"SGVsbG8=\"}") };
         var reader = CreateReader(rows);
 
         await reader.ReadAsync(CancellationToken.None);
@@ -1104,7 +1087,6 @@ public class CouchbaseDbDataReaderTests
         await reader.ReadAsync(CancellationToken.None);
         var buffer = new byte[10];
 
-        // bufferOffset == buffer.Length is valid when length is 0
         var result = reader.GetBytes(0, 0, buffer, 10, 0);
         Assert.Equal(0, result);
     }
@@ -1124,7 +1106,7 @@ public class CouchbaseDbDataReaderTests
     [Fact]
     public async Task GetBytes_WithDataOffsetBeyondSourceLength_ReturnsZero()
     {
-        var rows = new List<JsonElement> { ParseElement("{\"data\": \"SGVsbG8=\"}") }; // 5 bytes
+        var rows = new List<JsonElement> { ParseElement("{\"data\": \"SGVsbG8=\"}") };
         var reader = CreateReader(rows);
 
         await reader.ReadAsync(CancellationToken.None);
@@ -1210,7 +1192,6 @@ public class CouchbaseDbDataReaderTests
         await reader.ReadAsync(CancellationToken.None);
         var buffer = new char[10];
 
-        // bufferOffset == buffer.Length is valid when length is 0
         var result = reader.GetChars(0, 0, buffer, 10, 0);
         Assert.Equal(0, result);
     }
@@ -1230,7 +1211,7 @@ public class CouchbaseDbDataReaderTests
     [Fact]
     public async Task GetChars_WithDataOffsetBeyondSourceLength_ReturnsZero()
     {
-        var rows = new List<JsonElement> { ParseElement("{\"text\": \"Hello\"}") }; // 5 chars
+        var rows = new List<JsonElement> { ParseElement("{\"text\": \"Hello\"}") };
         var reader = CreateReader(rows);
 
         await reader.ReadAsync(CancellationToken.None);
@@ -1269,91 +1250,6 @@ public class CouchbaseDbDataReaderTests
         Assert.Equal('e', buffer[2]);
         Assert.Equal('l', buffer[3]);
         Assert.Equal('l', buffer[4]);
-    }
-
-    #endregion
-
-    #region Initial Cancellation Token Tests
-
-    [Fact]
-    public void FieldCount_WithCancelledToken_ThrowsOperationCancelledException()
-    {
-        var cts = new CancellationTokenSource();
-        cts.Cancel();
-
-        var reader = CreateReaderWithCancellationToken(
-            new List<JsonElement> { ParseElement("{\"id\": 1}") },
-            cts.Token);
-
-        Assert.Throws<OperationCanceledException>(() => _ = reader.FieldCount);
-    }
-
-    [Fact]
-    public void HasRows_WithCancelledToken_ThrowsOperationCancelledException()
-    {
-        var cts = new CancellationTokenSource();
-        cts.Cancel();
-
-        var reader = CreateReaderWithCancellationToken(
-            new List<JsonElement> { ParseElement("{\"id\": 1}") },
-            cts.Token);
-
-        Assert.Throws<OperationCanceledException>(() => _ = reader.HasRows);
-    }
-
-    [Fact]
-    public void GetName_WithCancelledToken_ThrowsOperationCancelledException()
-    {
-        var cts = new CancellationTokenSource();
-        cts.Cancel();
-
-        var reader = CreateReaderWithCancellationToken(
-            new List<JsonElement> { ParseElement("{\"id\": 1}") },
-            cts.Token);
-
-        Assert.Throws<OperationCanceledException>(() => reader.GetName(0));
-    }
-
-    [Fact]
-    public void GetOrdinal_WithCancelledToken_ThrowsOperationCancelledException()
-    {
-        var cts = new CancellationTokenSource();
-        cts.Cancel();
-
-        var reader = CreateReaderWithCancellationToken(
-            new List<JsonElement> { ParseElement("{\"id\": 1}") },
-            cts.Token);
-
-        Assert.Throws<OperationCanceledException>(() => reader.GetOrdinal("id"));
-    }
-
-    [Fact]
-    public async Task SchemaDiscovery_WithValidToken_AllowsSubsequentReads()
-    {
-        // This test verifies that accessing schema properties before ReadAsync
-        // uses the initial token and doesn't prevent subsequent reads
-        var cts = new CancellationTokenSource();
-        var rows = new List<JsonElement>
-        {
-            ParseElement("{\"id\": 1}"),
-            ParseElement("{\"id\": 2}")
-        };
-
-        var reader = CreateReaderWithCancellationToken(rows, cts.Token);
-
-        // Access schema before ReadAsync - this triggers enumerator creation with initial token
-        Assert.Equal(1, reader.FieldCount);
-
-        // First read should work (buffered row from schema discovery)
-        Assert.True(await reader.ReadAsync(CancellationToken.None));
-        Assert.Equal(1L, reader.GetInt64(0));
-
-        // Second read should also work
-        Assert.True(await reader.ReadAsync(CancellationToken.None));
-        Assert.Equal(2L, reader.GetInt64(0));
-
-        // No more rows
-        Assert.False(await reader.ReadAsync(CancellationToken.None));
     }
 
     #endregion
@@ -1461,8 +1357,6 @@ public class CouchbaseDbDataReaderTests
     [Fact]
     public async Task IndexerByName_WithColumnNames_ReturnsCorrectValue()
     {
-        // This is the core contract test: reader["name"] must call GetValue(GetOrdinal("name"))
-        // and return the value that the shaper ordinal for "name" maps to — not the wrong one.
         var rows = new List<JsonElement>
         {
             ParseElement("{\"id\": 99, \"name\": \"bob\"}")
@@ -1539,8 +1433,7 @@ public class CouchbaseDbDataReaderTests
     [Fact]
     public async Task GetOrdinal_WithColumnNames_DoesNotRequireSchemaDiscovery()
     {
-        // GetOrdinal with _columnNames must resolve without calling EnsureFieldInfo,
-        // so it works even before Read() and without triggering a row buffer.
+        // GetOrdinal with _columnNames must resolve without requiring a prior ReadAsync call.
         var rows = new List<JsonElement>
         {
             ParseElement("{\"id\": 1}")
@@ -1616,7 +1509,6 @@ public class CouchbaseDbDataReaderTests
             ParseElement("{\"name\": \"positional\", \"title\": \"alias\"}")
         };
         // Slot 0 is null (positional → "name"), slot 1 has alias "name" (mapped to "title").
-        // This is a degenerate case; alias wins.
         var reader = CreateReaderWithColumnNames(rows, new string?[] { null, "name" });
         await reader.ReadAsync(CancellationToken.None);
 
@@ -1628,7 +1520,7 @@ public class CouchbaseDbDataReaderTests
     {
         // JSON response has only 1 field; projection has 2 null slots.
         // Slot 0 resolves positionally to "id" — present.
-        // Slot 1 is a null slot beyond _fieldNames.Count — must be DBNull, not throw.
+        // Slot 1 is a null slot beyond the JSON field count — must be DBNull, not throw.
         var rows = new List<JsonElement>
         {
             ParseElement("{\"id\": 42}")
@@ -1644,7 +1536,6 @@ public class CouchbaseDbDataReaderTests
     public async Task GetValue_NoColumnNames_OutOfRangeOrdinalThrows()
     {
         // Without _columnNames, an out-of-range ordinal is programmer error and must throw.
-        // (DBNull is only returned for null-slot positions beyond the JSON field count.)
         var rows = new List<JsonElement>
         {
             ParseElement("{\"id\": 7}")
@@ -1663,9 +1554,6 @@ public class CouchbaseDbDataReaderTests
     [Fact]
     public async Task GetSchemaTable_WithNullSlot_StoresDBNullForColumnName()
     {
-        // When _columnNames has a null slot, GetSchemaTable stores DBNull.Value for ColumnName
-        // (because there is no alias for that ordinal). The DataTable accepts DBNull.Value for
-        // a typeof(string) column (stored as object internally).
         var rows = new List<JsonElement>
         {
             ParseElement("{\"id\": 1, \"name\": \"alice\"}")
@@ -1676,10 +1564,8 @@ public class CouchbaseDbDataReaderTests
         var schema = reader.GetSchemaTable();
 
         Assert.Equal(2, schema.Rows.Count);
-        // Null slot → ColumnName is DBNull.Value, not a string
         Assert.Equal(DBNull.Value, schema.Rows[0]["ColumnName"]);
         Assert.Equal(0, schema.Rows[0]["ColumnOrdinal"]);
-        // Non-null slot → ColumnName is the alias
         Assert.Equal("name", schema.Rows[1]["ColumnName"]);
         Assert.Equal(1, schema.Rows[1]["ColumnOrdinal"]);
     }
@@ -1687,8 +1573,6 @@ public class CouchbaseDbDataReaderTests
     [Fact]
     public async Task GetOrdinal_WithDuplicateColumnNames_FirstWins()
     {
-        // When two slots share the same alias, TryAdd keeps the first.
-        // GetOrdinal("dup") must return the first slot's ordinal (0), not the second (1).
         var rows = new List<JsonElement>
         {
             ParseElement("{\"id\": 1, \"name\": \"alice\"}")
@@ -1696,15 +1580,12 @@ public class CouchbaseDbDataReaderTests
         var reader = CreateReaderWithColumnNames(rows, new string?[] { "dup", "dup" });
         await reader.ReadAsync(CancellationToken.None);
 
-        // First-wins: ordinal 0 is returned for "dup" even though slot 1 also has it.
         Assert.Equal(0, reader.GetOrdinal("dup"));
     }
 
     [Fact]
     public async Task GetValues_WithColumnNames_UsesProjectionCount()
     {
-        // When _columnNames is set and has fewer slots than the JSON fields, GetValues
-        // must iterate over projection count (2), not JSON field count (3).
         var rows = new List<JsonElement>
         {
             ParseElement("{\"a\": 1, \"b\": 2, \"c\": 3}")
@@ -1715,11 +1596,9 @@ public class CouchbaseDbDataReaderTests
         var values = new object[5];
         var count = reader.GetValues(values);
 
-        // Only 2 slots in projection — count must be min(5, 2) = 2
         Assert.Equal(2, count);
         Assert.Equal(1L, values[0]);
         Assert.Equal(2L, values[1]);
-        // Remaining entries in values are untouched (default null)
         Assert.Null(values[2]);
     }
 
@@ -1739,7 +1618,6 @@ public class CouchbaseDbDataReaderTests
     [Fact]
     public async Task GetName_WithColumnNames_OutOfRange_ThrowsIndexOutOfRangeException()
     {
-        // The (uint)ordinal >= (uint)_columnNames.Length guard at line 369 must fire.
         var rows = new List<JsonElement>
         {
             ParseElement("{\"id\": 1}")
@@ -1747,7 +1625,6 @@ public class CouchbaseDbDataReaderTests
         var reader = CreateReaderWithColumnNames(rows, new string?[] { "id" });
         await reader.ReadAsync(CancellationToken.None);
 
-        // Ordinal 1 is out of range for a 1-element projection.
         Assert.Throws<IndexOutOfRangeException>(() => reader.GetName(1));
         Assert.Throws<IndexOutOfRangeException>(() => reader.GetName(-1));
     }
@@ -1755,8 +1632,6 @@ public class CouchbaseDbDataReaderTests
     [Fact]
     public async Task GetOrdinal_WithAllNullColumnNames_ResolvesJsonFieldNamesViaFallback()
     {
-        // _projectionOrdinals is empty (all slots null), but the constrained fallback
-        // resolves JSON field names that map to null-slot positions.
         var rows = new List<JsonElement>
         {
             ParseElement("{\"id\": 1, \"name\": \"alice\"}")
@@ -1764,18 +1639,15 @@ public class CouchbaseDbDataReaderTests
         var reader = CreateReaderWithColumnNames(rows, new string?[] { null, null });
         await reader.ReadAsync(CancellationToken.None);
 
-        // Both slots are null — JSON field names resolve via the constrained fallback.
         Assert.Equal(0, reader.GetOrdinal("id"));
         Assert.Equal(1, reader.GetOrdinal("name"));
 
-        // A name that doesn't exist in the JSON response still throws.
         Assert.Throws<IndexOutOfRangeException>(() => reader.GetOrdinal("anything"));
     }
 
     [Fact]
     public void FieldCount_WithEmptyColumnNames_ReturnsZero()
     {
-        // Empty _columnNames array → FieldCount must be 0 without triggering schema discovery.
         var rows = new List<JsonElement>
         {
             ParseElement("{\"id\": 1}")
@@ -1788,7 +1660,6 @@ public class CouchbaseDbDataReaderTests
     [Fact]
     public async Task GetValues_WithColumnNamesAndSmallerArray_UsesMinOfArrayAndProjection()
     {
-        // Array is smaller than projection — must return min(array.Length, _columnNames.Length).
         var rows = new List<JsonElement>
         {
             ParseElement("{\"a\": 10, \"b\": 20, \"c\": 30}")
@@ -1796,7 +1667,7 @@ public class CouchbaseDbDataReaderTests
         var reader = CreateReaderWithColumnNames(rows, new string?[] { "a", "b", "c" });
         await reader.ReadAsync(CancellationToken.None);
 
-        var values = new object[2]; // smaller than projection (3)
+        var values = new object[2];
         var count = reader.GetValues(values);
 
         Assert.Equal(2, count);
@@ -1830,8 +1701,7 @@ public class CouchbaseDbDataReaderTests
     [Fact]
     public async Task ScalarRaw_NumberRow_GetOrdinalWithAnyNameReturnsZero()
     {
-        // The EF Core shaper may request any alias name for scalar projections;
-        // a SELECT RAW result maps any name to ordinal 0.
+        // No-column-names path: scalar SELECT RAW maps any name to ordinal 0.
         var rows = new List<JsonElement> { ParseElement("5") };
         var reader = CreateReader(rows);
         await reader.ReadAsync(CancellationToken.None);
@@ -1923,7 +1793,7 @@ public class CouchbaseDbDataReaderTests
     [Fact]
     public async Task GetValue_WithColumnNames_MultipleAliases_ResolvesEachIndependently()
     {
-        // Each alias resolves via _fieldOrdinals to its canonical name, then exact property access.
+        // Each alias resolves via TryGetPropertyCI to its value.
         var rows = new List<JsonElement> { ParseElement("{\"name\": \"alice\", \"age\": 30}") };
         var reader = CreateReaderWithColumnNames(rows, new string?[] { "age", "name" });
         await reader.ReadAsync(CancellationToken.None);
@@ -1932,27 +1802,26 @@ public class CouchbaseDbDataReaderTests
         Assert.Equal("alice", reader.GetValue(1));
     }
 
-    // GetValue — canonical-name O(1) path via _fieldOrdinals
+    // GetValue — canonical-name path via TryGetPropertyCI
 
     [Fact]
-    public async Task GetValue_WithColumnNames_SchemaPreBuiltViaHasRows_CaseInsensitiveAliasResolves()
+    public async Task GetValue_WithColumnNames_HasRows_CaseInsensitiveAliasResolves()
     {
-        // Accessing HasRows before ReadAsync triggers EnsureFieldInfo (builds _fieldOrdinals).
-        // GetValue must still resolve the alias correctly via the pre-built _fieldOrdinals.
+        // Accessing HasRows before ReadAsync no longer triggers schema discovery.
+        // GetValue must still resolve the alias correctly via TryGetPropertyCI.
         var rows = new List<JsonElement> { ParseElement("{\"blogId\": 99}") };
         var reader = CreateReaderWithColumnNames(rows, new string?[] { "BlogId" });
 
-        _ = reader.HasRows; // triggers schema discovery before ReadAsync
+        _ = reader.HasRows; // returns false before ReadAsync; no side effects
         await reader.ReadAsync(CancellationToken.None);
 
         Assert.Equal(99L, reader.GetValue(0));
     }
 
     [Fact]
-    public async Task GetValue_WithColumnNames_MultipleRows_CanonicalNameUsedForEveryRow()
+    public async Task GetValue_WithColumnNames_MultipleRows_AliasUsedForEveryRow()
     {
-        // _fieldOrdinals is built from the first row and reused for subsequent rows.
-        // Alias casing differs from JSON key on every row — all must resolve correctly.
+        // TryGetPropertyCI resolves the alias for every row.
         var rows = new List<JsonElement>
         {
             ParseElement("{\"blogId\": 1}"),
@@ -1971,8 +1840,6 @@ public class CouchbaseDbDataReaderTests
     [Fact]
     public async Task GetValue_WithColumnNames_FieldPresentInFirstRowAbsentInLater_ReturnsDBNull()
     {
-        // _fieldOrdinals maps "id" → 0 from the first row.
-        // A later row that lacks "id" must return DBNull rather than throw.
         var rows = new List<JsonElement>
         {
             ParseElement("{\"id\": 10}"),
@@ -1988,17 +1855,15 @@ public class CouchbaseDbDataReaderTests
     }
 
     [Fact]
-    public async Task GetValue_WithColumnNames_AliasNotInSchema_FallsBackToTryGetPropertyCI()
+    public async Task GetValue_WithColumnNames_AliasNotInFirstRow_FallsBackToTryGetPropertyCI()
     {
-        // When _fieldOrdinals does not contain the alias (alias added to _columnNames after
-        // the schema row), TryGetPropertyCI is the safety-net.  The schema is built from a
-        // first row that has no "extra" field; a second row that does exposes the fallback.
+        // The second row introduces a field absent from the first row.
+        // TryGetPropertyCI finds it case-insensitively on both rows.
         var rows = new List<JsonElement>
         {
             ParseElement("{\"id\": 1}"),
             ParseElement("{\"id\": 2, \"Extra\": 42}"),
         };
-        // Two slots: "id" appears in the schema; "extra" does not.
         var reader = CreateReaderWithColumnNames(rows, new string?[] { "id", "extra" });
 
         await reader.ReadAsync(CancellationToken.None);
@@ -2007,8 +1872,7 @@ public class CouchbaseDbDataReaderTests
 
         await reader.ReadAsync(CancellationToken.None);
         Assert.Equal(2L, reader.GetValue(0));
-        // "extra" absent from _fieldOrdinals (not in schema row) — TryGetPropertyCI fallback
-        // must find "Extra" case-insensitively and return 42.
+        // TryGetPropertyCI finds "Extra" case-insensitively.
         Assert.Equal(42L, reader.GetValue(1));
     }
 
@@ -2069,7 +1933,13 @@ public class CouchbaseDbDataReaderTests
         mockQueryResult.Setup(q => q.MetaData).Returns(metaData);
         mockQueryResult.Setup(q => q.Rows).Returns(rows.ToAsyncEnumerable());
 
-        return new CouchbaseDbDataReader<JsonElement>(mockQueryResult.Object);
+        // Use the raw ADO.NET constructor (no column names) so these tests cover the
+        // positional-access path, which resolves field names from the current row.
+        return new CouchbaseDbDataReader<JsonElement>(
+            mockQueryResult.Object,
+            connection: null,
+            System.Data.CommandBehavior.Default,
+            CancellationToken.None);
     }
 
     private static CouchbaseDbDataReader<JsonElement> CreateReaderWithColumnNames(
@@ -2081,22 +1951,6 @@ public class CouchbaseDbDataReaderTests
         mockQueryResult.Setup(q => q.MetaData).Returns(metaData);
         mockQueryResult.Setup(q => q.Rows).Returns(rows.ToAsyncEnumerable());
 
-        return new CouchbaseDbDataReader<JsonElement>(mockQueryResult.Object, columnNames);
-    }
-
-    private static CouchbaseDbDataReader<JsonElement> CreateReaderWithCancellationToken(
-        List<JsonElement> rows,
-        CancellationToken cancellationToken)
-    {
-        var mockQueryResult = new Mock<IQueryResult<JsonElement>>();
-        var metaData = new QueryMetaData { Status = QueryStatus.Success };
-        mockQueryResult.Setup(q => q.MetaData).Returns(metaData);
-        mockQueryResult.Setup(q => q.Rows).Returns(rows.ToAsyncEnumerable());
-
-        return new CouchbaseDbDataReader<JsonElement>(
-            mockQueryResult.Object,
-            connection: null,
-            CommandBehavior.Default,
-            cancellationToken);
+        return new CouchbaseDbDataReader<JsonElement>(mockQueryResult.Object, columnNames!);
     }
 }

--- a/tests/Couchbase.EntityFrameworkCore.UnitTests/Couchbase/EntityFrameworkCore/Storage/Internal/CouchbaseDbDataReaderTests.cs
+++ b/tests/Couchbase.EntityFrameworkCore.UnitTests/Couchbase/EntityFrameworkCore/Storage/Internal/CouchbaseDbDataReaderTests.cs
@@ -1853,6 +1853,53 @@ public class CouchbaseDbDataReaderTests
         Assert.Equal("alice", reader.GetString(1));
     }
 
+    [Fact]
+    public async Task PrimeAsync_CalledTwice_IsIdempotent()
+    {
+        // A second PrimeAsync call must not advance the enumerator again or overwrite
+        // the buffered first row.
+        var rows = new List<JsonElement>
+        {
+            ParseElement("{\"id\": 1}"),
+            ParseElement("{\"id\": 2}")
+        };
+        var reader = CreateReader(rows);
+
+        await reader.PrimeAsync(CancellationToken.None);
+        await reader.PrimeAsync(CancellationToken.None); // second call must be a no-op
+
+        Assert.True(reader.HasRows);
+
+        // Both rows must still be readable — the first row was not skipped.
+        Assert.True(await reader.ReadAsync(CancellationToken.None));
+        Assert.Equal(1L, reader.GetInt64(0));
+        Assert.True(await reader.ReadAsync(CancellationToken.None));
+        Assert.Equal(2L, reader.GetInt64(0));
+        Assert.False(await reader.ReadAsync(CancellationToken.None));
+    }
+
+    [Fact]
+    public async Task PrimeAsync_CalledAfterReadAsync_IsIdempotent()
+    {
+        // PrimeAsync after ReadAsync has already advanced the reader must not
+        // consume another row or alter HasRows.
+        var rows = new List<JsonElement>
+        {
+            ParseElement("{\"id\": 10}"),
+            ParseElement("{\"id\": 20}")
+        };
+        var reader = CreateReader(rows);
+
+        Assert.True(await reader.ReadAsync(CancellationToken.None));
+        Assert.Equal(10L, reader.GetInt64(0));
+
+        await reader.PrimeAsync(CancellationToken.None); // must be a no-op
+
+        Assert.True(await reader.ReadAsync(CancellationToken.None));
+        Assert.Equal(20L, reader.GetInt64(0));
+        Assert.False(await reader.ReadAsync(CancellationToken.None));
+    }
+
     #endregion
 
     #region Phase 2 — TryGetPropertyCI and GetOrdinal null-slot guards

--- a/tests/Couchbase.EntityFrameworkCore.UnitTests/Couchbase/EntityFrameworkCore/Storage/Internal/CouchbaseDbDataReaderTests.cs
+++ b/tests/Couchbase.EntityFrameworkCore.UnitTests/Couchbase/EntityFrameworkCore/Storage/Internal/CouchbaseDbDataReaderTests.cs
@@ -692,6 +692,22 @@ public class CouchbaseDbDataReaderTests
         Assert.Equal(2L, reader.GetInt64(1));
     }
 
+    [Fact]
+    public async Task GetSchemaTable_ScalarSelectRaw_ReturnsSingleEmptyNameRow()
+    {
+        // SELECT RAW 5 / COUNT(*) produces a scalar JsonElement (not an object).
+        // GetSchemaTable must return one row consistent with FieldCount==1 and GetName(0)=="".
+        var rows = new List<JsonElement> { ParseElement("42") };
+        var reader = CreateReader(rows);
+
+        Assert.True(await reader.ReadAsync(CancellationToken.None));
+        var schema = reader.GetSchemaTable();
+
+        Assert.Equal(1, schema.Rows.Count);
+        Assert.Equal(string.Empty, schema.Rows[0]["ColumnName"]);
+        Assert.Equal(0, schema.Rows[0]["ColumnOrdinal"]);
+    }
+
     #region Value-Type Row Tracking Tests
 
     [Fact]

--- a/tests/Couchbase.EntityFrameworkCore.UnitTests/Couchbase/EntityFrameworkCore/Storage/Internal/CouchbaseDbDataReaderTests.cs
+++ b/tests/Couchbase.EntityFrameworkCore.UnitTests/Couchbase/EntityFrameworkCore/Storage/Internal/CouchbaseDbDataReaderTests.cs
@@ -1432,6 +1432,27 @@ public class CouchbaseDbDataReaderTests
     }
 
     [Fact]
+    public async Task GetName_NullSlot_ScalarRow_OrdinalZero_ReturnsEmptyString()
+    {
+        // Null slot 0 with a scalar (non-object) row must return "" like the no-column-names path.
+        var rows = new List<JsonElement> { ParseElement("42") };
+        var reader = CreateReaderWithColumnNames(rows, new string?[] { null });
+        await reader.ReadAsync(CancellationToken.None);
+
+        Assert.Equal(string.Empty, reader.GetName(0));
+    }
+
+    [Fact]
+    public async Task GetName_NullSlot_ScalarRow_OrdinalNonZero_ThrowsIndexOutOfRangeException()
+    {
+        var rows = new List<JsonElement> { ParseElement("42") };
+        var reader = CreateReaderWithColumnNames(rows, new string?[] { null, null });
+        await reader.ReadAsync(CancellationToken.None);
+
+        Assert.Throws<IndexOutOfRangeException>(() => reader.GetName(1));
+    }
+
+    [Fact]
     public void FieldCount_WithColumnNames_ReturnsProjectionLength()
     {
         // JSON has 3 fields, but projection only exposes 2.

--- a/tests/Couchbase.EntityFrameworkCore.UnitTests/Couchbase/EntityFrameworkCore/Storage/Internal/CouchbaseDbDataReaderTests.cs
+++ b/tests/Couchbase.EntityFrameworkCore.UnitTests/Couchbase/EntityFrameworkCore/Storage/Internal/CouchbaseDbDataReaderTests.cs
@@ -1399,6 +1399,17 @@ public class CouchbaseDbDataReaderTests
     }
 
     [Fact]
+    public void GetName_NullSlot_NoCurrentRow_ThrowsInvalidOperationException()
+    {
+        // Ordinal 0 is a null slot (in-range), but no ReadAsync has been called.
+        // Must throw InvalidOperationException (no current row), not IndexOutOfRangeException.
+        var rows = new List<JsonElement> { ParseElement("{\"id\": 1}") };
+        var reader = CreateReaderWithColumnNames(rows, new string?[] { null });
+
+        Assert.Throws<InvalidOperationException>(() => reader.GetName(0));
+    }
+
+    [Fact]
     public void FieldCount_WithColumnNames_ReturnsProjectionLength()
     {
         // JSON has 3 fields, but projection only exposes 2.

--- a/tests/Couchbase.EntityFrameworkCore.UnitTests/Couchbase/EntityFrameworkCore/Storage/Internal/CouchbaseDbDataReaderTests.cs
+++ b/tests/Couchbase.EntityFrameworkCore.UnitTests/Couchbase/EntityFrameworkCore/Storage/Internal/CouchbaseDbDataReaderTests.cs
@@ -1982,6 +1982,75 @@ public class CouchbaseDbDataReaderTests
         Assert.True(await reader.ReadAsync(CancellationToken.None));
     }
 
+    [Fact]
+    public async Task NullRow_FieldCount_IsOne()
+    {
+        var reader = CreateNullRowReader();
+        await reader.ReadAsync(CancellationToken.None);
+        Assert.Equal(1, reader.FieldCount);
+    }
+
+    [Fact]
+    public async Task NullRow_GetValue_OrdinalZero_ReturnsDBNull()
+    {
+        var reader = CreateNullRowReader();
+        await reader.ReadAsync(CancellationToken.None);
+        Assert.Equal(DBNull.Value, reader.GetValue(0));
+    }
+
+    [Fact]
+    public async Task NullRow_GetValue_OrdinalNonZero_ThrowsIndexOutOfRangeException()
+    {
+        var reader = CreateNullRowReader();
+        await reader.ReadAsync(CancellationToken.None);
+        Assert.Throws<IndexOutOfRangeException>(() => reader.GetValue(1));
+    }
+
+    [Fact]
+    public async Task NullRow_GetName_OrdinalZero_ReturnsEmptyString()
+    {
+        var reader = CreateNullRowReader();
+        await reader.ReadAsync(CancellationToken.None);
+        Assert.Equal(string.Empty, reader.GetName(0));
+    }
+
+    [Fact]
+    public async Task NullRow_GetOrdinal_ReturnsZero()
+    {
+        var reader = CreateNullRowReader();
+        await reader.ReadAsync(CancellationToken.None);
+        Assert.Equal(0, reader.GetOrdinal("anything"));
+    }
+
+    [Fact]
+    public async Task NullRow_GetSchemaTable_ReturnsSingleEmptyNameRow()
+    {
+        var reader = CreateNullRowReader();
+        await reader.ReadAsync(CancellationToken.None);
+        var schema = reader.GetSchemaTable();
+        Assert.Equal(1, schema.Rows.Count);
+        Assert.Equal(string.Empty, schema.Rows[0]["ColumnName"]);
+        Assert.Equal(0, schema.Rows[0]["ColumnOrdinal"]);
+    }
+
+    [Fact]
+    public async Task NullRow_GetValues_CopiesDBNullToFirstSlot()
+    {
+        var reader = CreateNullRowReader();
+        await reader.ReadAsync(CancellationToken.None);
+        var values = new object[1];
+        Assert.Equal(1, reader.GetValues(values));
+        Assert.Equal(DBNull.Value, values[0]);
+    }
+
+    private static CouchbaseDbDataReader<object?> CreateNullRowReader()
+    {
+        var mockQueryResult = new Mock<IQueryResult<object?>>();
+        mockQueryResult.Setup(q => q.Rows).Returns(new object?[] { null }.ToAsyncEnumerable());
+        return new CouchbaseDbDataReader<object?>(mockQueryResult.Object!, connection: null,
+            System.Data.CommandBehavior.Default, CancellationToken.None);
+    }
+
     #endregion
 
     #region Phase 2 — TryGetPropertyCI and GetOrdinal null-slot guards

--- a/tests/Couchbase.EntityFrameworkCore.UnitTests/Couchbase/EntityFrameworkCore/Storage/Internal/CouchbaseDbDataReaderTests.cs
+++ b/tests/Couchbase.EntityFrameworkCore.UnitTests/Couchbase/EntityFrameworkCore/Storage/Internal/CouchbaseDbDataReaderTests.cs
@@ -1928,6 +1928,22 @@ public class CouchbaseDbDataReaderTests
     }
 
     [Fact]
+    public async Task PrimeAsync_AlreadyPrimed_CancelledToken_ThrowsOperationCanceledException()
+    {
+        // Cancellation must be checked before the idempotency guard so a cancelled token
+        // always surfaces as OperationCanceledException, even after priming is complete.
+        var rows = new List<JsonElement> { ParseElement("{\"id\": 1}") };
+        var reader = CreateReader(rows);
+        await reader.PrimeAsync(CancellationToken.None);
+
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(
+            () => reader.PrimeAsync(cts.Token));
+    }
+
+    [Fact]
     public async Task PrimeAsync_FieldAccessAfterBufferedRead_WorksCorrectly()
     {
         // After PrimeAsync + ReadAsync, all field accessors must see the buffered row.

--- a/tests/Couchbase.EntityFrameworkCore.UnitTests/Couchbase/EntityFrameworkCore/Storage/Internal/CouchbaseDbDataReaderTests.cs
+++ b/tests/Couchbase.EntityFrameworkCore.UnitTests/Couchbase/EntityFrameworkCore/Storage/Internal/CouchbaseDbDataReaderTests.cs
@@ -2010,6 +2010,58 @@ public class CouchbaseDbDataReaderTests
         Assert.False(await reader.ReadAsync(CancellationToken.None));
     }
 
+    [Fact]
+    public async Task PrimeAsync_MoveNextThrows_HasRowsIsFalse()
+    {
+        // If MoveNextAsync throws (e.g. cluster error mid-fetch), PrimeAsync must
+        // re-throw and leave HasRows == false so the reader is not silently usable.
+        var mockQueryResult = new Mock<IQueryResult<JsonElement>>();
+        mockQueryResult.Setup(q => q.Rows).Returns(ThrowingEnumerable());
+        var reader = new CouchbaseDbDataReader<JsonElement>(mockQueryResult.Object, (string?[]?)null);
+
+        await Assert.ThrowsAsync<InvalidOperationException>(
+            () => reader.PrimeAsync(CancellationToken.None));
+
+        Assert.False(reader.HasRows);
+    }
+
+    [Fact]
+    public async Task PrimeAsync_MoveNextThrows_SecondCallIsNoOp()
+    {
+        // After a failed prime the idempotency guard must prevent re-advancing the
+        // enumerator on a second call.  The second call must return without throwing.
+        var callCount = 0;
+        var mockQueryResult = new Mock<IQueryResult<JsonElement>>();
+        mockQueryResult.Setup(q => q.Rows).Returns(CountingThrowingEnumerable(() => callCount++));
+        var reader = new CouchbaseDbDataReader<JsonElement>(mockQueryResult.Object, (string?[]?)null);
+
+        // First call throws; enumerator has been advanced once.
+        await Assert.ThrowsAsync<InvalidOperationException>(
+            () => reader.PrimeAsync(CancellationToken.None));
+
+        Assert.Equal(1, callCount); // enumerator was tried exactly once
+
+        // Second call must be a no-op — enumerator must NOT be advanced again.
+        await reader.PrimeAsync(CancellationToken.None);
+
+        Assert.Equal(1, callCount); // still only one advance attempt
+    }
+
+    private static async IAsyncEnumerable<JsonElement> ThrowingEnumerable()
+    {
+        await Task.Yield();
+        throw new InvalidOperationException("simulated cluster error");
+        yield break; // unreachable; satisfies the compiler's iterator requirement
+    }
+
+    private static async IAsyncEnumerable<JsonElement> CountingThrowingEnumerable(Action onMoveNext)
+    {
+        await Task.Yield();
+        onMoveNext();
+        throw new InvalidOperationException("simulated cluster error");
+        yield break;
+    }
+
     #endregion
 
     #region Row-type validation — NotSupportedException for non-JsonElement rows

--- a/tests/Couchbase.EntityFrameworkCore.UnitTests/Couchbase/EntityFrameworkCore/Storage/Internal/CouchbaseDbDataReaderTests.cs
+++ b/tests/Couchbase.EntityFrameworkCore.UnitTests/Couchbase/EntityFrameworkCore/Storage/Internal/CouchbaseDbDataReaderTests.cs
@@ -1,4 +1,5 @@
 using System.Data;
+using System.Runtime.CompilerServices;
 using System.Text.Json;
 using Couchbase.EntityFrameworkCore.Storage.Internal;
 using Couchbase.Query;
@@ -917,6 +918,33 @@ public class CouchbaseDbDataReaderTests
         Assert.True(await reader.ReadAsync(cts.Token));
         Assert.True(await reader.ReadAsync(CancellationToken.None));
         Assert.False(await reader.ReadAsync(CancellationToken.None));
+    }
+
+    [Fact]
+    public async Task Constructor_4Arg_StoredTokenUsedAsEnumeratorDefault_WhenReadAsyncPassesNone()
+    {
+        // The token passed to the 4-arg constructor must be stored and bound to the
+        // underlying enumerator when ReadAsync is later called with CancellationToken.None,
+        // so that cancellation via the construction-time token propagates correctly.
+        //
+        // CancellableEnumerable uses [EnumeratorCancellation] so the token injected via
+        // GetAsyncEnumerator(token) is actually checked on each MoveNextAsync call,
+        // unlike a plain List.ToAsyncEnumerable() wrapper which does not observe the token.
+        var rows = new List<JsonElement> { ParseElement("{\"id\": 1}") };
+        var mockQueryResult = new Mock<IQueryResult<JsonElement>>();
+        mockQueryResult.Setup(q => q.Rows).Returns(CancellableEnumerable(rows));
+
+        using var cts = new CancellationTokenSource();
+        var reader = new CouchbaseDbDataReader<JsonElement>(
+            mockQueryResult.Object, connection: null,
+            System.Data.CommandBehavior.Default, cts.Token);
+
+        // Cancel before reading — the construction-time token must surface as cancellation
+        // even though ReadAsync is called with CancellationToken.None.
+        cts.Cancel();
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(
+            () => reader.ReadAsync(CancellationToken.None));
     }
 
     #endregion
@@ -2060,6 +2088,21 @@ public class CouchbaseDbDataReaderTests
         onMoveNext();
         throw new InvalidOperationException("simulated cluster error");
         yield break;
+    }
+
+    // [EnumeratorCancellation] causes the compiler to inject the token passed to
+    // GetAsyncEnumerator(token) into the cancellationToken parameter, so MoveNextAsync
+    // actually observes cancellation — unlike List.ToAsyncEnumerable() which ignores it.
+    private static async IAsyncEnumerable<JsonElement> CancellableEnumerable(
+        IEnumerable<JsonElement> rows,
+        [EnumeratorCancellation] CancellationToken cancellationToken = default)
+    {
+        foreach (var row in rows)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            await Task.Yield();
+            yield return row;
+        }
     }
 
     #endregion

--- a/tests/Couchbase.EntityFrameworkCore.UnitTests/Couchbase/EntityFrameworkCore/Storage/Internal/CouchbaseDbDataReaderTests.cs
+++ b/tests/Couchbase.EntityFrameworkCore.UnitTests/Couchbase/EntityFrameworkCore/Storage/Internal/CouchbaseDbDataReaderTests.cs
@@ -17,11 +17,17 @@ public class CouchbaseDbDataReaderTests
     }
 
     [Fact]
-    public void Constructor_WithNullColumnNames_ThrowsArgumentNullException()
+    public async Task Constructor_WithNullColumnNames_FallsBackToPositionalPath()
     {
-        var mockQueryResult = new Mock<IQueryResult<object>>();
-        Assert.Throws<ArgumentNullException>(() =>
-            new CouchbaseDbDataReader<object>(mockQueryResult.Object, null!));
+        // null columnNames is valid — it means "no alias mapping; use positional resolution".
+        // This mirrors the raw ADO.NET path and must not throw at construction or at read time.
+        var rows = new List<JsonElement> { ParseElement("{\"id\": 1}") };
+        var mockQueryResult = new Mock<IQueryResult<JsonElement>>();
+        mockQueryResult.Setup(q => q.Rows).Returns(rows.ToAsyncEnumerable());
+
+        var reader = new CouchbaseDbDataReader<JsonElement>(mockQueryResult.Object, (string?[]?)null);
+        Assert.True(await reader.ReadAsync(CancellationToken.None));
+        Assert.Equal(1L, reader.GetInt64(0));
     }
 
     [Fact]
@@ -2111,6 +2117,6 @@ public class CouchbaseDbDataReaderTests
         mockQueryResult.Setup(q => q.MetaData).Returns(metaData);
         mockQueryResult.Setup(q => q.Rows).Returns(rows.ToAsyncEnumerable());
 
-        return new CouchbaseDbDataReader<JsonElement>(mockQueryResult.Object, columnNames!);
+        return new CouchbaseDbDataReader<JsonElement>(mockQueryResult.Object, columnNames);
     }
 }

--- a/tests/Couchbase.EntityFrameworkCore.UnitTests/Couchbase/EntityFrameworkCore/Storage/Internal/CouchbaseDbDataReaderTests.cs
+++ b/tests/Couchbase.EntityFrameworkCore.UnitTests/Couchbase/EntityFrameworkCore/Storage/Internal/CouchbaseDbDataReaderTests.cs
@@ -2075,6 +2075,73 @@ public class CouchbaseDbDataReaderTests
         Assert.Equal(1, callCount); // still only one advance attempt
     }
 
+    [Fact]
+    public async Task PrimeAsync_ThenCloseAsync_ReaderIsClosedCleanly()
+    {
+        // Closing after PrimeAsync without any ReadAsync call must succeed — the
+        // buffered first row must not obstruct disposal.
+        var rows = new List<JsonElement> { ParseElement("{\"id\": 1}") };
+        var reader = CreateReader(rows);
+
+        await reader.PrimeAsync(CancellationToken.None);
+
+        Assert.True(reader.HasRows);
+        Assert.False(reader.IsClosed);
+
+        await reader.CloseAsync();
+
+        Assert.True(reader.IsClosed);
+    }
+
+    [Fact]
+    public async Task PrimeAsync_ThenCloseAsync_ReadAsyncReturnsFalse()
+    {
+        // ReadAsync on a closed reader must return false rather than throw.
+        var rows = new List<JsonElement> { ParseElement("{\"id\": 1}") };
+        var reader = CreateReader(rows);
+
+        await reader.PrimeAsync(CancellationToken.None);
+        await reader.CloseAsync();
+
+        Assert.False(await reader.ReadAsync(CancellationToken.None));
+    }
+
+    [Fact]
+    public async Task PrimeAsync_ThenClose_LinkedCtsIsDisposed()
+    {
+        // Close() must dispose the linked CTS transferred from CouchbaseCommand so that
+        // DbCommand.Cancel() no longer has a live token source to operate on.
+        var rows = new List<JsonElement> { ParseElement("{\"id\": 1}") };
+        var reader = CreateReader(rows);
+
+        // CTS ownership is transferred to the reader; the reader is responsible for disposal.
+        // 'using' here provides a safety net if the test fails before Close() is reached.
+        using var cts = new CancellationTokenSource();
+        reader.SetLinkedCts(cts);
+
+        await reader.PrimeAsync(CancellationToken.None);
+        reader.Close();
+
+        // After Close the linked CTS must be disposed — Cancel() on a disposed CTS throws.
+        Assert.Throws<ObjectDisposedException>(() => cts.Cancel());
+    }
+
+    [Fact]
+    public async Task PrimeAsync_ThenDisposeAsync_LinkedCtsIsDisposed()
+    {
+        // Same contract as the Close() path but exercised via DisposeAsync().
+        var rows = new List<JsonElement> { ParseElement("{\"id\": 1}") };
+        var reader = CreateReader(rows);
+
+        using var cts = new CancellationTokenSource();
+        reader.SetLinkedCts(cts);
+
+        await reader.PrimeAsync(CancellationToken.None);
+        await reader.DisposeAsync();
+
+        Assert.Throws<ObjectDisposedException>(() => cts.Cancel());
+    }
+
     private static async IAsyncEnumerable<JsonElement> ThrowingEnumerable()
     {
         await Task.Yield();

--- a/tests/Couchbase.EntityFrameworkCore.UnitTests/Couchbase/EntityFrameworkCore/Storage/Internal/CouchbaseDbDataReaderTests.cs
+++ b/tests/Couchbase.EntityFrameworkCore.UnitTests/Couchbase/EntityFrameworkCore/Storage/Internal/CouchbaseDbDataReaderTests.cs
@@ -1930,6 +1930,44 @@ public class CouchbaseDbDataReaderTests
 
     #endregion
 
+    #region Row-type validation — NotSupportedException for non-JsonElement rows
+
+    [Fact]
+    public async Task ReadAsync_NonJsonElementRow_ThrowsNotSupportedException()
+    {
+        var mockQueryResult = new Mock<IQueryResult<object>>();
+        mockQueryResult.Setup(q => q.Rows).Returns(new[] { (object)"not-a-json-element" }.ToAsyncEnumerable());
+        var reader = new CouchbaseDbDataReader<object>(mockQueryResult.Object, connection: null,
+            System.Data.CommandBehavior.Default, CancellationToken.None);
+
+        await Assert.ThrowsAsync<NotSupportedException>(() => reader.ReadAsync(CancellationToken.None));
+    }
+
+    [Fact]
+    public async Task PrimeAsync_NonJsonElementRow_ThrowsNotSupportedException()
+    {
+        var mockQueryResult = new Mock<IQueryResult<object>>();
+        mockQueryResult.Setup(q => q.Rows).Returns(new[] { (object)"not-a-json-element" }.ToAsyncEnumerable());
+        var reader = new CouchbaseDbDataReader<object>(mockQueryResult.Object, connection: null,
+            System.Data.CommandBehavior.Default, CancellationToken.None);
+
+        await Assert.ThrowsAsync<NotSupportedException>(() => reader.PrimeAsync(CancellationToken.None));
+    }
+
+    [Fact]
+    public async Task ReadAsync_NullRow_DoesNotThrow()
+    {
+        // null is allowed (e.g. SELECT RAW null) — only non-null non-JsonElement throws.
+        var mockQueryResult = new Mock<IQueryResult<object>>();
+        mockQueryResult.Setup(q => q.Rows).Returns(new object?[] { null }.ToAsyncEnumerable<object?>());
+        var reader = new CouchbaseDbDataReader<object?>(mockQueryResult.Object!, connection: null,
+            System.Data.CommandBehavior.Default, CancellationToken.None);
+
+        Assert.True(await reader.ReadAsync(CancellationToken.None));
+    }
+
+    #endregion
+
     #region Phase 2 — TryGetPropertyCI and GetOrdinal null-slot guards
 
     // GetValue — case-insensitive property lookup via TryGetPropertyCI


### PR DESCRIPTION
### Summary

Deletes the first-row peek, sync-over-async call, and all schema-discovery
fields (`_bufferedRow`, `_schemaInitialized`, `_fieldNames`, `_fieldOrdinals`,
`EnsureFieldInfo`, `InitializeFieldInfo`) — approximately 150 lines removed.

- `FieldCount`, `GetName`, and `GetOrdinal` are now O(1) for non-null alias
  slots, driven by `_projectionOrdinals` built at construction time
- `HasRows` is accurate before the first `ReadAsync` call via `PrimeAsync`,
  which eagerly advances to the first row and buffers it; `ReadAsync` drains
  the buffer on first invocation so no row is skipped
- Nine follow-up corrections were made after the core phase landed

---

### Follow-up corrections

#### Cancellation / lifetime

`DbCommand.Cancel()` was not propagating to the row enumerator: `PrimeAsync`
received the external token instead of `linkedCts.Token`, and `linkedCts` was
disposed before the reader's first `ReadAsync` call. Fixed by passing
`linkedCts.Token` throughout and transferring CTS ownership to the reader,
which disposes it on close.

#### `PrimeAsync` hardening

- Made `PrimeAsync` idempotent: a second call now no-ops when `_hasRows`,
  `_hasBufferedRow`, or `_hasCurrentRow` is already set, preventing silent
  row loss on double-prime
- Row type validation added at both materialization points (`ReadAsync` and
  `PrimeAsync`): a non-null, non-`JsonElement` row now throws
  `NotSupportedException` immediately rather than surfacing later as `DBNull`
  or `IndexOutOfRangeException`

#### Constructor

The 2-arg constructor's `columnNames` parameter changed from `string?[]` to
`string?[]?`. `null` is now treated as "no alias mapping" and routes through
the existing positional path, fixing a runtime `ArgumentNullException` when
`CouchbaseQueryEnumerable` produces `null` from
`_projectionAliases ?? _readerColumns?.Select(...)`.

#### `GetName` / `GetOrdinal` exception consistency

- Both methods threw `IndexOutOfRangeException` in the null-slot path when no
  row had been read. Replaced the `_hasCurrentRow` guard with
  `EnsureCurrentRow()` so the exception is `InvalidOperationException`,
  consistent with every other method that requires a current row
- Both methods also threw `IndexOutOfRangeException` for scalar/null rows at
  ordinal 0 in the null-slot path. Added scalar/null branches
  (`return string.Empty` / `return 0`) consistent with the no-column-names
  path and with `GetValue`

#### Scalar and null row consistency

- `GetSchemaTable` returned an empty `DataTable` for scalar `SELECT RAW` rows
  (non-object `JsonElement`), inconsistent with `FieldCount == 1` and
  `GetName(0) == ""`. Fixed to emit one schema row (`ColumnName=""`,
  `ColumnOrdinal=0`)
- Null rows (`SELECT RAW null`) were treated as zero-column in the positional
  path: `FieldCount` returned 0 and `GetValue` / `GetName` / `GetOrdinal` /
  `GetValues` / `GetSchemaTable` all threw or returned empty. Unified null and
  scalar branches so null rows behave identically to non-object scalar
  `JsonElement` rows

---

### Test plan

- [ ] All 166 unit tests in `CouchbaseDbDataReaderTests` pass
- [ ] Verify `HasRows` is `true` before first `ReadAsync` on a non-empty result
- [ ] Verify `DbCommand.Cancel()` stops iteration mid-stream
- [ ] Verify `SELECT RAW` scalar and `SELECT RAW null` queries return one
      column with the correct value

---