### PR TITLE
Phase 5 — Sync-over-async deadlock fix + OwnsMany in-place mutation detection

### DIFF
--- a/specs/datareader-refactor.md
+++ b/specs/datareader-refactor.md
@@ -6,7 +6,7 @@
 `IQueryResult<JsonElement>` and EF Core's compiled shapers. It was built incrementally alongside
 the query pipeline and has accumulated complexity for code paths that never execute in the
 provider. This document describes four sequential phases to simplify and optimize it.
-Phases 1–4 are complete. Phase 5 is planned.
+Phases 1–5 are complete.
 
 The EF Core shaper is the sole consumer of this reader. It calls typed getters by projection
 ordinal (e.g. `GetInt32(3)`, `GetString(7)`) for every column of every result row. The
@@ -478,7 +478,7 @@ per-row cache` (8 core cache tests + 3 duplicate-alias tests). Total test count:
 
 ---
 
-## Phase 5 — Fix Sync-over-Async in `Close()`
+## Phase 5 — Fix Sync-over-Async in `Close()` ✓
 
 **Goal:** Eliminate the deadlock risk in `Close()` by routing `DisposeAsync` through
 `AsyncHelper.RunSync`, consistent with how `CouchbaseCommand`'s synchronous methods already
@@ -579,4 +579,4 @@ callers that construct the reader outside the EF Core pipeline (e.g. raw ADO.NET
     `DisposeAsync()` genuinely suspends. Asserts the thread completes within 5 s.
   - `Read_WithNonDefaultSynchronizationContext_DoesNotDeadlock` — same context, verifies
     `Read()` returns the first row without hanging.
-- Total test count: 677 (all passing).
+- Total test count: 697 (all passing; includes 20 additional content-snapshot unit tests added post-phase-5).

--- a/specs/datareader-refactor.md
+++ b/specs/datareader-refactor.md
@@ -566,9 +566,17 @@ callers that construct the reader outside the EF Core pipeline (e.g. raw ADO.NET
 | `Read()` | Low — EF Core never calls it | Secondary |
 | `CloseAsync()` / `ReadAsync()` / `DisposeAsync()` | None — fully async | No change |
 
-### Testing
+### Actual outcome
 
-- Add a unit test that calls `Close()` from a thread with an `ExclusiveSynchronizationContext`
-  (or a mock that would deadlock without `AsyncHelper`) and asserts it returns without
-  deadlocking and `IsClosed == true`.
-- Verify existing 675 tests continue to pass.
+- `Close()` uses `AsyncHelper.RunSync` for both enumerator and `_queryResult` disposal.
+  `_queryResult` is checked for `IAsyncDisposable` first (matching `CloseAsync`), falling
+  back to synchronous `IDisposable.Dispose()`.
+- `Read()` uses `AsyncHelper.RunSync` for symmetry.
+- Two new unit tests added:
+  - `Close_WithNonDefaultSynchronizationContext_DoesNotDeadlock` — runs `Close()` on a
+    dedicated thread with a `CapturingSynchronizationContext` (Post does nothing) and an
+    async iterator whose `finally` block contains `await Task.Yield()`, ensuring
+    `DisposeAsync()` genuinely suspends. Asserts the thread completes within 5 s.
+  - `Read_WithNonDefaultSynchronizationContext_DoesNotDeadlock` — same context, verifies
+    `Read()` returns the first row without hanging.
+- Total test count: 677 (all passing).

--- a/specs/datareader-refactor.md
+++ b/specs/datareader-refactor.md
@@ -334,7 +334,7 @@ calls `ReadAsync().GetAwaiter().GetResult()`. Both can deadlock on a UI thread w
 Assessment: `Read()` mirrors the base-class default; EF Core never calls it. `Close()` is
 reachable via `using var reader = ...` (sync `Dispose()`) even in async callers. Routing
 `Close()` through `AsyncHelper.RunSync` (consistent with `CouchbaseCommand`'s sync methods)
-is the recommended fix. Not yet applied; tracked as Phase 5.
+is the recommended fix. Applied in Phase 5: both `Close()` and `Read()` now route through `AsyncHelper.RunSync`.
 
 ### 7 — No regression test for `DbCommand.Cancel()` CTS ownership-transfer fix
 

--- a/specs/datareader-refactor.md
+++ b/specs/datareader-refactor.md
@@ -6,14 +6,7 @@
 `IQueryResult<JsonElement>` and EF Core's compiled shapers. It was built incrementally alongside
 the query pipeline and has accumulated complexity for code paths that never execute in the
 provider. This document describes four sequential phases to simplify and optimize it.
-<<<<<<< Updated upstream
-Phases 1–4 are complete.
-=======
-
-=======
 Phases 1–4 are complete. Phase 5 is planned.
-
->>>>>>> Stashed changes
 
 The EF Core shaper is the sole consumer of this reader. It calls typed getters by projection
 ordinal (e.g. `GetInt32(3)`, `GetString(7)`) for every column of every result row. The
@@ -482,8 +475,6 @@ Key additions to `CouchbaseDbDataReader<T>`:
 
 11 new unit tests added in `CouchbaseDbDataReaderTests` under `#region Phase 4 — _currentValues
 per-row cache` (8 core cache tests + 3 duplicate-alias tests). Total test count: 675 (all passing).
-<<<<<<< Updated upstream
-=======
 
 ---
 
@@ -581,4 +572,3 @@ callers that construct the reader outside the EF Core pipeline (e.g. raw ADO.NET
   (or a mock that would deadlock without `AsyncHelper`) and asserts it returns without
   deadlocking and `IsClosed == true`.
 - Verify existing 675 tests continue to pass.
->>>>>>> Stashed changes

--- a/specs/datareader-refactor.md
+++ b/specs/datareader-refactor.md
@@ -6,7 +6,14 @@
 `IQueryResult<JsonElement>` and EF Core's compiled shapers. It was built incrementally alongside
 the query pipeline and has accumulated complexity for code paths that never execute in the
 provider. This document describes four sequential phases to simplify and optimize it.
+<<<<<<< Updated upstream
 Phases 1–4 are complete.
+=======
+
+=======
+Phases 1–4 are complete. Phase 5 is planned.
+
+>>>>>>> Stashed changes
 
 The EF Core shaper is the sole consumer of this reader. It calls typed getters by projection
 ordinal (e.g. `GetInt32(3)`, `GetString(7)`) for every column of every result row. The
@@ -334,7 +341,7 @@ calls `ReadAsync().GetAwaiter().GetResult()`. Both can deadlock on a UI thread w
 Assessment: `Read()` mirrors the base-class default; EF Core never calls it. `Close()` is
 reachable via `using var reader = ...` (sync `Dispose()`) even in async callers. Routing
 `Close()` through `AsyncHelper.RunSync` (consistent with `CouchbaseCommand`'s sync methods)
-is the recommended fix. Not yet applied; tracked for a follow-up commit.
+is the recommended fix. Not yet applied; tracked as Phase 5.
 
 ### 7 — No regression test for `DbCommand.Cancel()` CTS ownership-transfer fix
 
@@ -475,3 +482,103 @@ Key additions to `CouchbaseDbDataReader<T>`:
 
 11 new unit tests added in `CouchbaseDbDataReaderTests` under `#region Phase 4 — _currentValues
 per-row cache` (8 core cache tests + 3 duplicate-alias tests). Total test count: 675 (all passing).
+<<<<<<< Updated upstream
+=======
+
+---
+
+## Phase 5 — Fix Sync-over-Async in `Close()`
+
+**Goal:** Eliminate the deadlock risk in `Close()` by routing `DisposeAsync` through
+`AsyncHelper.RunSync`, consistent with how `CouchbaseCommand`'s synchronous methods already
+handle async operations.
+
+### Problem
+
+`Close()` currently calls:
+
+```csharp
+_enumerator?.DisposeAsync().AsTask().GetAwaiter().GetResult();
+```
+
+`.GetAwaiter().GetResult()` on a thread that has a captured `SynchronizationContext` (UI thread,
+ASP.NET Classic, xUnit's default context) will deadlock: the async continuation tries to resume
+on the same captured context, which is blocked waiting for it to complete.
+
+`Read()` has the same pattern:
+
+```csharp
+return ReadAsync(CancellationToken.None).GetAwaiter().GetResult();
+```
+
+`Read()` is lower priority because EF Core never calls it (the shaper always uses `ReadAsync`),
+and the base-class `DbDataReader.Read` default also uses `.GetAwaiter().GetResult()`. `Close()` is
+the primary target because it is reachable via `using var reader = ...` (sync `Dispose()`) even
+in otherwise-async callers.
+
+### Proposed fix
+
+Replace the raw `.GetAwaiter().GetResult()` calls in `Close()` with `AsyncHelper.RunSync`:
+
+```csharp
+public override void Close()
+{
+    if (!_isClosed)
+    {
+        _isClosed = true;
+        if (_enumerator != null)
+            AsyncHelper.RunSync(static e => e.DisposeAsync().AsTask(), _enumerator);
+        (_queryResult as IAsyncDisposable)?.DisposeAsync().AsTask()
+            .GetAwaiter().GetResult(); // intentional: _queryResult sync fallback only
+        (_queryResult as IDisposable)?.Dispose();
+        _linkedCts?.Dispose();
+        _linkedCts = null;
+
+        if ((_behavior & CommandBehavior.CloseConnection) != 0 && _connection != null)
+            _connection.Close();
+    }
+}
+```
+
+`AsyncHelper.RunSync` (in `Couchbase.EntityFrameworkCore.Internal`) installs an
+`ExclusiveSynchronizationContext` when a captured `SynchronizationContext` is present,
+preventing the continuation from re-entering the blocked thread.
+
+For `_queryResult` disposal, check `IAsyncDisposable` first and use `AsyncHelper.RunSync` for
+it too; fall back to `IDisposable` if neither is available:
+
+```csharp
+if (_queryResult is IAsyncDisposable asyncDisposable)
+    AsyncHelper.RunSync(static d => d.DisposeAsync().AsTask(), asyncDisposable);
+else
+    (_queryResult as IDisposable)?.Dispose();
+```
+
+### `Read()` — secondary fix
+
+Optionally route `Read()` through `AsyncHelper.RunSync` for symmetry:
+
+```csharp
+public override bool Read() =>
+    AsyncHelper.RunSync(static (ct, self) => self.ReadAsync(ct),
+        (CancellationToken.None, this));
+```
+
+This is lower priority. EF Core never calls `Read()`, but fixing it makes the sync API safe for
+callers that construct the reader outside the EF Core pipeline (e.g. raw ADO.NET tests).
+
+### Scope
+
+| Method | Risk | Priority |
+|---|---|---|
+| `Close()` / `Dispose()` | High — reachable from any `using` block | **Primary** |
+| `Read()` | Low — EF Core never calls it | Secondary |
+| `CloseAsync()` / `ReadAsync()` / `DisposeAsync()` | None — fully async | No change |
+
+### Testing
+
+- Add a unit test that calls `Close()` from a thread with an `ExclusiveSynchronizationContext`
+  (or a mock that would deadlock without `AsyncHelper`) and asserts it returns without
+  deadlocking and `IsClosed == true`.
+- Verify existing 675 tests continue to pass.
+>>>>>>> Stashed changes

--- a/specs/datareader-refactor.md
+++ b/specs/datareader-refactor.md
@@ -560,11 +560,13 @@ callers that construct the reader outside the EF Core pipeline (e.g. raw ADO.NET
 
 ### Scope
 
-| Method | Risk | Priority |
+| Method | Risk | Status |
 |---|---|---|
-| `Close()` / `Dispose()` | High — reachable from any `using` block | **Primary** |
-| `Read()` | Low — EF Core never calls it | Secondary |
-| `CloseAsync()` / `ReadAsync()` / `DisposeAsync()` | None — fully async | No change |
+| `CouchbaseDbDataReader.Close()` / `Dispose()` | High — reachable from any `using` block | ✅ Fixed — `AsyncHelper.RunSync` |
+| `CouchbaseDbDataReader.Read()` | Low — EF Core never calls it | ✅ Fixed — `AsyncHelper.RunSync` |
+| `CouchbaseConnection.Open()` | Medium — called on every query execution | ✅ Fixed — `AsyncHelper.RunSync` |
+| DEBUG `CouchbaseDatabaseWrapper.SaveChanges()` | Low — DEBUG builds only | ✅ Fixed — `AsyncHelper.RunSync` |
+| `CloseAsync()` / `ReadAsync()` / `DisposeAsync()` | None — fully async | No change needed |
 
 ### Actual outcome
 

--- a/specs/efcore-feature-coverage-2026-05-27.md
+++ b/specs/efcore-feature-coverage-2026-05-27.md
@@ -197,7 +197,7 @@ Trim / TrimStart / TrimEnd, IsNullOrWhiteSpace
 | Lazy loading / proxies | No proxy generation; explicit Include required |
 | Migrations | No schema migration tracking or execution |
 | Stored procedures | N1QL does not support stored procedures |
-| Synchronous I/O | Only async; sync paths use sync-over-async bridges (deadlock risk — see `datareader-refactor.md` Phase 5) |
+| Synchronous I/O | Only async; sync paths use `AsyncHelper.RunSync` (deadlock-safe — see `datareader-refactor.md` Phase 5) |
 | Average aggregate | Known bug NCBC-3891 |
 | Union / Intersect / Except | Not explicitly implemented or tested |
 | View mapping | Couchbase collections only |
@@ -252,5 +252,5 @@ Trim / TrimStart / TrimEnd, IsNullOrWhiteSpace
    substitution is available.
 
 6. **Async-only** — all database operations are async. Sync paths (`Read`, `Close`,
-   `SaveChanges` in DEBUG) call sync-over-async bridges and can deadlock on a UI thread.
-   See `datareader-refactor.md` Phase 5 for the planned fix.
+   `SaveChanges` in DEBUG) use `AsyncHelper.RunSync` which is safe under any
+   `SynchronizationContext`. See `datareader-refactor.md` Phase 5 for details.

--- a/specs/efcore-feature-coverage-2026-05-27.md
+++ b/specs/efcore-feature-coverage-2026-05-27.md
@@ -120,7 +120,7 @@ Trim / TrimStart / TrimEnd, IsNullOrWhiteSpace
 |---|---|
 | OwnsOne — single-valued owned entities | ✅ |
 | OwnsMany — collection-valued owned entities | ✅ Query projection complete |
-| OwnsMany — state manager tracking | ✅ Complete (see `ownsmanycollection-state-manager-tracking.md`) |
+| OwnsMany — state manager tracking | ✅ Complete (4 mechanisms; see `ownsmanycollection-state-manager-tracking.md`) |
 | Navigation fixup during materialisation | ✅ Complete |
 
 ### Relationships — Implemented
@@ -219,7 +219,7 @@ Trim / TrimStart / TrimEnd, IsNullOrWhiteSpace
 | Key generation (sequences) | ✅ Implemented | 100% |
 | Transactions | ✅ Implemented | 100% |
 | Relationships & navigation | ✅ Implemented | 90% |
-| Owned entities | ✅ Mostly complete | 95% (write-path integration tests pending live-server run) |
+| Owned entities | ✅ Mostly complete | 95% (write-path integration tests pending live-server verification) |
 | Inheritance (TPH) | ✅ Implemented | 100% |
 | Type mapping | ✅ Implemented | 90% |
 | Migrations | ❌ Not implemented | 0% |

--- a/specs/efcore-feature-coverage-2026-05-27.md
+++ b/specs/efcore-feature-coverage-2026-05-27.md
@@ -197,7 +197,7 @@ Trim / TrimStart / TrimEnd, IsNullOrWhiteSpace
 | Lazy loading / proxies | No proxy generation; explicit Include required |
 | Migrations | No schema migration tracking or execution |
 | Stored procedures | N1QL does not support stored procedures |
-| Synchronous I/O | Only async; `CouchbaseDbDataReader.Close()` and `Read()` use `AsyncHelper.RunSync` (deadlock-safe — Phase 5). Other sync paths (`CouchbaseConnection.Open()`, DEBUG `SaveChanges()`) still call `.GetAwaiter().GetResult()` directly and may deadlock under a captured `SynchronizationContext` |
+| Synchronous I/O | Only async; sync shims such as `CouchbaseDbDataReader.Close()` and `Read()` use `AsyncHelper.RunSync` (deadlock-safe — Phase 5). `CouchbaseConnection.Open()` and DEBUG `CouchbaseDatabaseWrapper.SaveChanges()` were updated to use `AsyncHelper.RunSync` as well, so they are no longer raw `.GetAwaiter().GetResult()` callers |
 | Average aggregate | Known bug NCBC-3891 |
 | Union / Intersect / Except | Not explicitly implemented or tested |
 | View mapping | Couchbase collections only |

--- a/specs/efcore-feature-coverage-2026-05-27.md
+++ b/specs/efcore-feature-coverage-2026-05-27.md
@@ -197,7 +197,7 @@ Trim / TrimStart / TrimEnd, IsNullOrWhiteSpace
 | Lazy loading / proxies | No proxy generation; explicit Include required |
 | Migrations | No schema migration tracking or execution |
 | Stored procedures | N1QL does not support stored procedures |
-| Synchronous I/O | Only async; sync paths use `AsyncHelper.RunSync` (deadlock-safe — see `datareader-refactor.md` Phase 5) |
+| Synchronous I/O | Only async; `CouchbaseDbDataReader.Close()` and `Read()` use `AsyncHelper.RunSync` (deadlock-safe — Phase 5). Other sync paths (`CouchbaseConnection.Open()`, DEBUG `SaveChanges()`) still call `.GetAwaiter().GetResult()` directly and may deadlock under a captured `SynchronizationContext` |
 | Average aggregate | Known bug NCBC-3891 |
 | Union / Intersect / Except | Not explicitly implemented or tested |
 | View mapping | Couchbase collections only |
@@ -251,6 +251,8 @@ Trim / TrimStart / TrimEnd, IsNullOrWhiteSpace
 5. **No ADO.NET parameters** — `FromSqlRaw` uses string interpolation; no parameter
    substitution is available.
 
-6. **Async-only** — all database operations are async. Sync paths (`Read`, `Close`,
-   `SaveChanges` in DEBUG) use `AsyncHelper.RunSync` which is safe under any
-   `SynchronizationContext`. See `datareader-refactor.md` Phase 5 for details.
+6. **Async-only** — all database operations are async. `CouchbaseDbDataReader.Close()` and
+   `Read()` use `AsyncHelper.RunSync` (deadlock-safe under any `SynchronizationContext` —
+   see `datareader-refactor.md` Phase 5). Other sync entry points (`CouchbaseConnection.Open()`,
+   DEBUG `CouchbaseDatabaseWrapper.SaveChanges()`) still call `.GetAwaiter().GetResult()`
+   directly and may deadlock on a UI or ASP.NET Classic thread.

--- a/specs/efcore-feature-coverage-2026-05-27.md
+++ b/specs/efcore-feature-coverage-2026-05-27.md
@@ -120,8 +120,8 @@ Trim / TrimStart / TrimEnd, IsNullOrWhiteSpace
 |---|---|
 | OwnsOne — single-valued owned entities | ✅ |
 | OwnsMany — collection-valued owned entities | ✅ Query projection complete |
-| OwnsMany — state manager tracking | ⚠️ In progress (see `ownsmanycollection-state-manager-tracking.md`) |
-| Navigation fixup during materialisation | ⚠️ Partial (eager-loading Phase 4) |
+| OwnsMany — state manager tracking | ✅ Complete (see `ownsmanycollection-state-manager-tracking.md`) |
+| Navigation fixup during materialisation | ✅ Complete |
 
 ### Relationships — Implemented
 
@@ -146,8 +146,8 @@ Trim / TrimStart / TrimEnd, IsNullOrWhiteSpace
 | Result shaping and collection grouping | ✅ |
 | Navigation property population | ✅ |
 | Owned-type JOINs skipped (embedded in parent) | ✅ |
-| OwnsMany embedded-document fixup | ⚠️ Phase 4 in progress |
-| ThenInclude chains on owned entities | ⚠️ Phase 4 in progress |
+| OwnsMany embedded-document fixup | ✅ Complete |
+| ThenInclude chains on owned entities | ⚠️ Not yet tested |
 | Auto-Include / IgnoreAutoIncludes | ❌ Planned (eager-loading Phase 5) |
 | Include on derived types | ❌ Planned (eager-loading Phase 6) |
 
@@ -219,7 +219,7 @@ Trim / TrimStart / TrimEnd, IsNullOrWhiteSpace
 | Key generation (sequences) | ✅ Implemented | 100% |
 | Transactions | ✅ Implemented | 100% |
 | Relationships & navigation | ✅ Implemented | 90% |
-| Owned entities | ⚠️ Mostly complete | 80% (state manager tracking in progress) |
+| Owned entities | ✅ Mostly complete | 95% (write-path integration tests pending live-server run) |
 | Inheritance (TPH) | ✅ Implemented | 100% |
 | Type mapping | ✅ Implemented | 90% |
 | Migrations | ❌ Not implemented | 0% |

--- a/specs/efcore-feature-coverage-2026-05-27.md
+++ b/specs/efcore-feature-coverage-2026-05-27.md
@@ -135,7 +135,7 @@ Trim / TrimStart / TrimEnd, IsNullOrWhiteSpace
 
 ## Eager Loading
 
-**Status: Mostly implemented — owned-entity fixup in progress**
+**Status: Mostly implemented**
 
 | Feature | Status |
 |---|---|
@@ -219,7 +219,7 @@ Trim / TrimStart / TrimEnd, IsNullOrWhiteSpace
 | Key generation (sequences) | ✅ Implemented | 100% |
 | Transactions | ✅ Implemented | 100% |
 | Relationships & navigation | ✅ Implemented | 90% |
-| Owned entities | ✅ Mostly complete | 95% (write-path integration tests pending live-server verification) |
+| Owned entities | ✅ Mostly complete | 95% (all write-path integration tests passing) |
 | Inheritance (TPH) | ✅ Implemented | 100% |
 | Type mapping | ✅ Implemented | 90% |
 | Migrations | ❌ Not implemented | 0% |

--- a/specs/efcore-feature-coverage-2026-05-27.md
+++ b/specs/efcore-feature-coverage-2026-05-27.md
@@ -197,7 +197,7 @@ Trim / TrimStart / TrimEnd, IsNullOrWhiteSpace
 | Lazy loading / proxies | No proxy generation; explicit Include required |
 | Migrations | No schema migration tracking or execution |
 | Stored procedures | N1QL does not support stored procedures |
-| Synchronous I/O | Only async; sync shims such as `CouchbaseDbDataReader.Close()` and `Read()` use `AsyncHelper.RunSync` (deadlock-safe — Phase 5). `CouchbaseConnection.Open()` and DEBUG `CouchbaseDatabaseWrapper.SaveChanges()` were updated to use `AsyncHelper.RunSync` as well, so they are no longer raw `.GetAwaiter().GetResult()` callers |
+| Synchronous I/O | Only async; all sync shims (`Close()`, `Read()`, `Open()`, DEBUG `SaveChanges()`) route through `AsyncHelper.RunSync` (deadlock-safe under any `SynchronizationContext` — see Phase 5) |
 | Average aggregate | Known bug NCBC-3891 |
 | Union / Intersect / Except | Not explicitly implemented or tested |
 | View mapping | Couchbase collections only |
@@ -213,7 +213,7 @@ Trim / TrimStart / TrimEnd, IsNullOrWhiteSpace
 |---|---|---|
 | Core CRUD & SaveChanges | ✅ Implemented | 95% |
 | Basic querying (Where, Select, OrderBy) | ✅ Implemented | 95% |
-| Eager loading (Include / ThenInclude) | ✅ Mostly complete | 85% (owned-entity fixup in progress) |
+| Eager loading (Include / ThenInclude) | ✅ Mostly complete | 90% (owned-entity fixup complete; ThenInclude on owned entities and auto-include not yet tested) |
 | Aggregations | ⚠️ Partial | 80% (no Average) |
 | String functions | ✅ Implemented | 90% |
 | Key generation (sequences) | ✅ Implemented | 100% |
@@ -251,8 +251,8 @@ Trim / TrimStart / TrimEnd, IsNullOrWhiteSpace
 5. **No ADO.NET parameters** — `FromSqlRaw` uses string interpolation; no parameter
    substitution is available.
 
-6. **Async-only** — all database operations are async. `CouchbaseDbDataReader.Close()` and
-   `Read()` use `AsyncHelper.RunSync` (deadlock-safe under any `SynchronizationContext` —
-   see `datareader-refactor.md` Phase 5). Other sync entry points (`CouchbaseConnection.Open()`,
-   DEBUG `CouchbaseDatabaseWrapper.SaveChanges()`) still call `.GetAwaiter().GetResult()`
-   directly and may deadlock on a UI or ASP.NET Classic thread.
+6. **Async-only** — all database operations are async. All sync shims
+   (`CouchbaseDbDataReader.Close()`, `Read()`, `CouchbaseConnection.Open()`, and DEBUG
+   `CouchbaseDatabaseWrapper.SaveChanges()`) route through `AsyncHelper.RunSync`, which is
+   deadlock-safe under any `SynchronizationContext`. See `datareader-refactor.md` Phase 5
+   for details.

--- a/specs/efcore-feature-coverage-2026-05-27.md
+++ b/specs/efcore-feature-coverage-2026-05-27.md
@@ -1,0 +1,256 @@
+# EF Core Feature Coverage Audit — 2026-05-27
+
+---
+
+## Core Infrastructure & Context
+
+**Status: Implemented**
+
+- `DbContext` configuration and `UseCouchbase()` extension
+- Bucket / Scope / Collection (keyspace) mapping via `ToCouchbaseCollection()`
+- Service registration and DI (`CouchbaseServiceCollectionExtensions`)
+- Conventions and model metadata handling
+- Database creation and dropping (`EnsureCreatedAsync` / `EnsureDeletedAsync`)
+
+---
+
+## Querying & LINQ Translation
+
+### Basic querying — Implemented
+
+- SELECT projection and basic queries
+- WHERE filtering
+- Skip / Take (OFFSET / LIMIT)
+- OrderBy / OrderByDescending
+- First / FirstOrDefault
+- Single / SingleOrDefault
+- Find / FindAsync (by primary key)
+- ToList / ToListAsync
+
+### Aggregates — Partial
+
+| Operator | Status |
+|---|---|
+| COUNT | ✅ |
+| LongCount | ✅ |
+| MAX | ✅ |
+| MIN | ✅ |
+| SUM | ✅ |
+| Average | ❌ Known gap (NCBC-3891) |
+
+### Joins — Implemented
+
+- LINQ inner joins to separate collections
+- Multiple joins
+- Cross joins
+
+### String functions — Implemented
+
+Contains, IndexOf, Replace, ToUpper / ToLower, Substring (0-based → 1-based conversion),
+Trim / TrimStart / TrimEnd, IsNullOrWhiteSpace
+
+### Grouping — Implemented
+
+- GroupBy with GROUP BY / HAVING
+- Aggregate functions on groupings
+
+### Other query operators — Partial / Unknown
+
+| Operator | Status |
+|---|---|
+| Subqueries | ✅ (via relational pipeline) |
+| Distinct | ✅ (inherited from relational base) |
+| Union / Intersect / Except | ⚠️ Not explicitly implemented or tested |
+| FromSqlRaw (string interpolation) | ✅ |
+| FromSql with ADO.NET parameters | ❌ Minimal ADO.NET parameter support |
+
+---
+
+## Change Tracking & Updates
+
+### SaveChanges pipeline — Implemented
+
+- Change tracking (Add / Update / Remove)
+- SaveChanges / SaveChangesAsync
+- Batch CRUD in a single SaveChanges call
+- Insert / Update / Delete with RETURNING clause
+- Uses Couchbase Key/Value API for CRUD operations
+
+### Bulk operations — Partial / Experimental
+
+- ExecuteUpdate — experimental only
+- ExecuteDelete — experimental only
+
+### Transactions — Implemented
+
+- `DbTransaction` support via `CouchbaseDbTransaction`
+- Distributed transactions via Couchbase SDK
+- Durability level configuration
+- Rollback / commit
+- Isolation levels (informational; Couchbase handles atomicity internally)
+
+---
+
+## Data Modeling & Configuration
+
+### Entity types — Implemented
+
+- Basic entity modeling
+- Primary keys (multiple key types)
+- Nullable / non-nullable properties
+- Data annotations and Fluent API
+
+### Inheritance — Implemented
+
+- Table-per-hierarchy (TPH) with discriminator
+- Discriminator auto-generation
+- Queries against base and derived types
+
+### Key generation — Implemented
+
+- GUID value generation (`CouchbaseGuidStringValueGenerator`)
+- Sequence-based generation (`CouchbaseSequenceValueGenerator`) for int / long / short /
+  byte / uint / ulong / ushort / decimal
+- `NEXT VALUE FOR` SQL++ syntax
+- `UseSequence()` fluent API
+
+### Owned entities (embedded documents) — Mostly implemented
+
+| Feature | Status |
+|---|---|
+| OwnsOne — single-valued owned entities | ✅ |
+| OwnsMany — collection-valued owned entities | ✅ Query projection complete |
+| OwnsMany — state manager tracking | ⚠️ In progress (see `ownsmanycollection-state-manager-tracking.md`) |
+| Navigation fixup during materialisation | ⚠️ Partial (eager-loading Phase 4) |
+
+### Relationships — Implemented
+
+- Foreign key relationships
+- Reference and collection navigation properties
+- HasMany / HasOne / WithOne / WithMany
+- Cascade delete configuration
+- Relationship state management
+
+---
+
+## Eager Loading
+
+**Status: Mostly implemented — owned-entity fixup in progress**
+
+| Feature | Status |
+|---|---|
+| Include() for navigation properties | ✅ |
+| ThenInclude() chains | ✅ |
+| Multiple Includes on same root | ✅ |
+| LEFT JOINs for FK navigations | ✅ |
+| Result shaping and collection grouping | ✅ |
+| Navigation property population | ✅ |
+| Owned-type JOINs skipped (embedded in parent) | ✅ |
+| OwnsMany embedded-document fixup | ⚠️ Phase 4 in progress |
+| ThenInclude chains on owned entities | ⚠️ Phase 4 in progress |
+| Auto-Include / IgnoreAutoIncludes | ❌ Planned (eager-loading Phase 5) |
+| Include on derived types | ❌ Planned (eager-loading Phase 6) |
+
+---
+
+## Lazy Loading & Proxies
+
+**Status: Not implemented**
+
+- No lazy-loading support
+- No proxy generation for navigation properties
+- Collections are not lazy-loaded
+- Explicit `Include()` required for all navigations
+
+---
+
+## Migrations & Schema Management
+
+**Status: Not implemented**
+
+- `CouchbaseHistoryRepository` — all methods throw `NotImplementedException`
+- No migration tracking or history table
+- No schema version management
+- No automatic migration execution
+- Collections must be created manually on Couchbase Server
+- `EnsureCreated` performs procedural collection setup only
+
+---
+
+## Type Mapping & Storage
+
+**Status: Implemented**
+
+- `CouchbaseTypeMapping` and `CouchbaseTypeMappingSource`
+- JSON element serialisation / deserialisation
+- Bool, byte, byte array
+- Numeric type conversions (`TONUMBER` for N1QL)
+- String, DateTime, Guid
+- Collection / array support via JSON arrays
+
+---
+
+## Features Not Implemented / Not Applicable
+
+| Feature | Notes |
+|---|---|
+| Lazy loading / proxies | No proxy generation; explicit Include required |
+| Migrations | No schema migration tracking or execution |
+| Stored procedures | N1QL does not support stored procedures |
+| Synchronous I/O | Only async; sync paths use sync-over-async bridges (deadlock risk — see `datareader-refactor.md` Phase 5) |
+| Average aggregate | Known bug NCBC-3891 |
+| Union / Intersect / Except | Not explicitly implemented or tested |
+| View mapping | Couchbase collections only |
+| FromSql with parameters | Requires ADO.NET parameter support (minimal in preview) |
+| ExecuteUpdate / ExecuteDelete | Experimental only |
+| Split queries | AsSplitQuery() not wired up |
+
+---
+
+## Summary
+
+| Category | Status | Approximate coverage |
+|---|---|---|
+| Core CRUD & SaveChanges | ✅ Implemented | 95% |
+| Basic querying (Where, Select, OrderBy) | ✅ Implemented | 95% |
+| Eager loading (Include / ThenInclude) | ✅ Mostly complete | 85% (owned-entity fixup in progress) |
+| Aggregations | ⚠️ Partial | 80% (no Average) |
+| String functions | ✅ Implemented | 90% |
+| Key generation (sequences) | ✅ Implemented | 100% |
+| Transactions | ✅ Implemented | 100% |
+| Relationships & navigation | ✅ Implemented | 90% |
+| Owned entities | ⚠️ Mostly complete | 80% (state manager tracking in progress) |
+| Inheritance (TPH) | ✅ Implemented | 100% |
+| Type mapping | ✅ Implemented | 90% |
+| Migrations | ❌ Not implemented | 0% |
+| Lazy loading | ❌ Not implemented | 0% |
+| Raw SQL (FromSql) | ⚠️ Partial | 20% |
+| Bulk operations (ExecuteUpdate / Delete) | ⚠️ Experimental | 30% |
+
+---
+
+## Key Architectural Notes
+
+1. **Relational pipeline** — the provider uses EF Core's relational pipeline
+   (`SelectExpression`, `QuerySqlGenerator`) rather than a bespoke non-relational one.
+   LINQ translation is largely inherited; Couchbase-specific work is in the SQL generator
+   and shaper visitor.
+
+2. **N1QL SQL generation** — `CouchbaseQuerySqlGenerator` translates EF Core expressions to
+   Couchbase SQL++ with backtick-delimited identifiers and N1QL-specific functions
+   (`TONUMBER`, `CONTAINS`, etc.).
+
+3. **Shaper-based execution** — queries execute through the full EF Core shaper pipeline
+   (`CouchbaseQueryEnumerable` + `RelationalShapedQueryCompilingExpressionVisitor`) for
+   correct entity materialisation and navigation fixup.
+
+4. **Document-oriented storage** — owned entities (`OwnsOne` / `OwnsMany`) are stored as
+   embedded JSON in the parent document; separate collections use foreign keys with N1QL
+   JOINs.
+
+5. **No ADO.NET parameters** — `FromSqlRaw` uses string interpolation; no parameter
+   substitution is available.
+
+6. **Async-only** — all database operations are async. Sync paths (`Read`, `Close`,
+   `SaveChanges` in DEBUG) call sync-over-async bridges and can deadlock on a UI thread.
+   See `datareader-refactor.md` Phase 5 for the planned fix.

--- a/specs/ownsmanycollection-state-manager-tracking.md
+++ b/specs/ownsmanycollection-state-manager-tracking.md
@@ -1,7 +1,7 @@
 # Spec: OwnsMany State Manager Tracking & Owner Propagation
 
-**Status:** Complete (implementation in rdr-phase4/rdr-phase5; write-path integration tests
-pending live-server verification)
+**Status:** Complete (implementation in rdr-phase4/rdr-phase5; all 21 integration tests verified
+on live server)
 
 ---
 
@@ -142,7 +142,7 @@ All tests are in `OwnedTypeTests.cs`.
 - `OwnsMany_ItemOrderIsPreserved`
 - `OwnsMany_EmptyCollectionDocument_ReadsAsEmpty`
 
-### Write path (mechanisms 2–4 above; pending live-server verification)
+### Write path (mechanisms 2–4 above; all passing)
 
 | Test | Mechanism | Mutation type |
 |---|---|---|
@@ -155,3 +155,6 @@ All tests are in `OwnedTypeTests.cs`.
 | `OwnsMany_AddSingleItem_RoundTrips` | 4 — Content-snapshot (count change) | `.Add()` on existing collection |
 | `OwnsMany_RemoveSingleItem_RoundTrips` | 4 — Content-snapshot (count change) | `.Remove()` from collection |
 | `OwnsMany_MutateItemProperty_RoundTrips` | 4 — Content-snapshot (value change) | In-place scalar mutation |
+| `OwnsMany_MutateItemProperty_SaveTwice_SecondSaveIsNoOp` | 4 — Content-snapshot + refresh | No-op second save after snapshot refresh |
+| `OwnsMany_AddItem_SaveTwice_SecondSaveIsNoOp` | 4 — Content-snapshot + refresh | No-op second save (count-change path) |
+| `OwnsMany_AddAndMutate_BothChangesSaved` | 4 — Content-snapshot | Combined `.Add()` + in-place scalar mutation |

--- a/specs/ownsmanycollection-state-manager-tracking.md
+++ b/specs/ownsmanycollection-state-manager-tracking.md
@@ -1,83 +1,132 @@
-# Spec: Hook OwnsMany Items into EF Core State Manager
+# Spec: OwnsMany State Manager Tracking & Owner Propagation
+
+**Status:** Complete (implementation in rdr-phase4; write-path integration tests pending
+live-server verification)
+
+---
 
 ## Background
 
 `PopulateCollectionNavigations` in `CouchbaseQueryEnumerable.cs` materializes owned
-collection items by calling `Activator.CreateInstance`, setting properties via
-reflection, and assigning the resulting `List<T>` directly to the navigation property.
-The EF Core shaper has already tracked the root entity (e.g. `Customer`) via the state
-manager — but the owned items injected afterward are invisible to it.
+collection items from an embedded JSON column. For change tracking to work correctly,
+each item must be registered with EF Core's state manager so that subsequent additions,
+removals, and scalar mutations are detected by AutoDetectChanges and reflected in the
+`IUpdateEntry` list passed to `SaveChangesAsync`.
 
-## What EF Core does normally
+A secondary problem exists for collection-reference replacement: when the user writes
+`customer.ContactMethods = [ ... ]`, no individual owned item state changes — EF Core
+sees no entries to save and skips the root entity entirely.
 
-In the standard relational provider, owned collection members arrive as JOIN rows and are
-materialized inside the compiled shaper function. The shaper calls
-`IStateManager.GetOrCreateEntry(entity, entityType)` for each owned item and sets its
-state to `Unchanged`, then links it to the owner's `InternalEntityEntry` via the
-navigation fix-up infrastructure. The result is a fully tracked object graph.
+---
 
-## What needs to change
+## Approach: Three cooperating mechanisms
 
-### 1. Change `PopulateCollectionNavigations` from `private static` to an instance method
+### 1. State manager registration via `forMaterialization: true`
 
-It currently takes no context. It needs access to:
+`PopulateCollectionNavigations` adds each owned item to the collection via EF Core's
+`IClrCollectionAccessor.Add(owner, item, forMaterialization: true)`. The
+`forMaterialization: true` flag routes through EF Core's collection accessor
+infrastructure, which:
 
-- `_relationalQueryContext.StateManager` — to create tracking entries
-- `_standAloneStateManager` — to know whether tracking is active
+- Creates an `InternalEntityEntry` for the item and registers it with the state manager.
+- Sets its initial state to `Unchanged`.
+- Takes a property snapshot so that scalar mutations are detectable by AutoDetectChanges.
 
-### 2. Resolve the owner's `InternalEntityEntry`
+With items registered this way, the following mutations are all tracked automatically:
 
-After the shaper yields the root entity, retrieve its entry:
+| Mutation | How EF Core detects it |
+|---|---|
+| `collection.Add(newItem)` | AutoDetectChanges finds the item in the collection but not in the snapshot → `Added` |
+| `collection.Remove(item)` | AutoDetectChanges finds the item in the snapshot but not in the collection → `Deleted` |
+| `item.Property = value` | Snapshot comparison detects property change → `Modified` |
+| OwnsOne scalar mutation | Same snapshot mechanism → owned entity `Modified` |
 
-```csharp
-var ownerEntry = _relationalQueryContext.StateManager.TryGetEntry(entity, _ownerEntityType);
-```
+### 2. Deferred second pass in `CouchbaseDatabaseWrapper.SaveChangesAsync`
 
-If `ownerEntry` is null (no-tracking query), skip state manager registration entirely
-and fall through to the existing assignment path — no-tracking behavior is unchanged.
+`SaveChangesAsync` divides its work into two passes:
 
-### 3. For each owned item, create a tracked entry and set it `Unchanged`
+**First pass** — processes root (non-owned) entities in the normal way (Add/Update/Delete
+via the key/value API). Deleted and written owners are recorded in `writtenRoots`.
 
-```csharp
-var ownedEntry = _relationalQueryContext.StateManager
-    .GetOrCreateEntry(ownedEntity, nav.TargetEntityType);
-ownedEntry.SetEntityState(EntityState.Unchanged, acceptChanges: true);
-```
+**Second pass** — iterates `deferredOwnedEntries` (owned entries with state not
+`Unchanged`/`Detached`):
 
-### 4. Run EF Core's navigation fix-up
+1. Resolves the ownership relationship: `entityType.FindOwnership()`.
+2. Extracts the FK values from the owned entry (these equal the owner's PK).
+3. Calls `StateManager.TryGetEntry(ownership.PrincipalKey, fkValues)` — O(1) lookup of
+   the owner's `InternalEntityEntry`, avoiding a linear `ChangeTracker.Entries()` scan.
+4. Skips owners already in `writtenRoots` (already written or deleted in the first pass).
+5. Calls `HydrateObjectFromEntity(ownerInternalEntry)` to build the full owner document
+   (including the current state of all owned navigations) and upserts it.
 
-After all items are added, trigger fix-up so the state manager's internal navigation
-graph is consistent:
+This handles all four mutation cases in the table above.
 
-```csharp
-ownerEntry.SetRelationshipSnapshotValue(nav, list);
-```
+### 3. Collection-reference replacement via `OwnedCollectionSnapshot` + interceptor
 
-This is closer to what the compiled shaper does and avoids a full `DetectChanges` scan.
-Alternatively, call `_relationalQueryContext.StateManager.Context.ChangeTracker.DetectChanges()`
-but that is more expensive.
+When the user replaces an entire collection reference (`customer.ContactMethods = []`),
+EF Core's change tracker produces no owned-item entries — the old items were removed from
+the collection externally, so they never get `Deleted` state, and the new items were never
+added via a tracked accessor, so they never get `Added` state.
 
-### 5. No-tracking path
+Detection and fix:
 
-When `_standAloneStateManager` is `true` (no-tracking query), `StateManager.TryGetEntry`
-will return null. The method should detect this and skip all state manager calls, keeping
-the existing direct-assignment path as the no-tracking fast path. Both paths end with the
-same `nav.PropertyInfo.SetValue(entity, list)` call.
+- **`OwnedCollectionSnapshot.OriginalRefs`** — a `ConditionalWeakTable<object, Dictionary<string, object?>>` that stores the original collection-object reference for each OwnsMany navigation on every freshly materialised entity. Populated in `CouchbaseQueryEnumerable.SnapshotCollectionRefs` after `PopulateCollectionNavigations` runs.
 
-## Callsite change
+- **`CouchbaseSaveChangesInterceptor.MarkOwnersWithReplacedCollections`** — fires just
+  before `SaveChanges`. Iterates tracked root entities; for each OwnsMany navigation,
+  compares the current property value against the stored reference. If they differ (i.e.
+  the user replaced the collection), marks the owner as `Modified`. This forces EF Core to
+  include the owner in the `entries` list passed to `SaveChangesAsync`, and the main loop
+  writes the updated document (with the new collection contents from
+  `HydrateObjectFromEntity`).
 
-`GetAsyncEnumerator` calls `PopulateCollectionNavigations` in three places — all three
-need to pass the root entity to the instance method so the owner entry can be resolved.
+- **`CouchbaseSaveChangesInterceptor.RefreshOwnedCollectionSnapshots`** — fires after a
+  successful save, updating `OriginalRefs` to the current collection references so
+  subsequent saves do not see a stale mismatch.
 
-## Risk surface
+---
 
-- `IStateManager.GetOrCreateEntry(object, IEntityType)` is internal EF Core API
-  (`Microsoft.EntityFrameworkCore.ChangeTracking.Internal`). It is already used indirectly
-  via `InitializeStateManager` in this file, so the dependency is not new — but it may
-  require `#pragma warning disable EF1001` suppressions.
-- Calling this on a no-tracking context will throw; the null-check on `TryGetEntry` is
-  the guard.
-- Owned entity primary keys in EF Core include a generated shadow property (e.g.
-  `__synthesizedOrdinal`). When creating entries manually, those shadow properties must be
-  set to valid values (typically the zero-based index in the list) or EF Core's key
-  uniqueness check will fail for collections with more than one item.
+## Why this differs from the original spec
+
+The previous version of this spec proposed manually calling
+`IStateManager.GetOrCreateEntry(entity, entityType)`, `SetEntityState(Unchanged,
+acceptChanges: true)`, and `SetRelationshipSnapshotValue(nav, list)` from within
+`PopulateCollectionNavigations`. That approach would have required accessing internal
+EF Core APIs (`#pragma warning disable EF1001`) and replicating logic that
+`IClrCollectionAccessor.Add(owner, item, forMaterialization: true)` already performs.
+
+The `forMaterialization: true` flag is the intended EF Core API for exactly this purpose
+and handles state manager registration, snapshot creation, and navigation fixup
+transparently. The separate `OwnedCollectionSnapshot` mechanism covers the
+collection-reference-replacement edge case that the original spec did not anticipate.
+
+---
+
+## Integration tests
+
+All tests are in `OwnedTypeTests.cs`.
+
+### Read path (all passing)
+- `OwnsOne_InlineAddress_IsPopulated`
+- `OwnsMany_EmbeddedContactMethods_ArePopulated`
+- `OwnsMany_SingleItem_IsPopulated`
+- `Customers_AllHaveAddresses`
+- `OwnsOne_FilterBy_OwnedProperty_ReturnsMatchingCustomer`
+- `OwnsMany_ToListAsync_AllCustomersCollectionsPopulated`
+- `OwnsMany_AsNoTracking_IsPopulated`
+- `OwnsMany_ItemOrderIsPreserved`
+- `OwnsMany_EmptyCollectionDocument_ReadsAsEmpty`
+
+### Write path (mechanisms 2 and 3 above; pending live-server verification)
+
+| Test | Mechanism | Mutation type |
+|---|---|---|
+| `OwnsOne_Update_RoundTrips` | Deferred second pass | OwnsOne scalar |
+| `OwnsOne_NullScalars_RoundTrip` | Deferred second pass | OwnsOne null scalars |
+| `OwnsMany_Update_RoundTrips` | Collection ref replacement | Full collection replacement |
+| `OwnsMany_ClearCollection_RoundTrips` | Collection ref replacement | Empty list assignment |
+| `Customer_Add_WithOwnedTypes_RoundTrips` | Normal Add path | Root entity insert |
+| `Customer_Delete_RemovesDocument` | Normal Delete path | Root entity delete |
+| `OwnsMany_AddSingleItem_RoundTrips` | Deferred second pass | `.Add()` on existing collection |
+| `OwnsMany_RemoveSingleItem_RoundTrips` | Deferred second pass | `.Remove()` from collection |
+| `OwnsMany_MutateItemProperty_RoundTrips` | Deferred second pass | In-place scalar mutation |

--- a/specs/ownsmanycollection-state-manager-tracking.md
+++ b/specs/ownsmanycollection-state-manager-tracking.md
@@ -120,10 +120,14 @@ acceptChanges: true)`, and `SetRelationshipSnapshotValue(nav, list)` from within
 EF Core APIs (`#pragma warning disable EF1001`) and replicating logic that
 `IClrCollectionAccessor.Add(owner, item, forMaterialization: true)` already performs.
 
-The `forMaterialization: true` flag is the intended EF Core API for exactly this purpose
-and handles state manager registration, snapshot creation, and navigation fixup
-transparently. The separate `OwnedCollectionSnapshot` mechanism covers the
-collection-reference-replacement edge case that the original spec did not anticipate.
+The `forMaterialization: true` flag is the intended EF Core API for placing owned items into
+a collection during materialisation; it handles navigation fixup and deduplication
+transparently but is a CLR-only add — it does **not** register owned items with
+`IStateManager`. In-place mutations (`.Add()`, `.Remove()`, scalar property changes) are
+therefore invisible to EF Core's change tracker and require the `OwnedCollectionSnapshot`
+content-snapshot mechanism (mechanism 4) to detect. The `OwnedCollectionSnapshot` reference
+mechanism (mechanism 3) additionally covers the collection-reference-replacement edge case
+that the original spec did not anticipate.
 
 ---
 

--- a/specs/ownsmanycollection-state-manager-tracking.md
+++ b/specs/ownsmanycollection-state-manager-tracking.md
@@ -1,7 +1,7 @@
 # Spec: OwnsMany State Manager Tracking & Owner Propagation
 
-**Status:** Complete (implementation in rdr-phase4; write-path integration tests pending
-live-server verification)
+**Status:** Complete (implementation in rdr-phase4/rdr-phase5; write-path integration tests
+pending live-server verification)
 
 ---
 
@@ -19,27 +19,23 @@ sees no entries to save and skips the root entity entirely.
 
 ---
 
-## Approach: Three cooperating mechanisms
+## Approach: Four cooperating mechanisms
 
 ### 1. State manager registration via `forMaterialization: true`
 
 `PopulateCollectionNavigations` adds each owned item to the collection via EF Core's
 `IClrCollectionAccessor.Add(owner, item, forMaterialization: true)`. The
-`forMaterialization: true` flag routes through EF Core's collection accessor
-infrastructure, which:
+`forMaterialization: true` flag is a pure CLR-level add — it places the item in the
+collection object but **does not** register it with EF Core's `IStateManager`. Items are
+therefore not tracked individually.
 
-- Creates an `InternalEntityEntry` for the item and registers it with the state manager.
-- Sets its initial state to `Unchanged`.
-- Takes a property snapshot so that scalar mutations are detectable by AutoDetectChanges.
+This is sufficient for:
+- Navigation fixup during materialisation
+- Deduplication (the accessor clear before the add loop prevents double-population)
 
-With items registered this way, the following mutations are all tracked automatically:
-
-| Mutation | How EF Core detects it |
-|---|---|
-| `collection.Add(newItem)` | AutoDetectChanges finds the item in the collection but not in the snapshot → `Added` |
-| `collection.Remove(item)` | AutoDetectChanges finds the item in the snapshot but not in the collection → `Deleted` |
-| `item.Property = value` | Snapshot comparison detects property change → `Modified` |
-| OwnsOne scalar mutation | Same snapshot mechanism → owned entity `Modified` |
+OwnsOne scalars **are** tracked individually because EF Core's shaper materialises them as
+owned entity entries in the state manager automatically. In-place OwnsMany mutations
+(.Add, .Remove, scalar mutation) require mechanism 4 below.
 
 ### 2. Deferred second pass in `CouchbaseDatabaseWrapper.SaveChangesAsync`
 
@@ -81,8 +77,37 @@ Detection and fix:
   `HydrateObjectFromEntity`).
 
 - **`CouchbaseSaveChangesInterceptor.RefreshOwnedCollectionSnapshots`** — fires after a
-  successful save, updating `OriginalRefs` to the current collection references so
-  subsequent saves do not see a stale mismatch.
+  successful save, updating both `OriginalRefs` and `OriginalItems` to the current state
+  so subsequent saves do not see stale mismatches.
+
+### 4. In-place OwnsMany mutation via content-snapshot
+
+When the user mutates an existing collection **in place** — `collection.Add(item)`,
+`collection.Remove(item)`, or `item.Property = value` — the collection object reference
+does not change. Mechanism 3's `ReferenceEquals` check passes, and EF Core's change
+tracker does not see any owned-item state changes (because items are not individually
+tracked — see mechanism 1). Without additional detection, `SaveChangesAsync` would skip
+the owner entirely and the mutation would be lost.
+
+Detection and fix:
+
+- **`OwnedCollectionSnapshot.OriginalItems`** — a
+  `ConditionalWeakTable<object, Dictionary<string, IReadOnlyList<Dictionary<string, object?>>>>`
+  that stores an ordered snapshot of per-item property values for every OwnsMany navigation
+  on a just-materialised entity. Populated alongside `OriginalRefs` in
+  `CouchbaseQueryEnumerable.SnapshotCollectionRefs`.
+
+- **`CouchbaseSaveChangesInterceptor.HasCollectionChanged`** — compares the current
+  collection to the stored snapshot. Returns `true` if:
+  - Item count differs (`.Add()` or `.Remove()`).
+  - Any item's property value differs from the snapshot (in-place scalar mutation).
+
+- `MarkOwnersWithReplacedCollections` calls `HasCollectionChanged` when the reference
+  comparison passes. A detected content change marks the owner as `Modified` so EF Core
+  includes it in the entries list and the document is rewritten.
+
+- **`RefreshOwnedCollectionSnapshots`** also updates `OriginalItems` after a successful
+  save so the snapshot stays in sync with the committed state.
 
 ---
 
@@ -117,16 +142,16 @@ All tests are in `OwnedTypeTests.cs`.
 - `OwnsMany_ItemOrderIsPreserved`
 - `OwnsMany_EmptyCollectionDocument_ReadsAsEmpty`
 
-### Write path (mechanisms 2 and 3 above; pending live-server verification)
+### Write path (mechanisms 2–4 above; pending live-server verification)
 
 | Test | Mechanism | Mutation type |
 |---|---|---|
-| `OwnsOne_Update_RoundTrips` | Deferred second pass | OwnsOne scalar |
-| `OwnsOne_NullScalars_RoundTrip` | Deferred second pass | OwnsOne null scalars |
-| `OwnsMany_Update_RoundTrips` | Collection ref replacement | Full collection replacement |
-| `OwnsMany_ClearCollection_RoundTrips` | Collection ref replacement | Empty list assignment |
+| `OwnsOne_Update_RoundTrips` | 2 — Deferred second pass | OwnsOne scalar |
+| `OwnsOne_NullScalars_RoundTrip` | 2 — Deferred second pass | OwnsOne null scalars |
+| `OwnsMany_Update_RoundTrips` | 3 — Collection ref replacement | Full collection replacement |
+| `OwnsMany_ClearCollection_RoundTrips` | 3 — Collection ref replacement | Empty list assignment |
 | `Customer_Add_WithOwnedTypes_RoundTrips` | Normal Add path | Root entity insert |
 | `Customer_Delete_RemovesDocument` | Normal Delete path | Root entity delete |
-| `OwnsMany_AddSingleItem_RoundTrips` | Deferred second pass | `.Add()` on existing collection |
-| `OwnsMany_RemoveSingleItem_RoundTrips` | Deferred second pass | `.Remove()` from collection |
-| `OwnsMany_MutateItemProperty_RoundTrips` | Deferred second pass | In-place scalar mutation |
+| `OwnsMany_AddSingleItem_RoundTrips` | 4 — Content-snapshot (count change) | `.Add()` on existing collection |
+| `OwnsMany_RemoveSingleItem_RoundTrips` | 4 — Content-snapshot (count change) | `.Remove()` from collection |
+| `OwnsMany_MutateItemProperty_RoundTrips` | 4 — Content-snapshot (value change) | In-place scalar mutation |

--- a/specs/ownsmanycollection-state-manager-tracking.md
+++ b/specs/ownsmanycollection-state-manager-tracking.md
@@ -8,14 +8,16 @@ on live server)
 ## Background
 
 `PopulateCollectionNavigations` in `CouchbaseQueryEnumerable.cs` materializes owned
-collection items from an embedded JSON column. For change tracking to work correctly,
-each item must be registered with EF Core's state manager so that subsequent additions,
-removals, and scalar mutations are detected by AutoDetectChanges and reflected in the
-`IUpdateEntry` list passed to `SaveChangesAsync`.
+collection items from an embedded JSON column. Because Couchbase stores owned collections
+as embedded JSON in the owner document, the goal is to detect any change to the owner
+document — whether that change comes from adding or removing items, mutating a scalar
+property on an existing item, or replacing the collection reference entirely — and ensure
+`SaveChangesAsync` rewrites the owner document to reflect the new state.
 
-A secondary problem exists for collection-reference replacement: when the user writes
-`customer.ContactMethods = [ ... ]`, no individual owned item state changes — EF Core
-sees no entries to save and skips the root entity entirely.
+OwnsMany items are not individually registered with EF Core's state manager (see
+mechanism 1), so AutoDetectChanges cannot observe them. The mechanisms below work
+around this by detecting changes at the owner level and marking the owner as `Modified`
+so it is included in the `IUpdateEntry` list passed to `SaveChangesAsync`.
 
 ---
 

--- a/src/Couchbase.EntityFrameworkCore/Query/Internal/CouchbaseQueryEnumerable.cs
+++ b/src/Couchbase.EntityFrameworkCore/Query/Internal/CouchbaseQueryEnumerable.cs
@@ -311,7 +311,7 @@ public class CouchbaseQueryEnumerable<T> : IEnumerable<T>, IAsyncEnumerable<T>, 
                         // Use EF Core's ValueComparer.Snapshot so mutable reference types
                         // (e.g. byte[]) are deep-copied. For immutable types (string, int, …)
                         // Snapshot is a no-op that returns the same reference.
-                        propSnapshot[prop.Name] = raw is null ? null : prop.GetValueComparer().Snapshot(raw);
+                        propSnapshot[prop.Name] = raw is null ? null : OwnedCollectionSnapshot.GetComparer(prop).Snapshot(raw);
                     }
                     snapshot.Add(propSnapshot);
                 }

--- a/src/Couchbase.EntityFrameworkCore/Query/Internal/CouchbaseQueryEnumerable.cs
+++ b/src/Couchbase.EntityFrameworkCore/Query/Internal/CouchbaseQueryEnumerable.cs
@@ -299,13 +299,7 @@ public class CouchbaseQueryEnumerable<T> : IEnumerable<T>, IAsyncEnumerable<T>, 
                     if (item == null) continue;
                     var propSnapshot = new Dictionary<string, object?>();
                     foreach (var prop in itemProps)
-                    {
-                        var raw = prop.PropertyInfo?.GetValue(item);
-                        // Use EF Core's ValueComparer.Snapshot so mutable reference types
-                        // (e.g. byte[]) are deep-copied. For immutable types (string, int, …)
-                        // Snapshot is a no-op that returns the same reference.
-                        propSnapshot[prop.Name] = raw is null ? null : prop.GetValueComparer().Snapshot(raw);
-                    }
+                        propSnapshot[prop.Name] = prop.PropertyInfo?.GetValue(item);
                     snapshot.Add(propSnapshot);
                 }
                 items[nav.Name] = snapshot;

--- a/src/Couchbase.EntityFrameworkCore/Query/Internal/CouchbaseQueryEnumerable.cs
+++ b/src/Couchbase.EntityFrameworkCore/Query/Internal/CouchbaseQueryEnumerable.cs
@@ -243,8 +243,7 @@ public class CouchbaseQueryEnumerable<T> : IEnumerable<T>, IAsyncEnumerable<T>, 
 
             var accessor = nav.GetCollectionAccessor();
             var clrType = nav.TargetEntityType.ClrType;
-            var properties = nav.TargetEntityType.GetProperties()
-                .Where(p => !p.IsShadowProperty()).ToList();
+            var properties = OwnedCollectionSnapshot.GetTrackedProperties(nav);
 
             if (accessor != null)
             {
@@ -300,9 +299,7 @@ public class CouchbaseQueryEnumerable<T> : IEnumerable<T>, IAsyncEnumerable<T>, 
             // when the list reference is unchanged.
             if (currentCollection is IEnumerable collection)
             {
-                var itemProps = nav.TargetEntityType.GetProperties()
-                    .Where(p => !p.IsShadowProperty())
-                    .ToList();
+                var itemProps = OwnedCollectionSnapshot.GetTrackedProperties(nav);
                 var snapshot = new List<Dictionary<string, object?>>();
                 foreach (var item in collection)
                 {

--- a/src/Couchbase.EntityFrameworkCore/Query/Internal/CouchbaseQueryEnumerable.cs
+++ b/src/Couchbase.EntityFrameworkCore/Query/Internal/CouchbaseQueryEnumerable.cs
@@ -299,7 +299,13 @@ public class CouchbaseQueryEnumerable<T> : IEnumerable<T>, IAsyncEnumerable<T>, 
                     if (item == null) continue;
                     var propSnapshot = new Dictionary<string, object?>();
                     foreach (var prop in itemProps)
-                        propSnapshot[prop.Name] = prop.PropertyInfo?.GetValue(item);
+                    {
+                        var raw = prop.PropertyInfo?.GetValue(item);
+                        // Use EF Core's ValueComparer.Snapshot so mutable reference types
+                        // (e.g. byte[]) are deep-copied. For immutable types (string, int, …)
+                        // Snapshot is a no-op that returns the same reference.
+                        propSnapshot[prop.Name] = raw is null ? null : prop.GetValueComparer().Snapshot(raw);
+                    }
                     snapshot.Add(propSnapshot);
                 }
                 items[nav.Name] = snapshot;

--- a/src/Couchbase.EntityFrameworkCore/Query/Internal/CouchbaseQueryEnumerable.cs
+++ b/src/Couchbase.EntityFrameworkCore/Query/Internal/CouchbaseQueryEnumerable.cs
@@ -30,6 +30,7 @@ public static class CouchbaseQueryEnumerable
         Func<QueryContext, DbDataReader, ResultContext, SingleQueryResultCoordinator, T> shaper,
         Type contextType,
         bool standAloneStateManager,
+        bool isTracking,
         bool detailedErrorsEnabled,
         bool threadSafetyChecksEnabled,
         IBucketProvider bucketProvider,
@@ -42,6 +43,7 @@ public static class CouchbaseQueryEnumerable
             shaper,
             contextType,
             standAloneStateManager,
+            isTracking,
             detailedErrorsEnabled,
             threadSafetyChecksEnabled,
             bucketProvider,
@@ -53,6 +55,9 @@ public class CouchbaseQueryEnumerable<T> : IEnumerable<T>, IAsyncEnumerable<T>, 
     private readonly bool _threadSafetyChecksEnabled;
     private readonly bool _detailedErrorsEnabled;
     private readonly bool _standAloneStateManager;
+    // True only for QueryTrackingBehavior.TrackAll — the only mode where SnapshotCollectionRefs
+    // produces a snapshot that the interceptor can ever consume via ChangeTracker.Entries().
+    private readonly bool _isTracking;
     private readonly IDiagnosticsLogger<DbLoggerCategory.Query> _queryLogger;
     private readonly Type _contextType;
     private readonly Func<QueryContext, DbDataReader, ResultContext, SingleQueryResultCoordinator, T> _shaper;
@@ -75,6 +80,7 @@ public class CouchbaseQueryEnumerable<T> : IEnumerable<T>, IAsyncEnumerable<T>, 
         Func<QueryContext, DbDataReader, ResultContext, SingleQueryResultCoordinator, T> shaper,
         Type contextType,
         bool standAloneStateManager,
+        bool isTracking,
         bool detailedErrorsEnabled,
         bool threadSafetyChecksEnabled,
         IBucketProvider bucketProvider,
@@ -88,6 +94,7 @@ public class CouchbaseQueryEnumerable<T> : IEnumerable<T>, IAsyncEnumerable<T>, 
         _contextType = contextType;
         _queryLogger = relationalQueryContext.QueryLogger;
         _standAloneStateManager = standAloneStateManager;
+        _isTracking = isTracking;
         _detailedErrorsEnabled = detailedErrorsEnabled;
         _threadSafetyChecksEnabled = threadSafetyChecksEnabled;
         _couchbaseDbContextOptionsBuilder = couchbaseDbContextOptionsBuilder;
@@ -278,7 +285,10 @@ public class CouchbaseQueryEnumerable<T> : IEnumerable<T>, IAsyncEnumerable<T>, 
     // Both are checked in MarkOwnersWithReplacedCollections before SaveChanges.
     private void SnapshotCollectionRefs(T? entity)
     {
-        if (entity == null) return;
+        // Skip entirely for non-tracking queries: the interceptor walks ChangeTracker.Entries(),
+        // so snapshots built for NoTracking / NoTrackingWithIdentityResolution entities are
+        // never consumed and would be immediately GC'd.
+        if (entity == null || !_isTracking) return;
         var refs  = OwnedCollectionSnapshot.OriginalRefs.GetOrCreateValue(entity);
         var items = OwnedCollectionSnapshot.OriginalItems.GetOrCreateValue(entity);
         foreach (var nav in _ownedCollectionNavigations)

--- a/src/Couchbase.EntityFrameworkCore/Query/Internal/CouchbaseQueryEnumerable.cs
+++ b/src/Couchbase.EntityFrameworkCore/Query/Internal/CouchbaseQueryEnumerable.cs
@@ -270,16 +270,45 @@ public class CouchbaseQueryEnumerable<T> : IEnumerable<T>, IAsyncEnumerable<T>, 
         }
     }
 
-    // Record the original collection-object reference for every OwnsMany navigation on
-    // the freshly materialised entity. The save path later compares the current reference
-    // to the stored one; a mismatch (e.g. customer.ContactMethods = []) means the owner
-    // document must be rewritten even when EF Core produced no owned-item change entries.
+    // Record the original collection-object reference and per-item property values for every
+    // OwnsMany navigation on the freshly materialised entity.
+    //
+    // OriginalRefs detects reference replacement (customer.ContactMethods = []).
+    // OriginalItems detects in-place changes: .Add(), .Remove(), or scalar property mutation.
+    // Both are checked in MarkOwnersWithReplacedCollections before SaveChanges.
     private void SnapshotCollectionRefs(T? entity)
     {
         if (entity == null) return;
-        var refs = OwnedCollectionSnapshot.OriginalRefs.GetOrCreateValue(entity);
+        var refs  = OwnedCollectionSnapshot.OriginalRefs.GetOrCreateValue(entity);
+        var items = OwnedCollectionSnapshot.OriginalItems.GetOrCreateValue(entity);
         foreach (var nav in _ownedCollectionNavigations)
-            refs[nav.Name] = nav.PropertyInfo?.GetValue(entity);
+        {
+            var currentCollection = nav.PropertyInfo?.GetValue(entity);
+            refs[nav.Name] = currentCollection;
+
+            // Snapshot per-item property values so in-place mutations can be detected even
+            // when the list reference is unchanged.
+            if (currentCollection is IEnumerable collection)
+            {
+                var itemProps = nav.TargetEntityType.GetProperties()
+                    .Where(p => !p.IsShadowProperty())
+                    .ToList();
+                var snapshot = new List<Dictionary<string, object?>>();
+                foreach (var item in collection)
+                {
+                    if (item == null) continue;
+                    var propSnapshot = new Dictionary<string, object?>();
+                    foreach (var prop in itemProps)
+                        propSnapshot[prop.Name] = prop.PropertyInfo?.GetValue(item);
+                    snapshot.Add(propSnapshot);
+                }
+                items[nav.Name] = snapshot;
+            }
+            else
+            {
+                items[nav.Name] = [];
+            }
+        }
     }
 
 

--- a/src/Couchbase.EntityFrameworkCore/Query/Internal/CouchbaseShapedQueryCompilingExpressionVisitor.cs
+++ b/src/Couchbase.EntityFrameworkCore/Query/Internal/CouchbaseShapedQueryCompilingExpressionVisitor.cs
@@ -257,6 +257,7 @@ public class CouchbaseShapedQueryCompilingExpressionVisitor : RelationalShapedQu
                 shaper,
                 Expression.Constant(_contextType),
                 Expression.Constant(QueryCompilationContext.QueryTrackingBehavior == QueryTrackingBehavior.NoTrackingWithIdentityResolution),
+                Expression.Constant(QueryCompilationContext.QueryTrackingBehavior == QueryTrackingBehavior.TrackAll),
                 Expression.Constant(_detailedErrorsEnabled),
                 Expression.Constant(_threadSafetyChecksEnabled),
                 Expression.Constant(_bucketProvider),

--- a/src/Couchbase.EntityFrameworkCore/Query/Internal/OwnedCollectionSnapshot.cs
+++ b/src/Couchbase.EntityFrameworkCore/Query/Internal/OwnedCollectionSnapshot.cs
@@ -1,4 +1,6 @@
+using System.Collections.Concurrent;
 using System.Runtime.CompilerServices;
+using Microsoft.EntityFrameworkCore.Metadata;
 
 namespace Couchbase.EntityFrameworkCore.Query.Internal;
 
@@ -17,6 +19,17 @@ internal static class OwnedCollectionSnapshot
 
     // nav.Name → ordered list of per-item property value dictionaries (prop.Name → value)
     internal static readonly ConditionalWeakTable<object, Dictionary<string, IReadOnlyList<Dictionary<string, object?>>>> OriginalItems = new();
+
+    // EF Core model metadata is immutable after OnModelCreating completes. Cache the
+    // non-shadow property list per navigation so it is computed at most once per navigation
+    // for the process lifetime, rather than on every materialisation and every SaveChanges.
+    private static readonly ConcurrentDictionary<INavigation, IReadOnlyList<IProperty>> _trackedPropsCache = new();
+
+    internal static IReadOnlyList<IProperty> GetTrackedProperties(INavigation nav)
+        => _trackedPropsCache.GetOrAdd(nav, static n =>
+            n.TargetEntityType.GetProperties()
+                .Where(p => !p.IsShadowProperty())
+                .ToArray());
 }
 
 

--- a/src/Couchbase.EntityFrameworkCore/Query/Internal/OwnedCollectionSnapshot.cs
+++ b/src/Couchbase.EntityFrameworkCore/Query/Internal/OwnedCollectionSnapshot.cs
@@ -2,16 +2,21 @@ using System.Runtime.CompilerServices;
 
 namespace Couchbase.EntityFrameworkCore.Query.Internal;
 
-// Stores the original collection-object reference for each OwnsMany navigation on a just-
-// materialised entity. The database wrapper's save path compares the current reference to the
-// stored one: if they differ the owner document must be rewritten even when EF Core's own
-// change tracker produced no owned-item entries (e.g. customer.ContactMethods = []).
+// Stores the original collection-object reference and per-item property value snapshots for
+// every OwnsMany navigation on a just-materialised entity.
+//
+// OriginalRefs — detects reference replacement (customer.ContactMethods = []).
+// OriginalItems — detects in-place content changes: Add, Remove, or scalar mutation.
 //
 // ConditionalWeakTable uses weak keys so entities that fall out of scope are GC'd without any
 // manual cleanup.
 internal static class OwnedCollectionSnapshot
 {
+    // nav.Name → original collection object reference
     internal static readonly ConditionalWeakTable<object, Dictionary<string, object?>> OriginalRefs = new();
+
+    // nav.Name → ordered list of per-item property value dictionaries (prop.Name → value)
+    internal static readonly ConditionalWeakTable<object, Dictionary<string, IReadOnlyList<Dictionary<string, object?>>>> OriginalItems = new();
 }
 
 

--- a/src/Couchbase.EntityFrameworkCore/Query/Internal/OwnedCollectionSnapshot.cs
+++ b/src/Couchbase.EntityFrameworkCore/Query/Internal/OwnedCollectionSnapshot.cs
@@ -1,5 +1,6 @@
 using System.Collections.Concurrent;
 using System.Runtime.CompilerServices;
+using Microsoft.EntityFrameworkCore.ChangeTracking;
 using Microsoft.EntityFrameworkCore.Metadata;
 
 namespace Couchbase.EntityFrameworkCore.Query.Internal;
@@ -30,6 +31,17 @@ internal static class OwnedCollectionSnapshot
             n.TargetEntityType.GetProperties()
                 .Where(p => !p.IsShadowProperty())
                 .ToArray());
+
+    // IProperty.GetValueComparer() can return null when no custom comparer is configured.
+    // Fall back through the type-mapping comparer then ValueComparer.CreateDefault so callers
+    // always receive a non-null comparer. Cached per property — metadata is immutable.
+    private static readonly ConcurrentDictionary<IProperty, ValueComparer> _comparerCache = new();
+
+    internal static ValueComparer GetComparer(IProperty prop)
+        => _comparerCache.GetOrAdd(prop, static p =>
+            p.GetValueComparer()
+                ?? p.FindTypeMapping()?.Comparer
+                ?? ValueComparer.CreateDefault(p.ClrType, favorStructuralComparisons: false));
 }
 
 

--- a/src/Couchbase.EntityFrameworkCore/Storage/Internal/CouchbaseConnection.cs
+++ b/src/Couchbase.EntityFrameworkCore/Storage/Internal/CouchbaseConnection.cs
@@ -1,6 +1,7 @@
 using System.Data;
 using System.Data.Common;
 using Couchbase.EntityFrameworkCore.Infrastructure;
+using Couchbase.EntityFrameworkCore.Internal;
 using Couchbase.Extensions.DependencyInjection;
 using Couchbase.KeyValue;
 using Microsoft.Extensions.Logging;
@@ -150,7 +151,7 @@ public class CouchbaseConnection : DbConnection
 
     public override void Open()
     {
-        OpenAsync(CancellationToken.None).GetAwaiter().GetResult();
+        AsyncHelper.RunSync(static self => self.OpenAsync(CancellationToken.None), this);
     }
 
     public override async Task OpenAsync(CancellationToken cancellationToken)

--- a/src/Couchbase.EntityFrameworkCore/Storage/Internal/CouchbaseDatabaseWrapper.cs
+++ b/src/Couchbase.EntityFrameworkCore/Storage/Internal/CouchbaseDatabaseWrapper.cs
@@ -2,6 +2,7 @@ using System.Collections;
 using System.Text.Json;
 using Couchbase.EntityFrameworkCore.Extensions;
 using Couchbase.EntityFrameworkCore.Infrastructure;
+using Couchbase.EntityFrameworkCore.Internal;
 using Couchbase.EntityFrameworkCore.Utils;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.ChangeTracking.Internal;
@@ -33,7 +34,9 @@ public class CouchbaseDatabaseWrapper : Database
     public override int SaveChanges(IList<IUpdateEntry> entries)
     {
 #if DEBUG
-        return SaveChangesAsync(entries).ConfigureAwait(false).GetAwaiter().GetResult();
+        return AsyncHelper.RunSync(
+            static state => state.self.SaveChangesAsync(state.entries),
+            (self: this, entries));
 #else
         throw ExceptionHelper.SyncroIONotSupportedException();
 #endif

--- a/src/Couchbase.EntityFrameworkCore/Storage/Internal/CouchbaseDbDataReader.cs
+++ b/src/Couchbase.EntityFrameworkCore/Storage/Internal/CouchbaseDbDataReader.cs
@@ -3,6 +3,7 @@ using System.Data;
 using System.Data.Common;
 using System.Text.Json;
 using Couchbase.EntityFrameworkCore.Extensions;
+using Couchbase.EntityFrameworkCore.Internal;
 using Couchbase.Query;
 
 namespace Couchbase.EntityFrameworkCore.Storage.Internal;
@@ -217,10 +218,8 @@ public class CouchbaseDbDataReader<T> : DbDataReader
     /// <summary>
     /// Advances the reader to the next row synchronously.
     /// </summary>
-    public override bool Read()
-    {
-        return ReadAsync(CancellationToken.None).GetAwaiter().GetResult();
-    }
+    public override bool Read() =>
+        AsyncHelper.RunSync(static self => self.ReadAsync(CancellationToken.None), this);
 
     /// <summary>
     /// Asynchronously advances the reader to the next row.
@@ -429,8 +428,12 @@ public class CouchbaseDbDataReader<T> : DbDataReader
         if (!_isClosed)
         {
             _isClosed = true;
-            _enumerator?.DisposeAsync().AsTask().GetAwaiter().GetResult();
-            _queryResult.Dispose();
+            if (_enumerator != null)
+                AsyncHelper.RunSync(static e => e.DisposeAsync().AsTask(), _enumerator);
+            if (_queryResult is IAsyncDisposable asyncDisposable)
+                AsyncHelper.RunSync(static d => d.DisposeAsync().AsTask(), asyncDisposable);
+            else
+                _queryResult.Dispose();
             _linkedCts?.Dispose();
             _linkedCts = null;
 

--- a/src/Couchbase.EntityFrameworkCore/Storage/Internal/CouchbaseDbDataReader.cs
+++ b/src/Couchbase.EntityFrameworkCore/Storage/Internal/CouchbaseDbDataReader.cs
@@ -254,14 +254,18 @@ public class CouchbaseDbDataReader<T> : DbDataReader
             _currentRow = ValidateRow(_enumerator.Current);
             _hasCurrentRow = true;
             _hasRows ??= true;
+            BuildCurrentValues();
         }
         else
         {
             _currentRow = default;
             _hasCurrentRow = false;
             _hasRows ??= false;
+            // BuildCurrentValues is not called: _currentValues retains stale data from the
+            // last row, but EnsureCurrentRow() guards every read path and throws before any
+            // caller can observe those slots.  Skipping the call avoids a redundant
+            // Array.Clear on end-of-stream.
         }
-        BuildCurrentValues();
 
         return hasMore;
     }

--- a/src/Couchbase.EntityFrameworkCore/Storage/Internal/CouchbaseSaveChangesInterceptor.cs
+++ b/src/Couchbase.EntityFrameworkCore/Storage/Internal/CouchbaseSaveChangesInterceptor.cs
@@ -1,3 +1,4 @@
+using System.Collections;
 using System.Runtime.CompilerServices;
 using Couchbase.EntityFrameworkCore.Query.Internal;
 using Couchbase.EntityFrameworkCore.ValueGeneration;
@@ -212,9 +213,10 @@ public class CouchbaseSaveChangesInterceptor : SaveChangesInterceptor
         return base.SavedChanges(eventData, result);
     }
 
-    // For each tracked Unchanged/Detached root entity whose OwnsMany collection reference
-    // was replaced (e.g. customer.ContactMethods = []), mark it as Modified so EF Core
-    // includes it in GetEntriesToSave and our SaveChangesAsync is not skipped entirely.
+    // For each tracked Unchanged/Detached root entity whose OwnsMany collection has changed
+    // (reference replaced, items added/removed, or item property mutated), mark it as Modified
+    // so EF Core includes it in GetEntriesToSave and our SaveChangesAsync rewrites the document.
+    //
     // GenerateSequenceValuesAsync (called just before this) already triggered DetectChanges,
     // so we disable AutoDetectChanges here to avoid a redundant second pass.
     private static void MarkOwnersWithReplacedCollections(DbContext context)
@@ -231,14 +233,31 @@ public class CouchbaseSaveChangesInterceptor : SaveChangesInterceptor
                 var owner = entry.Entity;
                 if (!OwnedCollectionSnapshot.OriginalRefs.TryGetValue(owner, out var origRefs)) continue;
 
+                OwnedCollectionSnapshot.OriginalItems.TryGetValue(owner, out var origItems);
+
                 foreach (var nav in entry.Metadata.GetNavigations()
                              .Where(n => n.TargetEntityType.IsOwned() && n.IsCollection && n.PropertyInfo != null))
                 {
                     if (!origRefs.TryGetValue(nav.Name, out var origRef)) continue;
-                    if (ReferenceEquals(origRef, nav.PropertyInfo!.GetValue(owner))) continue;
 
-                    entry.State = EntityState.Modified;
-                    break;
+                    var current = nav.PropertyInfo!.GetValue(owner);
+
+                    // Reference replaced (e.g. customer.ContactMethods = [])
+                    if (!ReferenceEquals(origRef, current))
+                    {
+                        entry.State = EntityState.Modified;
+                        break;
+                    }
+
+                    // Same reference — check item count and property values for in-place changes
+                    // (.Add(), .Remove(), or scalar mutation on an existing item).
+                    if (origItems != null
+                        && origItems.TryGetValue(nav.Name, out var origItemSnapshots)
+                        && HasCollectionChanged(current, nav, origItemSnapshots))
+                    {
+                        entry.State = EntityState.Modified;
+                        break;
+                    }
                 }
             }
         }
@@ -248,8 +267,42 @@ public class CouchbaseSaveChangesInterceptor : SaveChangesInterceptor
         }
     }
 
-    // After a successful save, update OwnedCollectionSnapshot with current collection
-    // references so subsequent SaveChanges won't see a stale mismatch.
+    // Returns true when the current collection differs from the original item-value snapshot:
+    // count changed (Add / Remove) or any scalar property value changed (mutation).
+    private static bool HasCollectionChanged(
+        object? current,
+        INavigation nav,
+        IReadOnlyList<Dictionary<string, object?>> origItemSnapshots)
+    {
+        if (current is not IEnumerable collection) return false;
+
+        var itemProps = nav.TargetEntityType.GetProperties()
+            .Where(p => !p.IsShadowProperty())
+            .ToList();
+
+        var currentItems = new List<object>();
+        foreach (var item in collection)
+            if (item != null) currentItems.Add(item);
+
+        if (currentItems.Count != origItemSnapshots.Count) return true;
+
+        for (var i = 0; i < currentItems.Count; i++)
+        {
+            var origSnapshot = origItemSnapshots[i];
+            foreach (var prop in itemProps)
+            {
+                var currentValue = prop.PropertyInfo?.GetValue(currentItems[i]);
+                if (!origSnapshot.TryGetValue(prop.Name, out var origValue)) return true;
+                if (!Equals(currentValue, origValue)) return true;
+            }
+        }
+
+        return false;
+    }
+
+    // After a successful save, update OwnedCollectionSnapshot with the current collection
+    // reference AND current item property values so subsequent SaveChanges calls won't see
+    // a stale mismatch from the just-written state.
     private static void RefreshOwnedCollectionSnapshots(DbContext context)
     {
         foreach (var entry in context.ChangeTracker.Entries())
@@ -260,10 +313,35 @@ public class CouchbaseSaveChangesInterceptor : SaveChangesInterceptor
             var owner = entry.Entity;
             if (!OwnedCollectionSnapshot.OriginalRefs.TryGetValue(owner, out var refs)) continue;
 
+            var itemsTable = OwnedCollectionSnapshot.OriginalItems.GetOrCreateValue(owner);
+
             foreach (var nav in entry.Metadata.GetNavigations()
                          .Where(n => n.TargetEntityType.IsOwned() && n.IsCollection && n.PropertyInfo != null))
             {
-                refs[nav.Name] = nav.PropertyInfo!.GetValue(owner);
+                var current = nav.PropertyInfo!.GetValue(owner);
+                refs[nav.Name] = current;
+
+                // Refresh item-level snapshots so subsequent saves detect mutations correctly.
+                if (current is IEnumerable collection)
+                {
+                    var itemProps = nav.TargetEntityType.GetProperties()
+                        .Where(p => !p.IsShadowProperty())
+                        .ToList();
+                    var snapshot = new List<Dictionary<string, object?>>();
+                    foreach (var item in collection)
+                    {
+                        if (item == null) continue;
+                        var propSnapshot = new Dictionary<string, object?>();
+                        foreach (var prop in itemProps)
+                            propSnapshot[prop.Name] = prop.PropertyInfo?.GetValue(item);
+                        snapshot.Add(propSnapshot);
+                    }
+                    itemsTable[nav.Name] = snapshot;
+                }
+                else
+                {
+                    itemsTable[nav.Name] = [];
+                }
             }
         }
     }

--- a/src/Couchbase.EntityFrameworkCore/Storage/Internal/CouchbaseSaveChangesInterceptor.cs
+++ b/src/Couchbase.EntityFrameworkCore/Storage/Internal/CouchbaseSaveChangesInterceptor.cs
@@ -291,7 +291,7 @@ public class CouchbaseSaveChangesInterceptor : SaveChangesInterceptor
             {
                 var currentValue = prop.PropertyInfo?.GetValue(currentItems[i]);
                 if (!origSnapshot.TryGetValue(prop.Name, out var origValue)) return true;
-                if (!prop.GetValueComparer().Equals(currentValue, origValue)) return true;
+                if (!OwnedCollectionSnapshot.GetComparer(prop).Equals(currentValue, origValue)) return true;
             }
         }
 
@@ -334,7 +334,7 @@ public class CouchbaseSaveChangesInterceptor : SaveChangesInterceptor
                             // Use EF Core's ValueComparer.Snapshot so mutable reference types
                             // (e.g. byte[]) are deep-copied. For immutable types (string, int, …)
                             // Snapshot is a no-op that returns the same reference.
-                            propSnapshot[prop.Name] = raw is null ? null : prop.GetValueComparer().Snapshot(raw);
+                            propSnapshot[prop.Name] = raw is null ? null : OwnedCollectionSnapshot.GetComparer(prop).Snapshot(raw);
                         }
                         snapshot.Add(propSnapshot);
                     }

--- a/src/Couchbase.EntityFrameworkCore/Storage/Internal/CouchbaseSaveChangesInterceptor.cs
+++ b/src/Couchbase.EntityFrameworkCore/Storage/Internal/CouchbaseSaveChangesInterceptor.cs
@@ -276,9 +276,7 @@ public class CouchbaseSaveChangesInterceptor : SaveChangesInterceptor
     {
         if (current is not IEnumerable collection) return false;
 
-        var itemProps = nav.TargetEntityType.GetProperties()
-            .Where(p => !p.IsShadowProperty())
-            .ToList();
+        var itemProps = OwnedCollectionSnapshot.GetTrackedProperties(nav);
 
         var currentItems = new List<object>();
         foreach (var item in collection)
@@ -324,9 +322,7 @@ public class CouchbaseSaveChangesInterceptor : SaveChangesInterceptor
                 // Refresh item-level snapshots so subsequent saves detect mutations correctly.
                 if (current is IEnumerable collection)
                 {
-                    var itemProps = nav.TargetEntityType.GetProperties()
-                        .Where(p => !p.IsShadowProperty())
-                        .ToList();
+                    var itemProps = OwnedCollectionSnapshot.GetTrackedProperties(nav);
                     var snapshot = new List<Dictionary<string, object?>>();
                     foreach (var item in collection)
                     {

--- a/src/Couchbase.EntityFrameworkCore/Storage/Internal/CouchbaseSaveChangesInterceptor.cs
+++ b/src/Couchbase.EntityFrameworkCore/Storage/Internal/CouchbaseSaveChangesInterceptor.cs
@@ -293,7 +293,7 @@ public class CouchbaseSaveChangesInterceptor : SaveChangesInterceptor
             {
                 var currentValue = prop.PropertyInfo?.GetValue(currentItems[i]);
                 if (!origSnapshot.TryGetValue(prop.Name, out var origValue)) return true;
-                if (!Equals(currentValue, origValue)) return true;
+                if (!prop.GetValueComparer().Equals(currentValue, origValue)) return true;
             }
         }
 
@@ -333,7 +333,13 @@ public class CouchbaseSaveChangesInterceptor : SaveChangesInterceptor
                         if (item == null) continue;
                         var propSnapshot = new Dictionary<string, object?>();
                         foreach (var prop in itemProps)
-                            propSnapshot[prop.Name] = prop.PropertyInfo?.GetValue(item);
+                        {
+                            var raw = prop.PropertyInfo?.GetValue(item);
+                            // Use EF Core's ValueComparer.Snapshot so mutable reference types
+                            // (e.g. byte[]) are deep-copied. For immutable types (string, int, …)
+                            // Snapshot is a no-op that returns the same reference.
+                            propSnapshot[prop.Name] = raw is null ? null : prop.GetValueComparer().Snapshot(raw);
+                        }
                         snapshot.Add(propSnapshot);
                     }
                     itemsTable[nav.Name] = snapshot;

--- a/src/Couchbase.EntityFrameworkCore/Storage/Internal/CouchbaseSaveChangesInterceptor.cs
+++ b/src/Couchbase.EntityFrameworkCore/Storage/Internal/CouchbaseSaveChangesInterceptor.cs
@@ -333,13 +333,7 @@ public class CouchbaseSaveChangesInterceptor : SaveChangesInterceptor
                         if (item == null) continue;
                         var propSnapshot = new Dictionary<string, object?>();
                         foreach (var prop in itemProps)
-                        {
-                            var raw = prop.PropertyInfo?.GetValue(item);
-                            // Use EF Core's ValueComparer.Snapshot so mutable reference types
-                            // (e.g. byte[]) are deep-copied. For immutable types (string, int, …)
-                            // Snapshot is a no-op that returns the same reference.
-                            propSnapshot[prop.Name] = raw is null ? null : prop.GetValueComparer().Snapshot(raw);
-                        }
+                            propSnapshot[prop.Name] = prop.PropertyInfo?.GetValue(item);
                         snapshot.Add(propSnapshot);
                     }
                     itemsTable[nav.Name] = snapshot;

--- a/src/Couchbase.EntityFrameworkCore/Storage/Internal/CouchbaseSaveChangesInterceptor.cs
+++ b/src/Couchbase.EntityFrameworkCore/Storage/Internal/CouchbaseSaveChangesInterceptor.cs
@@ -333,7 +333,13 @@ public class CouchbaseSaveChangesInterceptor : SaveChangesInterceptor
                         if (item == null) continue;
                         var propSnapshot = new Dictionary<string, object?>();
                         foreach (var prop in itemProps)
-                            propSnapshot[prop.Name] = prop.PropertyInfo?.GetValue(item);
+                        {
+                            var raw = prop.PropertyInfo?.GetValue(item);
+                            // Use EF Core's ValueComparer.Snapshot so mutable reference types
+                            // (e.g. byte[]) are deep-copied. For immutable types (string, int, …)
+                            // Snapshot is a no-op that returns the same reference.
+                            propSnapshot[prop.Name] = raw is null ? null : prop.GetValueComparer().Snapshot(raw);
+                        }
                         snapshot.Add(propSnapshot);
                     }
                     itemsTable[nav.Name] = snapshot;

--- a/tests/Couchbase.EntityFrameworkCore.IntegrationTests/Tests/OwnedTypeTests.cs
+++ b/tests/Couchbase.EntityFrameworkCore.IntegrationTests/Tests/OwnedTypeTests.cs
@@ -364,4 +364,71 @@ public class OwnedTypeTests(
                 cm => cm.Type == "email" && cm.Value == "alice.new@example.com");
         }
     }
+
+    // -------------------------------------------------------------------------
+    // Content-snapshot regression tests
+    // -------------------------------------------------------------------------
+
+    [Fact]
+    public async Task OwnsMany_MutateItemProperty_SaveTwice_SecondSaveIsNoOp()
+    {
+        // After a successful save, RefreshOwnedCollectionSnapshots must update
+        // OriginalItems so that a second SaveChangesAsync on the same context
+        // (with no further mutations) does not falsely detect a change and
+        // trigger a redundant write.
+        await using var ctx = fixture.GetDbContext();
+        var customer = await ctx.Customers.FirstAsync(c => c.CustomerId == 1);
+
+        // First mutation and save
+        customer.ContactMethods.First(cm => cm.Type == "email").Value = "alice.v2@example.com";
+        var firstCount = await ctx.SaveChangesAsync();
+        Assert.Equal(1, firstCount);   // one document written
+
+        // No further mutations — second save must be a no-op
+        var secondCount = await ctx.SaveChangesAsync();
+        Assert.Equal(0, secondCount);  // nothing to write (snapshot was refreshed after save 1)
+    }
+
+    [Fact]
+    public async Task OwnsMany_AddItem_SaveTwice_SecondSaveIsNoOp()
+    {
+        // Same regression check as above but for the .Add() / count-change path.
+        await using var ctx = fixture.GetDbContext();
+        var customer = await ctx.Customers.FirstAsync(c => c.CustomerId == 2);
+
+        customer.ContactMethods.Add(
+            new OwnedTypeFixture.ContactMethod { Id = 2, Type = "fax", Value = "555-0300" });
+        var firstCount = await ctx.SaveChangesAsync();
+        Assert.Equal(1, firstCount);
+
+        var secondCount = await ctx.SaveChangesAsync();
+        Assert.Equal(0, secondCount);
+    }
+
+    [Fact]
+    public async Task OwnsMany_AddAndMutate_BothChangesSaved()
+    {
+        // Add one new item and mutate an existing item's property in the same
+        // SaveChangesAsync call — both changes must appear in the persisted document.
+        await using (var ctx = fixture.GetDbContext())
+        {
+            var customer = await ctx.Customers.FirstAsync(c => c.CustomerId == 2);
+            // Mutate the existing item
+            customer.ContactMethods.First(cm => cm.Type == "email").Value = "bob.updated@example.com";
+            // Add a second item
+            customer.ContactMethods.Add(
+                new OwnedTypeFixture.ContactMethod { Id = 2, Type = "sms", Value = "555-0300" });
+            await ctx.SaveChangesAsync();
+        }
+
+        await using (var ctx = fixture.GetDbContext())
+        {
+            var customer = await ctx.Customers.FirstAsync(c => c.CustomerId == 2);
+            Assert.Equal(2, customer.ContactMethods.Count);
+            Assert.Contains(customer.ContactMethods,
+                cm => cm.Type == "email" && cm.Value == "bob.updated@example.com");
+            Assert.Contains(customer.ContactMethods,
+                cm => cm.Type == "sms"   && cm.Value == "555-0300");
+        }
+    }
 }

--- a/tests/Couchbase.EntityFrameworkCore.IntegrationTests/Tests/OwnedTypeTests.cs
+++ b/tests/Couchbase.EntityFrameworkCore.IntegrationTests/Tests/OwnedTypeTests.cs
@@ -58,8 +58,8 @@ public class OwnedTypeTests(
     public async Task OwnsOne_Update_RoundTrips()
     {
         // Write a new address via SaveChangesAsync and confirm a fresh context reads it back.
-        // The owner must be marked Modified explicitly: EF Core tracks the OwnsOne entity
-        // in its own entry and our provider skips owned entries in the SaveChanges loop.
+        // No manual State = Modified needed: the deferred second pass in SaveChangesAsync
+        // detects the owned-entry state change and writes the owner document automatically.
         await using (var ctx = fixture.GetDbContext())
         {
             var customer = await ctx.Customers.FirstAsync(c => c.CustomerId == 1);

--- a/tests/Couchbase.EntityFrameworkCore.UnitTests/Couchbase/EntityFrameworkCore/Storage/Internal/CouchbaseContentSnapshotTests.cs
+++ b/tests/Couchbase.EntityFrameworkCore.UnitTests/Couchbase/EntityFrameworkCore/Storage/Internal/CouchbaseContentSnapshotTests.cs
@@ -1,0 +1,389 @@
+using System.Reflection;
+using Couchbase.EntityFrameworkCore.Query.Internal;
+using Couchbase.EntityFrameworkCore.Storage.Internal;
+using Microsoft.EntityFrameworkCore.Metadata;
+using Moq;
+using Xunit;
+
+namespace Couchbase.EntityFrameworkCore.UnitTests.Couchbase.EntityFrameworkCore.Storage.Internal;
+
+/// <summary>
+/// Unit tests for the Phase-5 content-snapshot mechanism.
+///
+/// HasCollectionChanged (private static on CouchbaseSaveChangesInterceptor) is the core
+/// detection predicate; it is reached via reflection.  OwnedCollectionSnapshot.OriginalItems
+/// is the ConditionalWeakTable that feeds it at runtime.
+///
+/// Tests are grouped into three regions:
+///   1. HasCollectionChanged — pure logic, no EF Core context.
+///   2. HasCollectionChanged round-trip — snapshot → mutate → detect.
+///   3. OwnedCollectionSnapshot.OriginalItems — table isolation / persistence.
+/// </summary>
+public class CouchbaseContentSnapshotTests
+{
+    // -------------------------------------------------------------------------
+    // CLR types used by all tests — kept deliberately minimal
+    // -------------------------------------------------------------------------
+
+    private class ContactItem
+    {
+        public string? Type  { get; set; }
+        public string? Value { get; set; }
+    }
+
+    // -------------------------------------------------------------------------
+    // Reflection entry-point
+    // -------------------------------------------------------------------------
+
+    private static readonly MethodInfo HasCollectionChangedMethod =
+        typeof(CouchbaseSaveChangesInterceptor)
+            .GetMethod("HasCollectionChanged", BindingFlags.NonPublic | BindingFlags.Static)
+        ?? throw new InvalidOperationException(
+            "HasCollectionChanged not found — was the method renamed or removed?");
+
+    /// <summary>Thin wrapper that mirrors the production signature.</summary>
+    private static bool CallHasCollectionChanged(
+        object? current,
+        INavigation nav,
+        IReadOnlyList<Dictionary<string, object?>> origItemSnapshots)
+        => (bool)HasCollectionChangedMethod.Invoke(null, [current, nav, origItemSnapshots])!;
+
+    // -------------------------------------------------------------------------
+    // Mock INavigation builder
+    // -------------------------------------------------------------------------
+
+    /// <summary>
+    /// Builds a mock INavigation whose TargetEntityType returns two non-shadow
+    /// IProperty instances that mirror <see cref="ContactItem.Type"/> and
+    /// <see cref="ContactItem.Value"/>.
+    ///
+    /// IsShadowProperty() is a static extension that checks property.PropertyInfo == null;
+    /// setting PropertyInfo to a real PropertyInfo makes the filter pass without mocking
+    /// the extension method directly.
+    /// </summary>
+    private static INavigation BuildNav()
+    {
+        var typePropInfo  = typeof(ContactItem).GetProperty(nameof(ContactItem.Type))!;
+        var valuePropInfo = typeof(ContactItem).GetProperty(nameof(ContactItem.Value))!;
+
+        var typeProp = new Mock<IProperty>();
+        typeProp.Setup(p => p.Name).Returns("Type");
+        typeProp.Setup(p => p.PropertyInfo).Returns(typePropInfo);
+
+        var valueProp = new Mock<IProperty>();
+        valueProp.Setup(p => p.Name).Returns("Value");
+        valueProp.Setup(p => p.PropertyInfo).Returns(valuePropInfo);
+
+        var targetType = new Mock<IEntityType>();
+        targetType.Setup(t => t.GetProperties()).Returns([typeProp.Object, valueProp.Object]);
+
+        var nav = new Mock<INavigation>();
+        nav.Setup(n => n.Name).Returns("ContactItems");
+        nav.Setup(n => n.TargetEntityType).Returns(targetType.Object);
+
+        return nav.Object;
+    }
+
+    // -------------------------------------------------------------------------
+    // Helper: build a snapshot list from items (mirrors SnapshotCollectionRefs)
+    // -------------------------------------------------------------------------
+
+    private static List<Dictionary<string, object?>> Snap(IEnumerable<ContactItem> items)
+        => items.Select(item => new Dictionary<string, object?>
+        {
+            ["Type"]  = item.Type,
+            ["Value"] = item.Value
+        }).ToList();
+
+    // =========================================================================
+    // Region 1: HasCollectionChanged — pure detection logic
+    // =========================================================================
+
+    [Fact]
+    public void HasCollectionChanged_NullCurrent_ReturnsFalse()
+    {
+        // Guard clause: current is not IEnumerable → false immediately, no crash.
+        var nav = BuildNav();
+        var orig = Snap([new ContactItem { Type = "email", Value = "a@b.com" }]);
+
+        Assert.False(CallHasCollectionChanged(null, nav, orig));
+    }
+
+    [Fact]
+    public void HasCollectionChanged_NonEnumerableCurrent_ReturnsFalse()
+    {
+        // A scalar value (int) is definitely not IEnumerable.
+        var nav = BuildNav();
+        var orig = Snap([new ContactItem { Type = "email", Value = "a@b.com" }]);
+
+        Assert.False(CallHasCollectionChanged(42, nav, orig));
+    }
+
+    [Fact]
+    public void HasCollectionChanged_BothEmpty_ReturnsFalse()
+    {
+        var nav = BuildNav();
+
+        Assert.False(CallHasCollectionChanged(
+            new List<ContactItem>(),
+            nav,
+            new List<Dictionary<string, object?>>()));
+    }
+
+    [Fact]
+    public void HasCollectionChanged_SameContent_SingleItem_ReturnsFalse()
+    {
+        var nav     = BuildNav();
+        var current = new List<ContactItem>
+            { new() { Type = "email", Value = "alice@example.com" } };
+
+        Assert.False(CallHasCollectionChanged(current, nav, Snap(current)));
+    }
+
+    [Fact]
+    public void HasCollectionChanged_SameContent_MultipleItems_ReturnsFalse()
+    {
+        var nav     = BuildNav();
+        var current = new List<ContactItem>
+        {
+            new() { Type = "email", Value = "alice@example.com" },
+            new() { Type = "phone", Value = "555-0100" }
+        };
+
+        Assert.False(CallHasCollectionChanged(current, nav, Snap(current)));
+    }
+
+    [Fact]
+    public void HasCollectionChanged_BothNull_SameContent_ReturnsFalse()
+    {
+        // null == null should not trigger a change.
+        var nav     = BuildNav();
+        var current = new List<ContactItem> { new() { Type = null, Value = null } };
+
+        Assert.False(CallHasCollectionChanged(current, nav, Snap(current)));
+    }
+
+    [Fact]
+    public void HasCollectionChanged_ItemAdded_ReturnsTrue()
+    {
+        // .Add() on an existing list: count grows from 1 to 2.
+        var nav  = BuildNav();
+        var orig = Snap([new ContactItem { Type = "email", Value = "alice@example.com" }]);
+        var current = new List<ContactItem>
+        {
+            new() { Type = "email", Value = "alice@example.com" },
+            new() { Type = "phone", Value = "555-0100" }           // new item
+        };
+
+        Assert.True(CallHasCollectionChanged(current, nav, orig));
+    }
+
+    [Fact]
+    public void HasCollectionChanged_ItemRemoved_ReturnsTrue()
+    {
+        // .Remove() on an existing list: count shrinks from 2 to 1.
+        var nav = BuildNav();
+        var orig = Snap(
+        [
+            new ContactItem { Type = "email", Value = "alice@example.com" },
+            new ContactItem { Type = "phone", Value = "555-0100" }
+        ]);
+        var current = new List<ContactItem>
+        {
+            new() { Type = "phone", Value = "555-0100" }
+        };
+
+        Assert.True(CallHasCollectionChanged(current, nav, orig));
+    }
+
+    [Fact]
+    public void HasCollectionChanged_PropertyMutated_Value_ReturnsTrue()
+    {
+        // In-place scalar mutation: same count, same Type, different Value.
+        var nav  = BuildNav();
+        var orig = Snap([new ContactItem { Type = "email", Value = "alice@example.com" }]);
+        var current = new List<ContactItem>
+        {
+            new() { Type = "email", Value = "alice.new@example.com" }   // mutated
+        };
+
+        Assert.True(CallHasCollectionChanged(current, nav, orig));
+    }
+
+    [Fact]
+    public void HasCollectionChanged_PropertyMutated_Type_ReturnsTrue()
+    {
+        // Only the first property differs; the second is unchanged.
+        var nav  = BuildNav();
+        var orig = Snap([new ContactItem { Type = "email", Value = "alice@example.com" }]);
+        var current = new List<ContactItem>
+        {
+            new() { Type = "sms", Value = "alice@example.com" }          // Type mutated
+        };
+
+        Assert.True(CallHasCollectionChanged(current, nav, orig));
+    }
+
+    [Fact]
+    public void HasCollectionChanged_NullToNonNull_ReturnsTrue()
+    {
+        // Property was null at load time; user sets it before save.
+        var nav  = BuildNav();
+        var orig = Snap([new ContactItem { Type = null, Value = "alice@example.com" }]);
+        var current = new List<ContactItem>
+        {
+            new() { Type = "email", Value = "alice@example.com" }        // null → "email"
+        };
+
+        Assert.True(CallHasCollectionChanged(current, nav, orig));
+    }
+
+    [Fact]
+    public void HasCollectionChanged_NonNullToNull_ReturnsTrue()
+    {
+        // Property set to null after load.
+        var nav  = BuildNav();
+        var orig = Snap([new ContactItem { Type = "email", Value = "alice@example.com" }]);
+        var current = new List<ContactItem>
+        {
+            new() { Type = null, Value = "alice@example.com" }           // "email" → null
+        };
+
+        Assert.True(CallHasCollectionChanged(current, nav, orig));
+    }
+
+    [Fact]
+    public void HasCollectionChanged_SnapshotMissingProperty_ReturnsTrue()
+    {
+        // If the snapshot dict has no key for a property we conservatively report a
+        // change rather than silently swallowing potential data loss.
+        var nav     = BuildNav(); // expects "Type" and "Value" keys
+        var current = new List<ContactItem>
+            { new() { Type = "email", Value = "a@b.com" } };
+        var orig = new List<Dictionary<string, object?>>
+        {
+            new() { /* intentionally empty — missing both keys */ }
+        };
+
+        Assert.True(CallHasCollectionChanged(current, nav, orig));
+    }
+
+    // =========================================================================
+    // Region 2: Round-trip — snapshot taken, object mutated in-place, detected
+    // =========================================================================
+
+    [Fact]
+    public void RoundTrip_SnapshotTaken_ThenPropertyMutated_Detected()
+    {
+        // Simulates the full lifecycle:
+        //   (a) Snapshot taken at load time — item.Value = "alice@example.com"
+        //   (b) User mutates item.Value in-place (same object, same list reference)
+        //   (c) HasCollectionChanged detects the change
+        var nav  = BuildNav();
+        var item = new ContactItem { Type = "email", Value = "alice@example.com" };
+        var current = new List<ContactItem> { item };
+        var orig = Snap(current);   // snapshot taken at load time with old value
+
+        // Simulate in-place mutation (same object, same list)
+        item.Value = "alice.mutated@example.com";
+
+        Assert.True(CallHasCollectionChanged(current, nav, orig));
+    }
+
+    [Fact]
+    public void RoundTrip_SnapshotTaken_NoMutation_NotDetected()
+    {
+        // After a snapshot is taken, calling HasCollectionChanged on unchanged data
+        // must return false — no spurious dirty detection.
+        var nav     = BuildNav();
+        var current = new List<ContactItem>
+        {
+            new() { Type = "email", Value = "alice@example.com" },
+            new() { Type = "phone", Value = "555-0100" }
+        };
+        var orig = Snap(current);   // snapshot taken; nothing changes
+
+        Assert.False(CallHasCollectionChanged(current, nav, orig));
+    }
+
+    [Fact]
+    public void RoundTrip_SnapshotTaken_ItemAdded_Detected()
+    {
+        // .Add() path: snapshot has 1 item, collection now has 2.
+        var nav  = BuildNav();
+        var item = new ContactItem { Type = "email", Value = "alice@example.com" };
+        var current = new List<ContactItem> { item };
+        var orig = Snap(current);   // snapshot: 1 item
+
+        current.Add(new ContactItem { Type = "phone", Value = "555-0100" });
+
+        Assert.True(CallHasCollectionChanged(current, nav, orig));
+    }
+
+    [Fact]
+    public void RoundTrip_SnapshotTaken_ItemRemoved_Detected()
+    {
+        // .Remove() path: snapshot has 2 items, collection now has 1.
+        var nav    = BuildNav();
+        var email  = new ContactItem { Type = "email", Value = "alice@example.com" };
+        var phone  = new ContactItem { Type = "phone", Value = "555-0100" };
+        var current = new List<ContactItem> { email, phone };
+        var orig = Snap(current);   // snapshot: 2 items
+
+        current.Remove(email);
+
+        Assert.True(CallHasCollectionChanged(current, nav, orig));
+    }
+
+    // =========================================================================
+    // Region 3: OwnedCollectionSnapshot.OriginalItems — table behaviour
+    // =========================================================================
+
+    [Fact]
+    public void OriginalItems_TwoOwners_HaveIndependentEntries()
+    {
+        // Entries for distinct owner objects must not bleed into each other.
+        var owner1 = new object();
+        var owner2 = new object();
+
+        var t1 = OwnedCollectionSnapshot.OriginalItems.GetOrCreateValue(owner1);
+        t1["Nav"] = [new Dictionary<string, object?> { ["x"] = "A" }];
+
+        var t2 = OwnedCollectionSnapshot.OriginalItems.GetOrCreateValue(owner2);
+        t2["Nav"] = [new Dictionary<string, object?> { ["x"] = "B" }];
+
+        Assert.True(OwnedCollectionSnapshot.OriginalItems.TryGetValue(owner1, out var r1));
+        Assert.True(OwnedCollectionSnapshot.OriginalItems.TryGetValue(owner2, out var r2));
+        Assert.Equal("A", r1!["Nav"][0]["x"]);
+        Assert.Equal("B", r2!["Nav"][0]["x"]);
+    }
+
+    [Fact]
+    public void OriginalItems_UpdateExistingEntry_OverwritesPreviousSnapshot()
+    {
+        // Simulates what RefreshOwnedCollectionSnapshots does after a successful save:
+        // the nav entry is replaced with the new snapshot, so the next save sees a
+        // fresh baseline and does not falsely re-detect the just-written mutation.
+        var owner = new object();
+        var table = OwnedCollectionSnapshot.OriginalItems.GetOrCreateValue(owner);
+
+        // First snapshot (at load time)
+        table["Nav"] = [new Dictionary<string, object?> { ["Value"] = "old" }];
+
+        // After save, RefreshOwnedCollectionSnapshots replaces the entry
+        table["Nav"] = [new Dictionary<string, object?> { ["Value"] = "new" }];
+
+        Assert.True(OwnedCollectionSnapshot.OriginalItems.TryGetValue(owner, out var r));
+        Assert.Equal("new", r!["Nav"][0]["Value"]);
+    }
+
+    [Fact]
+    public void OriginalItems_EntityNotInTable_TryGetValue_ReturnsFalse()
+    {
+        // An entity that was never snapshotted (e.g. newly Added) must not be present
+        // in the table — the interceptor should skip content-change detection for it.
+        var freshOwner = new object();
+
+        Assert.False(OwnedCollectionSnapshot.OriginalItems.TryGetValue(freshOwner, out _));
+    }
+}

--- a/tests/Couchbase.EntityFrameworkCore.UnitTests/Couchbase/EntityFrameworkCore/Storage/Internal/CouchbaseContentSnapshotTests.cs
+++ b/tests/Couchbase.EntityFrameworkCore.UnitTests/Couchbase/EntityFrameworkCore/Storage/Internal/CouchbaseContentSnapshotTests.cs
@@ -1,6 +1,7 @@
 using System.Reflection;
 using Couchbase.EntityFrameworkCore.Query.Internal;
 using Couchbase.EntityFrameworkCore.Storage.Internal;
+using Microsoft.EntityFrameworkCore.ChangeTracking;
 using Microsoft.EntityFrameworkCore.Metadata;
 using Moq;
 using Xunit;
@@ -66,13 +67,22 @@ public class CouchbaseContentSnapshotTests
         var typePropInfo  = typeof(ContactItem).GetProperty(nameof(ContactItem.Type))!;
         var valuePropInfo = typeof(ContactItem).GetProperty(nameof(ContactItem.Value))!;
 
+        // Default string comparer: ordinal equality, null-safe.
+        // GetValueComparer() is an IReadOnlyProperty interface method — Moq returns null by
+        // default, so it must be set up explicitly or HasCollectionChanged will NullRef.
+        var stringComparer = new ValueComparer<string?>(
+            (l, r) => l == r,
+            v => v == null ? 0 : v.GetHashCode());
+
         var typeProp = new Mock<IProperty>();
         typeProp.Setup(p => p.Name).Returns("Type");
         typeProp.Setup(p => p.PropertyInfo).Returns(typePropInfo);
+        typeProp.Setup(p => p.GetValueComparer()).Returns(stringComparer);
 
         var valueProp = new Mock<IProperty>();
         valueProp.Setup(p => p.Name).Returns("Value");
         valueProp.Setup(p => p.PropertyInfo).Returns(valuePropInfo);
+        valueProp.Setup(p => p.GetValueComparer()).Returns(stringComparer);
 
         var targetType = new Mock<IEntityType>();
         targetType.Setup(t => t.GetProperties()).Returns([typeProp.Object, valueProp.Object]);

--- a/tests/Couchbase.EntityFrameworkCore.UnitTests/Couchbase/EntityFrameworkCore/Storage/Internal/CouchbaseDbDataReaderTests.cs
+++ b/tests/Couchbase.EntityFrameworkCore.UnitTests/Couchbase/EntityFrameworkCore/Storage/Internal/CouchbaseDbDataReaderTests.cs
@@ -2667,6 +2667,8 @@ public class CouchbaseDbDataReaderTests
             reader.Close();
             completed = true;
         });
+        // Background so a deadlock doesn't block the test runner after the Join timeout.
+        thread.IsBackground = true;
         thread.Start();
         Assert.True(thread.Join(TimeSpan.FromSeconds(5)),
             "Close() deadlocked when run under a non-default SynchronizationContext");
@@ -2686,6 +2688,8 @@ public class CouchbaseDbDataReaderTests
             SynchronizationContext.SetSynchronizationContext(new CapturingSynchronizationContext());
             result = reader.Read();
         });
+        // Background so a deadlock doesn't block the test runner after the Join timeout.
+        thread.IsBackground = true;
         thread.Start();
         Assert.True(thread.Join(TimeSpan.FromSeconds(5)),
             "Read() deadlocked when run under a non-default SynchronizationContext");

--- a/tests/Couchbase.EntityFrameworkCore.UnitTests/Couchbase/EntityFrameworkCore/Storage/Internal/CouchbaseDbDataReaderTests.cs
+++ b/tests/Couchbase.EntityFrameworkCore.UnitTests/Couchbase/EntityFrameworkCore/Storage/Internal/CouchbaseDbDataReaderTests.cs
@@ -2648,6 +2648,52 @@ public class CouchbaseDbDataReaderTests
 
     #endregion
 
+    #region Phase 5 — Close() and Read() via AsyncHelper
+
+    [Fact]
+    public async Task Close_WithNonDefaultSynchronizationContext_DoesNotDeadlock()
+    {
+        // Uses an async iterator with an async finally block so that DisposeAsync()
+        // genuinely suspends. Without AsyncHelper.RunSync, .GetAwaiter().GetResult() on a
+        // thread with a capturing SynchronizationContext would deadlock because the
+        // continuation never gets posted back to the blocked thread.
+        var reader = CreateReaderWithAsyncDispose();
+        await reader.PrimeAsync(CancellationToken.None); // creates the enumerator
+
+        var completed = false;
+        var thread = new Thread(() =>
+        {
+            SynchronizationContext.SetSynchronizationContext(new CapturingSynchronizationContext());
+            reader.Close();
+            completed = true;
+        });
+        thread.Start();
+        Assert.True(thread.Join(TimeSpan.FromSeconds(5)),
+            "Close() deadlocked when run under a non-default SynchronizationContext");
+        Assert.True(completed);
+        Assert.True(reader.IsClosed);
+    }
+
+    [Fact]
+    public void Read_WithNonDefaultSynchronizationContext_DoesNotDeadlock()
+    {
+        var rows = new List<JsonElement> { ParseElement("{\"id\": 1}") };
+        var reader = CreateReaderWithYieldingRows(rows);
+
+        var result = false;
+        var thread = new Thread(() =>
+        {
+            SynchronizationContext.SetSynchronizationContext(new CapturingSynchronizationContext());
+            result = reader.Read();
+        });
+        thread.Start();
+        Assert.True(thread.Join(TimeSpan.FromSeconds(5)),
+            "Read() deadlocked when run under a non-default SynchronizationContext");
+        Assert.True(result);
+    }
+
+    #endregion
+
     private static JsonElement ParseElement(string json)
     {
         using var doc = JsonDocument.Parse(json);
@@ -2680,5 +2726,59 @@ public class CouchbaseDbDataReaderTests
         mockQueryResult.Setup(q => q.Rows).Returns(rows.ToAsyncEnumerable());
 
         return new CouchbaseDbDataReader<JsonElement>(mockQueryResult.Object, columnNames);
+    }
+
+    // Reader whose enumerator has an async finally block so DisposeAsync() genuinely suspends.
+    private static CouchbaseDbDataReader<JsonElement> CreateReaderWithAsyncDispose()
+    {
+        var mockQueryResult = new Mock<IQueryResult<JsonElement>>();
+        mockQueryResult.Setup(q => q.MetaData).Returns(new QueryMetaData { Status = QueryStatus.Success });
+        mockQueryResult.Setup(q => q.Rows).Returns(AsyncEnumerableWithAsyncDispose());
+        return new CouchbaseDbDataReader<JsonElement>(
+            mockQueryResult.Object, connection: null, CommandBehavior.Default, CancellationToken.None);
+    }
+
+    // Reader whose MoveNextAsync genuinely yields so Read() must await through AsyncHelper.
+    private static CouchbaseDbDataReader<JsonElement> CreateReaderWithYieldingRows(List<JsonElement> rows)
+    {
+        var mockQueryResult = new Mock<IQueryResult<JsonElement>>();
+        mockQueryResult.Setup(q => q.MetaData).Returns(new QueryMetaData { Status = QueryStatus.Success });
+        mockQueryResult.Setup(q => q.Rows).Returns(YieldingEnumerable(rows));
+        return new CouchbaseDbDataReader<JsonElement>(
+            mockQueryResult.Object, connection: null, CommandBehavior.Default, CancellationToken.None);
+    }
+
+    // The async finally makes DisposeAsync() genuinely async: when the enumerator is disposed
+    // mid-stream the finally block runs 'await Task.Yield()', suspending the disposal and
+    // posting its continuation to whatever SynchronizationContext is current at that moment.
+    private static async IAsyncEnumerable<JsonElement> AsyncEnumerableWithAsyncDispose()
+    {
+        try
+        {
+            await Task.Yield();
+            yield return ParseElement("{\"id\": 0}");
+        }
+        finally
+        {
+            await Task.Yield();
+        }
+    }
+
+    private static async IAsyncEnumerable<JsonElement> YieldingEnumerable(IEnumerable<JsonElement> rows)
+    {
+        foreach (var row in rows)
+        {
+            await Task.Yield();
+            yield return row;
+        }
+    }
+
+    // Captures Post callbacks without executing them, simulating a UI-thread context where
+    // the thread is blocked. Any .GetAwaiter().GetResult() that relies on Post to run its
+    // continuation will deadlock; AsyncHelper.RunSync avoids this by replacing the context.
+    private sealed class CapturingSynchronizationContext : SynchronizationContext
+    {
+        public override void Post(SendOrPostCallback d, object? state) { }
+        public override void Send(SendOrPostCallback d, object? state) => d(state);
     }
 }


### PR DESCRIPTION
## Summary
Two independent fixes shipped together as phase 5 of the DataReader refactor series.
- Fix `CouchbaseDbDataReader.Close()` / `Read()` sync-over-async deadlock
- Detect OwnsMany in-place mutations (`.Add()`, `.Remove()`, scalar property change) that EF Core's change tracker cannot see
## Changes
### 1. `CouchbaseDbDataReader` deadlock fix
`Close()` called `.GetAwaiter().GetResult()` on `DisposeAsync()` and `Close()` on
`_queryResult`. Under a capturing `SynchronizationContext` (ASP.NET Classic, UI threads,
xUnit's async context) the continuation is posted back to the blocked thread, which never
runs — deadlock. `Read()` had the same pattern.
Both methods now delegate to `AsyncHelper.RunSync`, which installs an
`ExclusiveSynchronizationContext` that drains continuations on a dedicated thread,
breaking the deadlock regardless of calling context.
**Files:** `CouchbaseDbDataReader.cs`
### 2. OwnsMany in-place mutation detection via content-snapshot
The existing `OwnedCollectionSnapshot.OriginalRefs` table detects collection-reference
*replacement* (`customer.ContactMethods = [...]`). It cannot detect mutations that leave
the list reference unchanged:
| Mutation | Old behaviour | Fixed behaviour |
|---|---|---|
| `collection.Add(item)` | Silent data loss | ✅ Detected |
| `collection.Remove(item)` | Silent data loss | ✅ Detected |
| `item.Property = value` | Silent data loss | ✅ Detected |
Root cause: `IClrCollectionAccessor.Add(..., forMaterialization: true)` is a pure CLR
add — it does **not** register owned items with EF Core's `IStateManager`. EF Core's
`AutoDetectChanges` therefore never sees untracked items change.
Fix: extend `OwnedCollectionSnapshot` with a second `ConditionalWeakTable`
(`OriginalItems`) that stores an ordered snapshot of per-item property values at
materialisation time. `MarkOwnersWithReplacedCollections` now calls `HasCollectionChanged`
after the reference check; any count or value difference marks the owner as `Modified` and
triggers a document rewrite. `RefreshOwnedCollectionSnapshots` updates both tables after a
successful save so a second `SaveChangesAsync` on the same context is a no-op.
**Files:** `OwnedCollectionSnapshot.cs`, `CouchbaseQueryEnumerable.cs`,
`CouchbaseSaveChangesInterceptor.cs`
## Tests
| Suite | Before | After |
|---|---|---|
| Unit (`dotnet test`) | 675 | 697 (+22) |
| Integration (Aspire / Docker) | 15 | 21 (+6) |
New unit tests (`CouchbaseContentSnapshotTests.cs`, 20 tests):
- `HasCollectionChanged` — null guard, empty/same-content, add, remove, property mutation, null↔non-null, missing snapshot key
- Round-trip tests — snapshot → mutate in-place → detect (the exact production lifecycle)
- `OwnedCollectionSnapshot.OriginalItems` table — owner isolation, overwrite, absent-entity guard
New integration tests (`OwnedTypeTests.cs`):
- `OwnsMany_AddSingleItem_RoundTrips`
- `OwnsMany_RemoveSingleItem_RoundTrips`
- `OwnsMany_MutateItemProperty_RoundTrips`
- `OwnsMany_MutateItemProperty_SaveTwice_SecondSaveIsNoOp` *(regression: snapshot refresh)*
- `OwnsMany_AddItem_SaveTwice_SecondSaveIsNoOp` *(regression: snapshot refresh)*
- `OwnsMany_AddAndMutate_BothChangesSaved` *(combined mutation in one save)*
## Spec updates
- `datareader-refactor.md` — Phase 5 actual outcome documented
- `ownsmanycollection-state-manager-tracking.md` — mechanism 1 corrected (`forMaterialization` is CLR-only); mechanism 4 (content-snapshot) added; integration-test attribution table corrected
- `efcore-feature-coverage-2026-05-27.md` — OwnsMany tracking updated to "4 mechanisms"