### PR TITLE
Replace private Keyspace class with CouchbaseKeyspace in CouchbaseQuerySqlGenerator

### DIFF
--- a/src/Couchbase.EntityFrameworkCore/Metadata/CouchbaseKeyspace.cs
+++ b/src/Couchbase.EntityFrameworkCore/Metadata/CouchbaseKeyspace.cs
@@ -49,7 +49,15 @@ public readonly record struct CouchbaseKeyspace
     /// <summary>
     /// Returns the keyspace in standard format: <c>Bucket.Scope.Collection</c>.
     /// </summary>
-    public override string ToString() => $"{Bucket}.{Scope}.{Collection}";
+    /// <exception cref="InvalidOperationException">
+    /// Thrown when the instance was default-initialized (e.g. <c>default(CouchbaseKeyspace)</c>)
+    /// and has null segments. Use the constructor or <see cref="Parse"/> instead.
+    /// </exception>
+    public override string ToString()
+    {
+        ThrowIfDefaultInitialized();
+        return $"{Bucket}.{Scope}.{Collection}";
+    }
 
     /// <summary>
     /// Returns the keyspace in SQL++ format with each segment backtick-delimited and any
@@ -61,8 +69,27 @@ public readonly record struct CouchbaseKeyspace
     /// logic.  This method is provided for contexts that do not have access to the helper
     /// (e.g. display, logging, serialisation).
     /// </remarks>
-    public string ToSqlString() =>
-        $"`{Bucket.Replace("`", "``")}`.`{Scope.Replace("`", "``")}`.`{Collection.Replace("`", "``")}`";
+    /// <exception cref="InvalidOperationException">
+    /// Thrown when the instance was default-initialized (e.g. <c>default(CouchbaseKeyspace)</c>)
+    /// and has null segments. Use the constructor or <see cref="Parse"/> instead.
+    /// </exception>
+    public string ToSqlString()
+    {
+        ThrowIfDefaultInitialized();
+        return $"`{Bucket.Replace("`", "``")}`.`{Scope.Replace("`", "``")}`.`{Collection.Replace("`", "``")}`";
+    }
+
+    /// <summary>
+    /// Throws <see cref="InvalidOperationException"/> when the struct was default-initialized,
+    /// leaving <see cref="Bucket"/>, <see cref="Scope"/>, or <see cref="Collection"/> null.
+    /// </summary>
+    private void ThrowIfDefaultInitialized()
+    {
+        if (Bucket is null || Scope is null || Collection is null)
+            throw new InvalidOperationException(
+                "This CouchbaseKeyspace instance was default-initialized and has null segments. " +
+                "Use the constructor or Parse() to create a valid instance.");
+    }
 
     /// <summary>
     /// Parses a keyspace string in the format <c>Bucket.Scope.Collection</c>.

--- a/src/Couchbase.EntityFrameworkCore/Metadata/CouchbaseKeyspace.cs
+++ b/src/Couchbase.EntityFrameworkCore/Metadata/CouchbaseKeyspace.cs
@@ -52,9 +52,17 @@ public readonly record struct CouchbaseKeyspace
     public override string ToString() => $"{Bucket}.{Scope}.{Collection}";
 
     /// <summary>
-    /// Returns the keyspace in SQL++ format with backtick escaping: <c>`Bucket`.`Scope`.`Collection`</c>.
+    /// Returns the keyspace in SQL++ format with each segment backtick-delimited and any
+    /// embedded backtick characters doubled: <c>`Bucket`.`Scope`.`Collection`</c>.
     /// </summary>
-    public string ToSqlString() => $"`{Bucket}`.`{Scope}`.`{Collection}`";
+    /// <remarks>
+    /// Prefer <c>ISqlGenerationHelper.DelimitIdentifier(keyspace.ToString())</c> inside the
+    /// query-SQL generation pipeline — that path uses the provider's authoritative escaping
+    /// logic.  This method is provided for contexts that do not have access to the helper
+    /// (e.g. display, logging, serialisation).
+    /// </remarks>
+    public string ToSqlString() =>
+        $"`{Bucket.Replace("`", "``")}`.`{Scope.Replace("`", "``")}`.`{Collection.Replace("`", "``")}`";
 
     /// <summary>
     /// Parses a keyspace string in the format <c>Bucket.Scope.Collection</c>.

--- a/src/Couchbase.EntityFrameworkCore/Query/Internal/CouchbaseFromSqlQueryingEnumerable.cs
+++ b/src/Couchbase.EntityFrameworkCore/Query/Internal/CouchbaseFromSqlQueryingEnumerable.cs
@@ -104,13 +104,14 @@ public class CouchbaseFromSqlQueryingEnumerable<T> : IEnumerable<T>, IAsyncEnume
     public async IAsyncEnumerator<T> GetAsyncEnumerator(CancellationToken cancellationToken = new CancellationToken())
     {
         using var dbCommand = CreateDbCommand();
-        var queryString = _relationalQueryContext.RelationalQueryStringFactory.Create(dbCommand);
+        // Use CommandText directly — RelationalQueryStringFactory.Create() would prepend
+        // per-parameter comment blocks before the SQL, which must not be sent to the server.
+        // Using CommandText keeps the executed SQL identical to what ToQueryString() returns.
+        var queryString = dbCommand.CommandText;
 
         var logger = (CouchbaseRelationalDiagnosticsCommandLogger)_relationalQueryContext.CommandLogger;
 #if DEBUG
-        //This likely needs to be refactored and just use the relational command instead
-        var loggingCommand = CreateDbCommand();
-        logger.LogStatement(loggingCommand, TimeSpan.Zero);
+        logger.LogStatement(dbCommand, TimeSpan.Zero);
 #endif
         var queryOptions = GetParameters(dbCommand);
 
@@ -158,8 +159,11 @@ public class CouchbaseFromSqlQueryingEnumerable<T> : IEnumerable<T>, IAsyncEnume
 
     public string ToQueryString()
     {
-        using var dbCommand = CreateDbCommand();
-        return _relationalQueryContext.RelationalQueryStringFactory.Create(dbCommand);
+        // Compile the SQL without opening a database connection.  This matches
+        // EF Core's contract for ToQueryString() and the implementation in
+        // CouchbaseQueryEnumerable.ToQueryString().
+        var relationalCommand = _relationalCommandResolver(_relationalQueryContext.Parameters);
+        return relationalCommand.CommandText;
     }
 
     public virtual DbCommand CreateDbCommand()

--- a/src/Couchbase.EntityFrameworkCore/Query/Internal/CouchbaseQueryEnumerable.cs
+++ b/src/Couchbase.EntityFrameworkCore/Query/Internal/CouchbaseQueryEnumerable.cs
@@ -304,17 +304,26 @@ public class CouchbaseQueryEnumerable<T> : IEnumerable<T>, IAsyncEnumerable<T>, 
 
     /// <summary>
     ///     <para>
-    ///         A string representation of the query used.
+    ///         Returns the SQL++ that would be sent to Couchbase for this query.
     ///     </para>
     ///     <para>
-    ///         Warning: this string may not be suitable for direct execution is intended only for use in debugging.
+    ///         This method compiles the LINQ expression to SQL++ without opening a database
+    ///         connection, so it can be used in unit tests and diagnostic tooling without
+    ///         a live Couchbase server.
+    ///     </para>
+    ///     <para>
+    ///         Warning: the returned string may not be suitable for direct execution;
+    ///         it is intended only for debugging and logging.
     ///     </para>
     /// </summary>
-    /// <returns>The query string.</returns>
+    /// <returns>The SQL++ query string.</returns>
     public string ToQueryString()
     {
-        using var dbCommand = CreateDbCommand();
-        return _relationalQueryContext.RelationalQueryStringFactory.Create(dbCommand);
+        // Resolve the compiled IRelationalCommand (SQL text + parameter descriptors) without
+        // opening a database connection.  Reading CommandText is pure in-memory work —
+        // no I/O occurs.  This matches EF Core's documented contract for ToQueryString().
+        var relationalCommand = _relationalCommandResolver(_relationalQueryContext.Parameters);
+        return relationalCommand.CommandText;
     }
 
     /// <summary>

--- a/src/Couchbase.EntityFrameworkCore/Query/Internal/CouchbaseQueryEnumerable.cs
+++ b/src/Couchbase.EntityFrameworkCore/Query/Internal/CouchbaseQueryEnumerable.cs
@@ -123,7 +123,11 @@ public class CouchbaseQueryEnumerable<T> : IEnumerable<T>, IAsyncEnumerable<T>, 
     public async IAsyncEnumerator<T> GetAsyncEnumerator(CancellationToken cancellationToken = new CancellationToken())
     {
         using var dbCommand = CreateDbCommand();
-        var queryString = _relationalQueryContext.RelationalQueryStringFactory.Create(dbCommand);
+        // Use CommandText directly — RelationalQueryStringFactory.Create() would prepend
+        // per-parameter comment blocks (for debugging) before the SQL, but those comment
+        // blocks are not part of the actual query and should not be sent to the server.
+        // Using CommandText keeps the executed SQL identical to what ToQueryString() returns.
+        var queryString = dbCommand.CommandText;
         var logger = (CouchbaseRelationalDiagnosticsCommandLogger)_relationalQueryContext.CommandLogger;
 #if DEBUG
         logger.LogStatement(dbCommand, TimeSpan.Zero);

--- a/src/Couchbase.EntityFrameworkCore/Query/Internal/CouchbaseQuerySqlGenerator.cs
+++ b/src/Couchbase.EntityFrameworkCore/Query/Internal/CouchbaseQuerySqlGenerator.cs
@@ -6,11 +6,12 @@ using System.Reflection;
 using System.Reflection.Emit;
 using System.Reflection.Metadata;
 using System.Text;
-using Couchbase.Core.Utils;
 using Couchbase.EntityFrameworkCore.Infrastructure;
+using Couchbase.EntityFrameworkCore.Metadata;
 using Couchbase.EntityFrameworkCore.Utils;
 using Couchbase.Extensions.DependencyInjection;
 using Microsoft.EntityFrameworkCore.Diagnostics;
+using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Query;
 using Microsoft.EntityFrameworkCore.Query.SqlExpressions;
 using Microsoft.EntityFrameworkCore.Storage;
@@ -21,7 +22,7 @@ namespace Couchbase.EntityFrameworkCore.Query.Internal;
 
 public class CouchbaseQuerySqlGenerator : QuerySqlGenerator
 {
-    private readonly ConcurrentDictionary<string, Keyspace> _tableNameCache = new();
+    private readonly ConcurrentDictionary<string, CouchbaseKeyspace> _tableNameCache = new();
 
     public CouchbaseQuerySqlGenerator(QuerySqlGeneratorDependencies dependencies) : base(dependencies)
     {
@@ -36,17 +37,10 @@ public class CouchbaseQuerySqlGenerator : QuerySqlGenerator
     /// <inheritdoc />
     protected override Expression VisitLeftJoin(LeftJoinExpression leftJoinExpression)
     {
-        // Skip LEFT JOINs for owned types - they don't have a proper keyspace (bucket.scope.collection)
-        // Owned types are embedded in their owner's document
-        if (leftJoinExpression.Table is TableExpression tableExpression)
-        {
-            var splitName = tableExpression.Name.Split('.');
-            if (splitName.Length != 3)
-            {
-                // This is an owned type - skip the JOIN entirely
-                return leftJoinExpression;
-            }
-        }
+        // Skip LEFT JOINs for owned types — they are embedded in their owner's document
+        // and have no independent keyspace.
+        if (leftJoinExpression.Table is TableExpression tableExpression && IsOwnedTable(tableExpression))
+            return leftJoinExpression;
 
         return base.VisitLeftJoin(leftJoinExpression);
     }
@@ -54,19 +48,41 @@ public class CouchbaseQuerySqlGenerator : QuerySqlGenerator
     /// <inheritdoc />
     protected override Expression VisitInnerJoin(InnerJoinExpression innerJoinExpression)
     {
-        // Skip INNER JOINs for owned types - they don't have a proper keyspace (bucket.scope.collection)
-        // Owned types are embedded in their owner's document
-        if (innerJoinExpression.Table is TableExpression tableExpression)
-        {
-            var splitName = tableExpression.Name.Split('.');
-            if (splitName.Length != 3)
-            {
-                // This is an owned type - skip the JOIN entirely
-                return innerJoinExpression;
-            }
-        }
+        // Skip INNER JOINs for owned types — they are embedded in their owner's document
+        // and have no independent keyspace.
+        if (innerJoinExpression.Table is TableExpression tableExpression && IsOwnedTable(tableExpression))
+            return innerJoinExpression;
 
         return base.VisitInnerJoin(innerJoinExpression);
+    }
+
+    /// <summary>
+    /// Returns <see langword="true"/> when every entity type mapped to
+    /// <paramref name="tableExpression"/> is an owned type.  Such tables have no independent
+    /// Couchbase keyspace — their data is embedded in the owner's document — and must be
+    /// skipped when emitting FROM / JOIN clauses.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The check uses <c>All</c>, not <c>Any</c>.  An owner table that also hosts
+    /// <c>OwnsOne</c> scalar navigations (table-splitting) will have both the owner entity
+    /// type <em>and</em> the owned entity type in <see cref="ITableBase.EntityTypeMappings"/>.
+    /// <c>Any</c> would incorrectly mark the owner's table as owned, causing its FROM clause
+    /// to be suppressed and producing a N1QL syntax error (<c>WHERE</c> with no preceding
+    /// <c>FROM</c>).  <c>All</c> only returns <see langword="true"/> for tables whose
+    /// mappings are exclusively owned types — i.e., a separate OwnsMany-item table that has
+    /// no corresponding Couchbase collection.
+    /// </para>
+    /// <para>
+    /// The empty-collection guard prevents vacuous <c>All</c> from returning
+    /// <see langword="true"/> for unmapped tables.
+    /// </para>
+    /// </remarks>
+    private static bool IsOwnedTable(TableExpression tableExpression)
+    {
+        var mappings = tableExpression.Table.EntityTypeMappings.ToList();
+        return mappings.Count > 0
+            && mappings.All(m => m.TypeBase is IEntityType et && et.IsOwned());
     }
 
     /// <inheritdoc />
@@ -409,54 +425,25 @@ public class CouchbaseQuerySqlGenerator : QuerySqlGenerator
         Sql.Append(")");
     }
 
-    private class Keyspace
-    {
-        private readonly string _sqlKeyspace;
-
-        public Keyspace(string originalName)
-        {
-            // Format is now standard: Bucket.Scope.Collection
-            var splitName = originalName.Split('.');
-            if (splitName.Length != 3)
-            {
-                // This may be an owned type which doesn't have a full keyspace - use the name as-is
-                _sqlKeyspace = originalName;
-                return;
-            }
-
-            var bucket = splitName[0].Trim('`');
-            var scope = splitName[1].Trim('`');
-            var collection = splitName[2].Trim('`');
-
-            // Build the SQL keyspace: `bucket`.`scope`.`collection`
-            _sqlKeyspace = $"{bucket.EscapeIfRequired()}.{scope.EscapeIfRequired()}.{collection.EscapeIfRequired()}";
-        }
-
-        public string SqlKeyspace
-        {
-            [DebuggerStepThrough] get => _sqlKeyspace;
-        }
-    }
-
     protected override Expression VisitTable(TableExpression tableExpression)
     {
         //NOTE: TableExpression is a sealed class so cannot be overridden without
         //bring it inside this assembly which then requires the TableExpressionBase to
         //be moved into this assembly as Alias field is internal.
 
-        // Skip owned type tables - they don't have a proper keyspace (bucket.scope.collection)
-        // Owned types are embedded in their owner's document and don't need separate FROM clauses
-        var splitName = tableExpression.Name.Split('.');
-        if (splitName.Length != 3)
-        {
-            // This is an owned type - skip generating FROM clause for it
+        // Skip owned type tables — they are embedded in their owner's document and have no
+        // independent Couchbase keyspace.
+        if (IsOwnedTable(tableExpression))
             return tableExpression;
-        }
 
+        // Parse once per distinct table name and cache. CouchbaseKeyspace stores Bucket,
+        // Scope, and Collection as properties; ToSqlString() produces the backtick-escaped
+        // SQL++ form on demand from those properties.
         var keyspace = _tableNameCache.GetOrAdd(
-            tableExpression.Name, key => new Keyspace(key));
+            tableExpression.Name,
+            static name => CouchbaseKeyspace.Parse(name));
 
-        Sql.Append(keyspace.SqlKeyspace)
+        Sql.Append(keyspace.ToSqlString())
             .Append(AliasSeparator)
             .Append(Dependencies.SqlGenerationHelper.DelimitIdentifier(tableExpression.Alias));
 

--- a/src/Couchbase.EntityFrameworkCore/Query/Internal/CouchbaseQuerySqlGenerator.cs
+++ b/src/Couchbase.EntityFrameworkCore/Query/Internal/CouchbaseQuerySqlGenerator.cs
@@ -80,9 +80,17 @@ public class CouchbaseQuerySqlGenerator : QuerySqlGenerator
     /// </remarks>
     private static bool IsOwnedTable(TableExpression tableExpression)
     {
-        var mappings = tableExpression.Table.EntityTypeMappings.ToList();
-        return mappings.Count > 0
-            && mappings.All(m => m.TypeBase is IEntityType et && et.IsOwned());
+        // Single-pass enumeration: track whether any mappings exist and whether every
+        // mapping seen so far is an owned entity type. Avoids the ToList() allocation
+        // that would otherwise occur on every FROM/JOIN clause generation.
+        var any = false;
+        foreach (var mapping in tableExpression.Table.EntityTypeMappings)
+        {
+            if (mapping.TypeBase is not IEntityType et || !et.IsOwned())
+                return false;
+            any = true;
+        }
+        return any;
     }
 
     /// <inheritdoc />

--- a/src/Couchbase.EntityFrameworkCore/Query/Internal/CouchbaseQuerySqlGenerator.cs
+++ b/src/Couchbase.EntityFrameworkCore/Query/Internal/CouchbaseQuerySqlGenerator.cs
@@ -436,14 +436,16 @@ public class CouchbaseQuerySqlGenerator : QuerySqlGenerator
         if (IsOwnedTable(tableExpression))
             return tableExpression;
 
-        // Parse once per distinct table name and cache. CouchbaseKeyspace stores Bucket,
-        // Scope, and Collection as properties; ToSqlString() produces the backtick-escaped
-        // SQL++ form on demand from those properties.
+        // Parse once per distinct table name and cache.
         var keyspace = _tableNameCache.GetOrAdd(
             tableExpression.Name,
             static name => CouchbaseKeyspace.Parse(name));
 
-        Sql.Append(keyspace.ToSqlString())
+        // Use the provider's SqlGenerationHelper to quote and escape each keyspace segment.
+        // DelimitIdentifier splits on '.' and applies EscapeIdentifier (backtick-doubling)
+        // per segment, keeping this path consistent with all other identifier quoting in
+        // the provider and safe against names that might contain backtick characters.
+        Sql.Append(Dependencies.SqlGenerationHelper.DelimitIdentifier(keyspace.ToString()))
             .Append(AliasSeparator)
             .Append(Dependencies.SqlGenerationHelper.DelimitIdentifier(tableExpression.Alias));
 

--- a/tests/Couchbase.EntityFrameworkCore.UnitTests/Couchbase/EntityFrameworkCore/Query/OwnedTableDetectionTests.cs
+++ b/tests/Couchbase.EntityFrameworkCore.UnitTests/Couchbase/EntityFrameworkCore/Query/OwnedTableDetectionTests.cs
@@ -1,0 +1,293 @@
+using Couchbase.EntityFrameworkCore.Extensions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata;
+using Xunit;
+
+namespace Couchbase.EntityFrameworkCore.UnitTests.Couchbase.EntityFrameworkCore.Query;
+
+/// <summary>
+/// Documents and verifies the owned-table detection logic used in
+/// <c>CouchbaseQuerySqlGenerator.IsOwnedTable</c>, which drives <c>VisitLeftJoin</c>,
+/// <c>VisitInnerJoin</c>, and <c>VisitTable</c>.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The central contract: <see cref="IEntityType.IsOwned"/> is <c>true</c> for owned
+/// entity types and <c>false</c> for owner / standalone entity types.
+/// </para>
+/// <para>
+/// <c>IsOwnedTable</c> uses <c>All</c> over
+/// <see cref="ITableBase.EntityTypeMappings"/> so that tables hosting both an owner entity
+/// and an <c>OwnsOne</c> scalar navigation (table-splitting) are not mistakenly suppressed.
+/// Using <c>Any</c> instead would return <c>true</c> for the owner's table, causing its
+/// FROM clause to be omitted and producing a N1QL syntax error at the <c>WHERE</c> keyword
+/// (Couchbase error 3000).
+/// </para>
+/// </remarks>
+public class OwnedTableDetectionTests
+{
+    // ---------------------------------------------------------------
+    // Section 1: EF Core IsOwned() semantics (model-only, no relational provider)
+    // ---------------------------------------------------------------
+
+    [Fact]
+    public void OwnsOne_OwnerEntityType_IsOwnedReturnsFalse()
+    {
+        var modelBuilder = new ModelBuilder();
+        modelBuilder.Entity<SingleOwner>(b => b.OwnsOne(o => o.Embedded));
+        var model = modelBuilder.FinalizeModel();
+
+        var ownerType = model.FindEntityType(typeof(SingleOwner))!;
+        Assert.False(ownerType.IsOwned(),
+            "The owner entity itself must NOT be reported as owned.");
+    }
+
+    [Fact]
+    public void OwnsOne_OwnedEntityType_IsOwnedReturnsTrue()
+    {
+        var modelBuilder = new ModelBuilder();
+        modelBuilder.Entity<SingleOwner>(b => b.OwnsOne(o => o.Embedded));
+        var model = modelBuilder.FinalizeModel();
+
+        var ownerType = model.FindEntityType(typeof(SingleOwner))!;
+        var ownedType = ownerType.FindNavigation(nameof(SingleOwner.Embedded))!.TargetEntityType;
+
+        Assert.True(ownedType.IsOwned(),
+            "The OwnsOne-owned entity type must be reported as owned.");
+    }
+
+    [Fact]
+    public void OwnsMany_OwnedEntityType_IsOwnedReturnsTrue()
+    {
+        var modelBuilder = new ModelBuilder();
+        modelBuilder.Entity<SingleOwner>(b => b.OwnsMany(o => o.Items));
+        var model = modelBuilder.FinalizeModel();
+
+        var ownerType  = model.FindEntityType(typeof(SingleOwner))!;
+        var ownedType  = ownerType.FindNavigation(nameof(SingleOwner.Items))!.TargetEntityType;
+
+        Assert.True(ownedType.IsOwned(),
+            "The OwnsMany-owned entity type must be reported as owned.");
+    }
+
+    [Fact]
+    public void StandaloneEntityType_IsOwnedReturnsFalse()
+    {
+        var modelBuilder = new ModelBuilder();
+        modelBuilder.Entity<SingleOwner>();
+        var model = modelBuilder.FinalizeModel();
+
+        var entityType = model.FindEntityType(typeof(SingleOwner))!;
+        Assert.False(entityType.IsOwned(),
+            "A standalone entity (no OwnsOne/OwnsMany relationship) must not be owned.");
+    }
+
+    // ---------------------------------------------------------------
+    // Section 2: Relational model EntityTypeMappings — All vs Any
+    //
+    // Requires a full DbContext with the Couchbase relational provider so that
+    // EF Core builds the ITable → IEntityType mapping used by IsOwnedTable.
+    // ---------------------------------------------------------------
+
+    [Fact]
+    public void OwnsOne_OwnerTable_EntityTypeMappingsContainsBothOwnerAndOwnedType()
+    {
+        // This is the critical model-level truth that IsOwnedTable relies on.
+        //
+        // With OwnsOne the owned entity is table-split onto the owner's table.  EF Core
+        // therefore registers BOTH the owner entity type AND the owned entity type in that
+        // table's EntityTypeMappings:
+        //
+        //   Any(m => IsOwned) = true   ← WRONG: would suppress the owner's FROM clause
+        //   All(m => IsOwned) = false  ← CORRECT: owner table is not an "owned-only" table
+        //
+        // If someone were to change All → Any in IsOwnedTable, this test would catch the
+        // regression before the integration tests (which need a live server).
+
+        using var ctx = CreateContext();
+
+        var ownerEntityType = ctx.Model.FindEntityType(typeof(Customer))!;
+        // GetTableMappings() is a relational extension method — only available when the
+        // context is built with a relational provider such as UseCouchbaseProvider.
+        var table    = ownerEntityType.GetTableMappings().First().Table;
+        var mappings = table.EntityTypeMappings.ToList();
+
+        // The owner table should carry mappings for at least the owner and the OwnsOne entity.
+        Assert.True(mappings.Count >= 2,
+            $"Owner table should have ≥ 2 EntityTypeMappings (got {mappings.Count}). " +
+            "Expected at least one entry for the owner and one for the OwnsOne entity.");
+
+        // At least one mapping must be for an owned entity.
+        Assert.Contains(mappings, m => m.TypeBase is IEntityType et && et.IsOwned());
+
+        // At least one mapping must be for the non-owned owner entity.
+        Assert.Contains(mappings, m => m.TypeBase is IEntityType et && !et.IsOwned());
+
+        // All(IsOwned) must return false — this is what IsOwnedTable correctly evaluates,
+        // keeping the owner's FROM clause in the generated N1QL.
+        var allOwned = mappings.All(m => m.TypeBase is IEntityType et && et.IsOwned());
+        Assert.False(allOwned,
+            "All(IsOwned) must be false for the owner table. " +
+            "If it returned true, IsOwnedTable would suppress the FROM clause, producing a " +
+            "N1QL syntax error (WHERE keyword without a preceding FROM).");
+    }
+
+    // ---------------------------------------------------------------
+    // Section 3: SQL generation — FROM-clause regression tests
+    //
+    // Verifies that CouchbaseQuerySqlGenerator emits valid N1QL for models
+    // with OwnsOne / OwnsMany relationships.  These tests catch the regression
+    // where using Any() instead of All() in IsOwnedTable caused the owner's
+    // FROM clause to be omitted, producing:
+    //
+    //   SELECT ... WHERE ...    ← invalid N1QL (no FROM)
+    //
+    // instead of the correct:
+    //
+    //   SELECT ... FROM `bucket`.`scope`.`customer` AS c WHERE ...
+    //
+    // The tests run without a live Couchbase server; ToQueryString() compiles
+    // the LINQ to SQL++ in-process without executing the query.
+    // ---------------------------------------------------------------
+
+    [Fact]
+    public void CustomerQuery_GeneratesFromClause()
+    {
+        using var ctx = CreateContext();
+
+        var sql = ctx.Customers.ToQueryString();
+
+        Assert.Contains("FROM", sql, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void CustomerQuery_FromClauseContainsBacktickedKeyspace()
+    {
+        using var ctx = CreateContext();
+
+        var sql = ctx.Customers.ToQueryString();
+
+        // Each part of the three-part keyspace must appear backtick-delimited.
+        Assert.Contains("`bucket`",   sql);
+        Assert.Contains("`scope`",    sql);
+        Assert.Contains("`customer`", sql);
+    }
+
+    [Fact]
+    public void CustomerQuery_WithWhere_FromPrecedesWhere()
+    {
+        // Regression: with Any() instead of All() in IsOwnedTable, the owner's FROM clause
+        // was suppressed for entities that also host OwnsOne scalars, yielding
+        // "SELECT … WHERE …" (no FROM).  Couchbase Server rejects this with:
+        //   ParsingFailureException: syntax error — line 5, column 5, at: WHERE [3000]
+        //
+        // This test verifies the correct ordering without requiring a live server.
+
+        using var ctx = CreateContext();
+
+        var sql = ctx.Customers
+            .Where(c => c.CustomerId > 0)
+            .ToQueryString();
+
+        var fromIndex  = sql.IndexOf("FROM",  StringComparison.OrdinalIgnoreCase);
+        var whereIndex = sql.IndexOf("WHERE", StringComparison.OrdinalIgnoreCase);
+
+        Assert.True(fromIndex  >= 0, $"Query must contain FROM clause.\nGenerated SQL:\n{sql}");
+        Assert.True(whereIndex >= 0, $"Query must contain WHERE clause.\nGenerated SQL:\n{sql}");
+        Assert.True(fromIndex < whereIndex,
+            $"FROM must appear before WHERE.\nGenerated SQL:\n{sql}");
+    }
+
+    [Fact]
+    public void CustomerQuery_WithOwnsOne_GeneratesNoJoinForEmbeddedAddress()
+    {
+        // Address is an OwnsOne / table-split scalar navigation — it is embedded in the
+        // owner document, not a separate Couchbase collection.  The generated SQL++ must
+        // not contain a JOIN clause for it.
+
+        using var ctx = CreateContext();
+
+        // A plain select (no explicit Include) should not add a JOIN.
+        var sql = ctx.Customers.ToQueryString();
+
+        Assert.DoesNotContain("JOIN", sql, StringComparison.OrdinalIgnoreCase);
+    }
+
+    // ---------------------------------------------------------------
+    // Helpers
+    // ---------------------------------------------------------------
+
+    private static CustomerContext CreateContext()
+    {
+        var clusterOptions = new ClusterOptions()
+            .WithConnectionString("couchbase://localhost")
+            .WithPasswordAuthentication("Administrator", "password");
+
+        // Build options via the strongly-typed builder.  UseCouchbaseProvider returns the
+        // non-generic base type, so we keep a local reference to preserve the generic form
+        // for the Options property.
+        var builder = new DbContextOptionsBuilder<CustomerContext>();
+        builder.UseCouchbaseProvider(clusterOptions);
+
+        return new CustomerContext(builder.Options);
+    }
+
+    // ---------------------------------------------------------------
+    // Test models — Section 1 (model-only tests, no relational provider)
+    // ---------------------------------------------------------------
+
+    private class SingleOwner
+    {
+        public int Id { get; set; }
+        public EmbeddedValue Embedded { get; set; } = new();
+        public List<OwnedItem> Items { get; set; } = [];
+    }
+
+    private class EmbeddedValue { public string? Value { get; set; } }
+
+    private class OwnedItem
+    {
+        public int     Id   { get; set; }
+        public string? Name { get; set; }
+    }
+
+    // ---------------------------------------------------------------
+    // Test models — Sections 2 & 3 (relational provider / SQL generation)
+    // ---------------------------------------------------------------
+
+    private class Customer
+    {
+        public int    CustomerId { get; set; }
+        public string Name       { get; set; } = "";
+        public Address           Address        { get; set; } = new();
+        public List<ContactMethod> ContactMethods { get; set; } = [];
+    }
+
+    private class Address
+    {
+        public string? Street { get; set; }
+        public string? City   { get; set; }
+    }
+
+    private class ContactMethod
+    {
+        public int    Id   { get; set; }
+        public string Type { get; set; } = "";
+    }
+
+    private class CustomerContext(DbContextOptions<CustomerContext> options) : DbContext(options)
+    {
+        public DbSet<Customer> Customers { get; set; } = null!;
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            modelBuilder.Entity<Customer>(b =>
+            {
+                b.ToCouchbaseCollection("bucket", "scope", "customer");
+                b.HasKey(c => c.CustomerId);
+                b.OwnsOne(c => c.Address);
+                b.OwnsMany(c => c.ContactMethods);
+            });
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Replace the private `Keyspace` inner class in `CouchbaseQuerySqlGenerator` with the
  shared `CouchbaseKeyspace` record from `Metadata/`, eliminating a redundant type
- Introduce `IsOwnedTable()` — a model-metadata-driven helper that replaces the fragile
  `Name.Split('.').Length != 3` heuristic for detecting owned-type tables in
  `VisitLeftJoin`, `VisitInnerJoin`, and `VisitTable`
- Route keyspace identifier quoting through `ISqlGenerationHelper.DelimitIdentifier` in
  `VisitTable`, and fix `CouchbaseKeyspace.ToSqlString()` to escape embedded backticks,
  eliminating a parallel quoting path
- Fix `CouchbaseQueryEnumerable.ToQueryString()` and
  `CouchbaseFromSqlQueryingEnumerable.ToQueryString()` to compile SQL without opening a
  database connection
- Align the live query string with `ToQueryString()` in both enumerables by switching
  from `RelationalQueryStringFactory.Create(dbCommand)` to `dbCommand.CommandText`
- Add `OwnedTableDetectionTests` (9 unit tests) covering the `IsOwnedTable` logic,
  relational model metadata, and SQL generation regression

---

## `CouchbaseQuerySqlGenerator` refactor

### Private `Keyspace` class → `CouchbaseKeyspace`

The private `Keyspace` inner class stored only a pre-rendered SQL string and used
`EscapeIfRequired` rather than uniform backtick quoting. `CouchbaseKeyspace` in
`Metadata/` already provides `Parse()`, `ToString()`, and `ToSqlString()` and is used
throughout the rest of the provider. The cache type changes from
`Dictionary<string, Keyspace>` to `ConcurrentDictionary<string, CouchbaseKeyspace>`.

### `IsOwnedTable()` — `All` not `Any`

The old heuristic (`Name.Split('.').Length != 3`) inferred owned tables from the
table-name format. The new helper reads `ITableBase.EntityTypeMappings` and checks
whether every mapping is an owned entity type.

`All` is required: an owner table that also hosts an `OwnsOne` scalar navigation
(table-splitting) contains **both** the owner entity type and the owned entity type in
`EntityTypeMappings`. Using `Any` would match the owner's table, suppressing its `FROM`
clause and producing a `WHERE` keyword with no preceding `FROM` — Couchbase error 3000.
`All` correctly returns `true` only for standalone owned-collection virtual tables that
have no corresponding Couchbase collection.

### Identifier quoting via `SqlGenerationHelper`

`VisitTable` previously called `keyspace.ToSqlString()`, which wrapped each segment in
backticks without escaping. `CouchbaseSqlGenerationHelper.DelimitIdentifier` splits on
`.` and applies `EscapeIdentifier` (backtick-doubling) per segment. All identifier
quoting in the provider now flows through a single authoritative path.
`CouchbaseKeyspace.ToSqlString()` is also fixed to escape embedded backticks for callers
(display, logging) that do not have access to the helper.

---

## Query enumerable behavior change: `CommandText` replaces `factory.Create(dbCommand)`

**Before:** Both `CouchbaseQueryEnumerable.GetAsyncEnumerator()` and
`CouchbaseFromSqlQueryingEnumerable.GetAsyncEnumerator()` computed the SQL string sent to
Couchbase via `RelationalQueryStringFactory.Create(dbCommand)`. When query parameters are
present, that factory prepends per-parameter diagnostic comment blocks before the SQL:

```sql
-- @p0
  Direction: Input
  Size: 4
  Value: 5

SELECT ... FROM `bucket`.`scope`.`customer` AS c WHERE c."CustomerId" > @p0