### PR TITLE
NCBC-3891: strip TONUMBER from AVG operand in N1QL SQL generator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -401,3 +401,4 @@ FodyWeavers.xsd
 **/.DS_Store
 
 .idea
+/specs/

--- a/src/Couchbase.EntityFrameworkCore/Query/Internal/CouchbaseQuerySqlGenerator.cs
+++ b/src/Couchbase.EntityFrameworkCore/Query/Internal/CouchbaseQuerySqlGenerator.cs
@@ -580,11 +580,17 @@ public class CouchbaseQuerySqlGenerator : QuerySqlGenerator
         // N1QL's AVG() natively returns a double for any numeric input. Strip the TONUMBER()
         // that EF Core injects for int/long arguments — it is unnecessary in SQL++ and can
         // trigger a CouchbaseParsingException on some server versions (NCBC-3891).
+        //
+        // Guard: only strip the Convert node when the target type is numeric (the same set that
+        // VisitSqlUnary routes to TONUMBER). ExpressionType.Convert is also used for TOSTRING and
+        // TOBOOLEAN — those must be left intact even though AVG(TOSTRING/TOBOOLEAN) is not valid
+        // standard SQL, because a custom translator could theoretically produce such a tree.
         if (sqlFunctionExpression.IsBuiltIn
             && sqlFunctionExpression.Name == "AVG"
             && sqlFunctionExpression.Arguments.Count == 1
             && sqlFunctionExpression.Arguments[0] is SqlUnaryExpression
-                { OperatorType: ExpressionType.Convert } numericCast)
+                { OperatorType: ExpressionType.Convert } numericCast
+            && IsNumericType(numericCast.Type))
         {
             Sql.Append("AVG(");
             Visit(numericCast.Operand);
@@ -660,7 +666,7 @@ public class CouchbaseQuerySqlGenerator : QuerySqlGenerator
         Action<IRelationalCommandBuilder>? joinAction = null)
     {
         joinAction ??= (isb => isb.Append(", "));
-        
+
         for (var i = 0; i < items.Count; i++)
         {
             if (i > 0)
@@ -671,6 +677,23 @@ public class CouchbaseQuerySqlGenerator : QuerySqlGenerator
             generationAction(items[i]);
         }
     }
+
+    /// <summary>
+    /// Returns <c>true</c> for CLR types that <see cref="VisitSqlUnary"/> maps to
+    /// <c>TONUMBER()</c> — the same exhaustive list used in that switch statement.
+    /// Used to narrow the AVG-stripping guard so that Convert-to-string and
+    /// Convert-to-bool cases are not accidentally removed (NCBC-3891).
+    /// </summary>
+    private static bool IsNumericType(Type type)
+        => type == typeof(double)
+        || type == typeof(float)
+        || type == typeof(decimal)
+        || type == typeof(int)
+        || type == typeof(uint)
+        || type == typeof(long)
+        || type == typeof(ulong)
+        || type == typeof(short)
+        || type == typeof(ushort);
 }
 
 /* ************************************************************

--- a/src/Couchbase.EntityFrameworkCore/Query/Internal/CouchbaseQuerySqlGenerator.cs
+++ b/src/Couchbase.EntityFrameworkCore/Query/Internal/CouchbaseQuerySqlGenerator.cs
@@ -577,6 +577,21 @@ public class CouchbaseQuerySqlGenerator : QuerySqlGenerator
 
     protected override Expression VisitSqlFunction(SqlFunctionExpression sqlFunctionExpression)
     {
+        // N1QL's AVG() natively returns a double for any numeric input. Strip the TONUMBER()
+        // that EF Core injects for int/long arguments — it is unnecessary in SQL++ and can
+        // trigger a CouchbaseParsingException on some server versions (NCBC-3891).
+        if (sqlFunctionExpression.IsBuiltIn
+            && sqlFunctionExpression.Name == "AVG"
+            && sqlFunctionExpression.Arguments.Count == 1
+            && sqlFunctionExpression.Arguments[0] is SqlUnaryExpression
+                { OperatorType: ExpressionType.Convert } numericCast)
+        {
+            Sql.Append("AVG(");
+            Visit(numericCast.Operand);
+            Sql.Append(")");
+            return sqlFunctionExpression;
+        }
+
         if (sqlFunctionExpression.IsBuiltIn)
         {
             if (sqlFunctionExpression.Instance != null)

--- a/tests/Couchbase.EntityFrameworkCore.UnitTests/Couchbase/EntityFrameworkCore/Query/CouchbaseAvgSqlGenerationTests.cs
+++ b/tests/Couchbase.EntityFrameworkCore.UnitTests/Couchbase/EntityFrameworkCore/Query/CouchbaseAvgSqlGenerationTests.cs
@@ -1,0 +1,132 @@
+using Couchbase.EntityFrameworkCore.Extensions;
+using Microsoft.EntityFrameworkCore;
+using Xunit;
+
+namespace Couchbase.EntityFrameworkCore.UnitTests.Couchbase.EntityFrameworkCore.Query;
+
+/// <summary>
+/// Verifies that <c>CouchbaseQuerySqlGenerator.VisitSqlFunction</c> strips the
+/// <c>TONUMBER()</c> wrapper that EF Core injects around integer-column arguments
+/// to <c>AVG()</c> (NCBC-3891).
+///
+/// <para>
+/// EF Core promotes the operand of <c>Average()</c> on an <c>int</c> column to
+/// <c>double</c> via an <c>ExpressionType.Convert</c> node.  The base
+/// <c>QuerySqlGenerator</c> turns that into <c>TONUMBER()</c>.  N1QL's
+/// <c>AVG()</c> already returns a <c>double</c> for any numeric input, so the
+/// <c>TONUMBER()</c> call is redundant and can trigger a
+/// <c>CouchbaseParsingException</c> on some server versions.
+/// </para>
+/// <para>
+/// The fix: at the top of <c>VisitSqlFunction</c>, detect the pattern
+/// <c>AVG(TONUMBER(…))</c> and emit <c>AVG(…)</c> directly, bypassing the
+/// outer <c>TONUMBER</c> call.
+/// </para>
+/// </summary>
+public class CouchbaseAvgSqlGenerationTests
+{
+    // ---------------------------------------------------------------
+    // AVG on int column — the TONUMBER regression (NCBC-3891)
+    // ---------------------------------------------------------------
+
+    [Fact]
+    public void Average_OnIntColumn_DoesNotEmitTonumber()
+    {
+        // Arrange — GroupBy + Average on an int column; EF Core injects Convert→double
+        using var ctx = CreateContext();
+        var query = ctx.Posts
+            .GroupBy(p => p.AuthorId)
+            .Select(g => new { g.Key, Avg = g.Average(p => p.Rating) });
+
+        // Act
+        var sql = query.ToQueryString();
+
+        // Assert — TONUMBER must not appear anywhere inside the AVG call
+        Assert.DoesNotContain("TONUMBER", sql, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void Average_OnIntColumn_EmitsAvgFunction()
+    {
+        using var ctx = CreateContext();
+        var query = ctx.Posts
+            .GroupBy(p => p.AuthorId)
+            .Select(g => new { g.Key, Avg = g.Average(p => p.Rating) });
+
+        var sql = query.ToQueryString();
+
+        // AVG( must appear in the generated SQL
+        Assert.Contains("AVG(", sql, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void Average_OnIntColumn_ColumnNameAppearsInsideAvg()
+    {
+        // The operand of AVG should be the raw column reference, not a function call.
+        using var ctx = CreateContext();
+        var query = ctx.Posts
+            .GroupBy(p => p.AuthorId)
+            .Select(g => new { g.Key, Avg = g.Average(p => p.Rating) });
+
+        var sql = query.ToQueryString();
+
+        // `rating` (backtick-delimited) must appear — proving the column reference survived
+        Assert.Contains("`rating`", sql, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void Average_OnDoubleColumn_EmitsAvgWithoutTonumber()
+    {
+        // A double column has no Convert injection, but the guard must still work correctly.
+        using var ctx = CreateContext();
+        var query = ctx.Posts
+            .GroupBy(p => p.AuthorId)
+            .Select(g => new { g.Key, Avg = g.Average(p => p.Score) });
+
+        var sql = query.ToQueryString();
+
+        Assert.Contains("AVG(", sql, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("TONUMBER", sql, StringComparison.OrdinalIgnoreCase);
+    }
+
+    // ---------------------------------------------------------------
+    // Helpers
+    // ---------------------------------------------------------------
+
+    private static PostContext CreateContext()
+    {
+        var clusterOptions = new ClusterOptions()
+            .WithConnectionString("couchbase://localhost")
+            .WithPasswordAuthentication("Administrator", "password");
+
+        var builder = new DbContextOptionsBuilder<PostContext>();
+        builder.UseCouchbaseProvider(clusterOptions);
+        return new PostContext(builder.Options);
+    }
+
+    // ---------------------------------------------------------------
+    // Test models
+    // ---------------------------------------------------------------
+
+    private class Post
+    {
+        public int    PostId   { get; set; }
+        public int    AuthorId { get; set; }
+        public int    Rating   { get; set; }   // int → triggers Convert→double in AVG
+        public double Score    { get; set; }   // double → no Convert injection
+    }
+
+    private class PostContext(DbContextOptions<PostContext> options) : DbContext(options)
+    {
+        public DbSet<Post> Posts { get; set; } = null!;
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            modelBuilder.Entity<Post>(b =>
+            {
+                b.ToCouchbaseCollection("bucket", "scope", "post");
+                b.HasKey(p => p.PostId);
+            });
+        }
+    }
+}


### PR DESCRIPTION
EF Core injects ExpressionType.Convert to double for Average() on integer columns, which VisitSqlUnary emits as TONUMBER(). N1QL's AVG() already returns double for any numeric input, so AVG(TONUMBER(col)) is unnecessary and triggers CouchbaseParsingException on some server versions. Strip the wrapping Convert node at the top of VisitSqlFunction when the pattern AVG(TONUMBER(...)) is detected. Add four unit tests covering int and double columns.