### PR TITLE
NCBC-3892: Phase 4 eager loading — nested owned-type materialisation and post-merge fixes

### DIFF
--- a/src/Couchbase.EntityFrameworkCore/Query/Internal/CouchbaseQueryEnumerable.cs
+++ b/src/Couchbase.EntityFrameworkCore/Query/Internal/CouchbaseQueryEnumerable.cs
@@ -305,6 +305,8 @@ public class CouchbaseQueryEnumerable<T> : IEnumerable<T>, IAsyncEnumerable<T>, 
             {
                 if (nestedElement.ValueKind != JsonValueKind.Array) continue;
                 var accessor = ownedNav.GetCollectionAccessor();
+                // Skip navigations with no accessor and no PropertyInfo — nothing to set.
+                if (accessor == null && ownedNav.PropertyInfo == null) continue;
                 var nestedClrType = ownedNav.TargetEntityType.ClrType;
                 if (accessor != null)
                 {
@@ -314,7 +316,7 @@ public class CouchbaseQueryEnumerable<T> : IEnumerable<T>, IAsyncEnumerable<T>, 
                 else
                 {
                     var list = (IList)Activator.CreateInstance(typeof(List<>).MakeGenericType(nestedClrType))!;
-                    ownedNav.PropertyInfo?.SetValue(ownedEntity, list);
+                    ownedNav.PropertyInfo!.SetValue(ownedEntity, list);
                 }
                 foreach (var nestedItemElement in nestedElement.EnumerateArray())
                 {
@@ -322,14 +324,21 @@ public class CouchbaseQueryEnumerable<T> : IEnumerable<T>, IAsyncEnumerable<T>, 
                     if (accessor != null)
                         accessor.Add(ownedEntity, nestedEntity, forMaterialization: true);
                     else
-                        ((IList)ownedNav.PropertyInfo!.GetValue(ownedEntity)!).Add(nestedEntity);
+                    {
+                        // PropertyInfo is guaranteed non-null here: we skipped above when both
+                        // accessor and PropertyInfo are null, and accessor is null in this branch.
+                        var existingList = (IList)ownedNav.PropertyInfo!.GetValue(ownedEntity)!;
+                        existingList.Add(nestedEntity);
+                    }
                 }
             }
             else
             {
                 if (nestedElement.ValueKind != JsonValueKind.Object) continue;
+                // Skip shadow/field-only navigations — no PropertyInfo means nowhere to assign.
+                if (ownedNav.PropertyInfo == null) continue;
                 var nestedEntity = MaterializeOwnedItem(nestedElement, ownedNav.TargetEntityType, fieldNamingPolicy, options);
-                ownedNav.PropertyInfo?.SetValue(ownedEntity, nestedEntity);
+                ownedNav.PropertyInfo.SetValue(ownedEntity, nestedEntity);
             }
         }
 

--- a/src/Couchbase.EntityFrameworkCore/Query/Internal/CouchbaseQueryEnumerable.cs
+++ b/src/Couchbase.EntityFrameworkCore/Query/Internal/CouchbaseQueryEnumerable.cs
@@ -247,7 +247,6 @@ public class CouchbaseQueryEnumerable<T> : IEnumerable<T>, IAsyncEnumerable<T>, 
 
             var accessor = nav.GetCollectionAccessor();
             var clrType = nav.TargetEntityType.ClrType;
-            var properties = OwnedCollectionSnapshot.GetTrackedProperties(nav);
 
             if (accessor != null)
             {
@@ -265,19 +264,76 @@ public class CouchbaseQueryEnumerable<T> : IEnumerable<T>, IAsyncEnumerable<T>, 
 
             foreach (var itemElement in arrayElement.EnumerateArray())
             {
-                var ownedEntity = Activator.CreateInstance(clrType)!;
-                foreach (var prop in properties)
-                {
-                    var jsonKey = fieldNamingPolicy?.ConvertName(prop.Name) ?? prop.Name;
-                    if (itemElement.TryGetPropertyCI(jsonKey, out var propElement))
-                        prop.PropertyInfo?.SetValue(ownedEntity, ConvertJsonValue(propElement, prop.ClrType, options));
-                }
+                var ownedEntity = MaterializeOwnedItem(itemElement, nav.TargetEntityType, fieldNamingPolicy, options);
                 if (accessor != null)
                     accessor.Add(entity!, ownedEntity, forMaterialization: true);
                 else
                     ((IList)nav.PropertyInfo!.GetValue(entity)!).Add(ownedEntity);
             }
         }
+    }
+
+    /// <summary>
+    /// Materialises a single owned entity from a <see cref="JsonElement"/> by setting its scalar
+    /// properties and recursively populating any nested owned navigations (OwnsOne / OwnsMany).
+    /// Called for every element of a top-level OwnsMany array, and recursively for nested owned
+    /// types within those elements.
+    /// </summary>
+    private static object MaterializeOwnedItem(
+        JsonElement itemElement,
+        IEntityType entityType,
+        JsonNamingPolicy? fieldNamingPolicy,
+        JsonSerializerOptions options)
+    {
+        var ownedEntity = Activator.CreateInstance(entityType.ClrType)!;
+
+        foreach (var prop in entityType.GetProperties())
+        {
+            if (prop.IsShadowProperty()) continue;
+            var jsonKey = fieldNamingPolicy?.ConvertName(prop.Name) ?? prop.Name;
+            if (itemElement.TryGetPropertyCI(jsonKey, out var propElement))
+                prop.PropertyInfo?.SetValue(ownedEntity, ConvertJsonValue(propElement, prop.ClrType, options));
+        }
+
+        foreach (var ownedNav in entityType.GetNavigations())
+        {
+            if (!ownedNav.TargetEntityType.IsOwned()) continue;
+            var fieldName = fieldNamingPolicy?.ConvertName(ownedNav.Name) ?? ownedNav.Name;
+            if (!itemElement.TryGetPropertyCI(fieldName, out var nestedElement)) continue;
+
+            if (ownedNav.IsCollection)
+            {
+                if (nestedElement.ValueKind != JsonValueKind.Array) continue;
+                var accessor = ownedNav.GetCollectionAccessor();
+                var nestedClrType = ownedNav.TargetEntityType.ClrType;
+                if (accessor != null)
+                {
+                    var coll = accessor.GetOrCreate(ownedEntity, forMaterialization: true);
+                    (coll as IList)?.Clear();
+                }
+                else
+                {
+                    var list = (IList)Activator.CreateInstance(typeof(List<>).MakeGenericType(nestedClrType))!;
+                    ownedNav.PropertyInfo?.SetValue(ownedEntity, list);
+                }
+                foreach (var nestedItemElement in nestedElement.EnumerateArray())
+                {
+                    var nestedEntity = MaterializeOwnedItem(nestedItemElement, ownedNav.TargetEntityType, fieldNamingPolicy, options);
+                    if (accessor != null)
+                        accessor.Add(ownedEntity, nestedEntity, forMaterialization: true);
+                    else
+                        ((IList)ownedNav.PropertyInfo!.GetValue(ownedEntity)!).Add(nestedEntity);
+                }
+            }
+            else
+            {
+                if (nestedElement.ValueKind != JsonValueKind.Object) continue;
+                var nestedEntity = MaterializeOwnedItem(nestedElement, ownedNav.TargetEntityType, fieldNamingPolicy, options);
+                ownedNav.PropertyInfo?.SetValue(ownedEntity, nestedEntity);
+            }
+        }
+
+        return ownedEntity;
     }
 
     // Record the original collection-object reference and per-item property values for every

--- a/src/Couchbase.EntityFrameworkCore/Query/Internal/CouchbaseQueryEnumerable.cs
+++ b/src/Couchbase.EntityFrameworkCore/Query/Internal/CouchbaseQueryEnumerable.cs
@@ -311,7 +311,15 @@ public class CouchbaseQueryEnumerable<T> : IEnumerable<T>, IAsyncEnumerable<T>, 
                 if (accessor != null)
                 {
                     var coll = accessor.GetOrCreate(ownedEntity, forMaterialization: true);
-                    (coll as IList)?.Clear();
+                    // Clear via IList for the common List<T> case; otherwise cast through
+                    // ICollection<T> which every mutable .NET collection implements and which
+                    // guarantees Clear() — this correctly handles HashSet<T>, SortedSet<T>, etc.
+                    if (coll is IList list)
+                        list.Clear();
+                    else if (coll != null)
+                        typeof(ICollection<>).MakeGenericType(nestedClrType)
+                            .GetMethod("Clear")!
+                            .Invoke(coll, null);
                 }
                 else
                 {

--- a/src/Couchbase.EntityFrameworkCore/Query/Internal/CouchbaseQuerySqlGenerator.cs
+++ b/src/Couchbase.EntityFrameworkCore/Query/Internal/CouchbaseQuerySqlGenerator.cs
@@ -133,9 +133,8 @@ public class CouchbaseQuerySqlGenerator : QuerySqlGenerator
     /// <see cref="VisitInnerJoin"/> will suppress when generating SQL.
     /// Includes both direct-table joins (<c>LEFT JOIN owned AS alias</c>) and lateral-join
     /// subqueries (<c>LEFT JOIN (SELECT … FROM owned …) AS alias</c>).
-    /// Used by both the SQL generator (to filter the SELECT projection) and by
-    /// <see cref="CouchbaseShapedQueryCompilingExpressionVisitor"/> (to keep
-    /// <c>projectionAliases</c> aligned with the actual N1QL result columns).
+    /// Used by <see cref="VisitSelect"/> to filter owned-join columns from the emitted
+    /// SELECT projection so N1QL does not see references to undefined table aliases.
     /// </summary>
     internal static HashSet<string> CollectOwnedJoinAliases(SelectExpression selectExpression)
     {

--- a/src/Couchbase.EntityFrameworkCore/Query/Internal/CouchbaseQuerySqlGenerator.cs
+++ b/src/Couchbase.EntityFrameworkCore/Query/Internal/CouchbaseQuerySqlGenerator.cs
@@ -42,6 +42,12 @@ public class CouchbaseQuerySqlGenerator : QuerySqlGenerator
         if (leftJoinExpression.Table is TableExpression tableExpression && IsOwnedTable(tableExpression))
             return leftJoinExpression;
 
+        // EF Core generates a lateral-join subquery (LEFT JOIN (SELECT ...) AS s) when
+        // OwnsMany items have nested owned navigations (OwnsOne/OwnsMany within OwnsMany).
+        // Skip the entire lateral join when its subquery only reads from owned tables.
+        if (leftJoinExpression.Table is SelectExpression innerSelect && IsAllOwnedTablesSelect(innerSelect))
+            return leftJoinExpression;
+
         return base.VisitLeftJoin(leftJoinExpression);
     }
 
@@ -51,6 +57,10 @@ public class CouchbaseQuerySqlGenerator : QuerySqlGenerator
         // Skip INNER JOINs for owned types — they are embedded in their owner's document
         // and have no independent keyspace.
         if (innerJoinExpression.Table is TableExpression tableExpression && IsOwnedTable(tableExpression))
+            return innerJoinExpression;
+
+        // Lateral-join subquery form — same logic as VisitLeftJoin above.
+        if (innerJoinExpression.Table is SelectExpression innerSelect && IsAllOwnedTablesSelect(innerSelect))
             return innerJoinExpression;
 
         return base.VisitInnerJoin(innerJoinExpression);
@@ -78,7 +88,7 @@ public class CouchbaseQuerySqlGenerator : QuerySqlGenerator
     /// <see langword="true"/> for unmapped tables.
     /// </para>
     /// </remarks>
-    private static bool IsOwnedTable(TableExpression tableExpression)
+    internal static bool IsOwnedTable(TableExpression tableExpression)
     {
         // Single-pass enumeration: track whether any mappings exist and whether every
         // mapping seen so far is an owned entity type. Avoids the ToList() allocation
@@ -91,6 +101,67 @@ public class CouchbaseQuerySqlGenerator : QuerySqlGenerator
             any = true;
         }
         return any;
+    }
+
+    /// <summary>
+    /// Returns <see langword="true"/> when every table referenced by
+    /// <paramref name="selectExpression"/> (directly and through its own JOINs) is an owned
+    /// type.  Used to detect EF Core's lateral-join subquery pattern for OwnsMany items that
+    /// have nested owned navigations — the whole subquery can be skipped because its data is
+    /// embedded in the parent document.
+    /// </summary>
+    internal static bool IsAllOwnedTablesSelect(SelectExpression selectExpression)
+    {
+        if (selectExpression.Tables.Count == 0) return false;
+        foreach (var table in selectExpression.Tables)
+        {
+            TableExpression? te = table switch
+            {
+                TableExpression t                                       => t,
+                LeftJoinExpression  lj when lj.Table is TableExpression t => t,
+                InnerJoinExpression ij when ij.Table is TableExpression t => t,
+                _ => null
+            };
+            if (te == null || !IsOwnedTable(te)) return false;
+        }
+        return true;
+    }
+
+    /// <summary>
+    /// Returns the set of table aliases for owned-type LEFT JOIN / INNER JOIN entries in
+    /// <paramref name="selectExpression"/> — those that <see cref="VisitLeftJoin"/> and
+    /// <see cref="VisitInnerJoin"/> will suppress when generating SQL.
+    /// Includes both direct-table joins (<c>LEFT JOIN owned AS alias</c>) and lateral-join
+    /// subqueries (<c>LEFT JOIN (SELECT … FROM owned …) AS alias</c>).
+    /// Used by both the SQL generator (to filter the SELECT projection) and by
+    /// <see cref="CouchbaseShapedQueryCompilingExpressionVisitor"/> (to keep
+    /// <c>projectionAliases</c> aligned with the actual N1QL result columns).
+    /// </summary>
+    internal static HashSet<string> CollectOwnedJoinAliases(SelectExpression selectExpression)
+    {
+        var aliases = new HashSet<string>(StringComparer.Ordinal);
+        foreach (var table in selectExpression.Tables)
+        {
+            switch (table)
+            {
+                // Direct owned-table join: LEFT JOIN ownedTable AS alias
+                case LeftJoinExpression lj when lj.Table is TableExpression te && IsOwnedTable(te):
+                    aliases.Add(te.Alias);
+                    break;
+                case InnerJoinExpression ij when ij.Table is TableExpression te && IsOwnedTable(te):
+                    aliases.Add(te.Alias);
+                    break;
+
+                // Lateral-join subquery: LEFT JOIN (SELECT … FROM owned …) AS s
+                case LeftJoinExpression lj when lj.Table is SelectExpression inner && IsAllOwnedTablesSelect(inner):
+                    if (inner.Alias != null) aliases.Add(inner.Alias);
+                    break;
+                case InnerJoinExpression ij when ij.Table is SelectExpression inner && IsAllOwnedTablesSelect(inner):
+                    if (inner.Alias != null) aliases.Add(inner.Alias);
+                    break;
+            }
+        }
+        return aliases;
     }
 
     /// <inheritdoc />
@@ -334,6 +405,20 @@ public class CouchbaseQuerySqlGenerator : QuerySqlGenerator
 
             if (selectExpression.Projection.Any())
             {
+                // Collect aliases of owned-type JOINs that will be suppressed in FROM/JOIN.
+                // Columns referencing those aliases are excluded from the SELECT list so N1QL
+                // does not see undefined table alias references (e.g. `cm0`.`id` when the
+                // contactMethod LEFT JOIN is skipped). The EF Core shaper's baked-in ordinals
+                // still expect those slots — they are kept as null placeholders in
+                // projectionAliases so CouchbaseDbDataReader returns DBNull for them, which
+                // the shaper interprets as "no collection rows". PopulateCollectionNavigations
+                // then populates the collection from the embedded JSON array.
+                var skippedAliases = CollectOwnedJoinAliases(selectExpression);
+                bool IsFromSkippedJoin(ProjectionExpression pe) =>
+                    skippedAliases.Count > 0
+                    && pe.Expression is ColumnExpression col
+                    && skippedAliases.Contains(col.TableAlias);
+
                 if (selectExpression.Projection.Count == 1)
                 {
                     var expression = selectExpression.Projection.First().Expression;
@@ -355,12 +440,12 @@ public class CouchbaseQuerySqlGenerator : QuerySqlGenerator
                     var dedupedProjections = new Dictionary<string, ProjectionExpression>();
                     foreach (var expression in selectExpression.Projection)
                     {
-                        dedupedProjections.TryAdd(expression.Alias, expression);
+                        if (!IsFromSkippedJoin(expression))
+                            dedupedProjections.TryAdd(expression.Alias, expression);
                     }
 
                     GenerateList(dedupedProjections.Values.ToList(), e => Visit(e));
                 }
-                // GenerateList(selectExpression.Projection, e => Visit(e));
             }
             else
             {

--- a/src/Couchbase.EntityFrameworkCore/Query/Internal/CouchbaseShapedQueryCompilingExpressionVisitor.cs
+++ b/src/Couchbase.EntityFrameworkCore/Query/Internal/CouchbaseShapedQueryCompilingExpressionVisitor.cs
@@ -234,6 +234,11 @@ public class CouchbaseShapedQueryCompilingExpressionVisitor : RelationalShapedQu
                     : pe.Expression is ColumnExpression c ? c.Name
                     : string.Empty;
 
+            // Keep the FULL unfiltered projection alias array so the EF Core shaper's baked-in
+            // ordinals remain correct. Columns from skipped owned-type JOINs (e.g. cm0.id) are
+            // absent from the N1QL result and return DBNull via CouchbaseDbDataReader, which is
+            // the expected signal for "no collection rows" — PopulateCollectionNavigations then
+            // fills the actual collection from the embedded JSON array.
             var projectionAliasesExpression = Dependencies.LiftableConstantFactory.CreateLiftableConstant(
                 selectExpression.Projection.Select(EffectiveAlias).ToArray(),
 #pragma warning disable EF9100

--- a/src/Couchbase.EntityFrameworkCore/Storage/Internal/CouchbaseDatabaseWrapper.cs
+++ b/src/Couchbase.EntityFrameworkCore/Storage/Internal/CouchbaseDatabaseWrapper.cs
@@ -148,9 +148,10 @@ public class CouchbaseDatabaseWrapper : Database
         {
             cancellationToken.ThrowIfCancellationRequested();
 
-            // Walk the ownership chain up to the root (non-owned) entity.
+            // Walk the ownership chain up to the root non-owned entity.
             // Deeply nested owned types (e.g. ContactTag → ContactMethod → Customer) require
-            // multiple hops; stop at the first entity type that has its own collection keyspace.
+            // multiple hops; stop at the first principal whose entity type is not owned —
+            // only non-owned types have an independent Couchbase keyspace to write to.
             var currentEntry = (InternalEntityEntry)ownedEntry;
             InternalEntityEntry? rootInternalEntry = null;
             IEntityType? rootEntityType = null;

--- a/src/Couchbase.EntityFrameworkCore/Storage/Internal/CouchbaseDatabaseWrapper.cs
+++ b/src/Couchbase.EntityFrameworkCore/Storage/Internal/CouchbaseDatabaseWrapper.cs
@@ -148,36 +148,50 @@ public class CouchbaseDatabaseWrapper : Database
         {
             cancellationToken.ThrowIfCancellationRequested();
 
-            var ownership = ownedEntry.EntityType.FindOwnership();
-            if (ownership == null) continue;
+            // Walk the ownership chain up to the root (non-owned) entity.
+            // Deeply nested owned types (e.g. ContactTag → ContactMethod → Customer) require
+            // multiple hops; stop at the first entity type that has its own collection keyspace.
+            var currentEntry = (InternalEntityEntry)ownedEntry;
+            InternalEntityEntry? rootInternalEntry = null;
+            IEntityType? rootEntityType = null;
 
-            // FK values on the owned entry are equal to the owner's PK values.
-            var fkValues = ownership.Properties
-                .Select(p => ownedEntry.GetCurrentValue(p))
-                .ToArray();
+            while (true)
+            {
+                var ownership = currentEntry.EntityType.FindOwnership();
+                if (ownership == null) break;
 
-            var ownerEntityType = ownership.PrincipalEntityType;
+                var fkValues = ownership.Properties
+                    .Select(p => currentEntry.GetCurrentValue(p))
+                    .ToArray();
 
-            // Use StateManager.TryGetEntry for O(1) owner lookup instead of a linear
-            // ChangeTracker.Entries() scan, and get the InternalEntityEntry directly so
-            // the IInfrastructure<InternalEntityEntry> unwrap is no longer needed.
-            var stateManager = ((InternalEntityEntry)ownedEntry).StateManager;
-            var ownerInternalEntry = stateManager.TryGetEntry(ownership.PrincipalKey, fkValues);
-            if (ownerInternalEntry == null) continue;
+                var ownerEntry = currentEntry.StateManager.TryGetEntry(ownership.PrincipalKey, fkValues);
+                if (ownerEntry == null) break;
 
-            var ownerEntity = ownerInternalEntry.Entity;
-            var ownerPrimaryKey = ownerEntityType.GetPrimaryKey(ownerEntity);
-            var rootKey = $"{ownerEntityType.ClrType.Name}:{ownerPrimaryKey}";
+                if (!ownership.PrincipalEntityType.IsOwned())
+                {
+                    rootInternalEntry = ownerEntry;
+                    rootEntityType = ownership.PrincipalEntityType;
+                    break;
+                }
+
+                currentEntry = ownerEntry;
+            }
+
+            if (rootInternalEntry == null || rootEntityType == null) continue;
+
+            var ownerEntity = rootInternalEntry.Entity;
+            var ownerPrimaryKey = rootEntityType.GetPrimaryKey(ownerEntity);
+            var rootKey = $"{rootEntityType.ClrType.Name}:{ownerPrimaryKey}";
 
             if (writtenRoots.Contains(rootKey)) continue;
             writtenRoots.Add(rootKey);
 
-            var ownerKeyspace = ownerEntityType.GetCollectionName()
+            var ownerKeyspace = rootEntityType.GetCollectionName()
                 ?? throw new InvalidOperationException(
-                    $"Owner entity type '{ownerEntityType.ClrType.Name}' has no mapped table name. " +
+                    $"Owner entity type '{rootEntityType.ClrType.Name}' has no mapped table name. " +
                     "Ensure the entity is mapped to a Couchbase collection via ToCouchbaseCollection().");
 
-            var ownerDocument = HydrateObjectFromEntity(ownerInternalEntry, _fieldNamingPolicy);
+            var ownerDocument = HydrateObjectFromEntity(rootInternalEntry, _fieldNamingPolicy);
 
             if (transaction != null)
             {
@@ -275,16 +289,9 @@ public class CouchbaseDatabaseWrapper : Database
                 var fieldName = fieldNamingPolicy?.ConvertName(nav.Name) ?? nav.Name;
                 if (navValue is IEnumerable items)
                 {
-                    var itemProps = nav.TargetEntityType.GetProperties()
-                        .Where(p => !p.IsShadowProperty()).ToList();
                     var list = new List<Dictionary<string, object?>>();
                     foreach (var item in items)
-                    {
-                        var itemDoc = new Dictionary<string, object?>();
-                        foreach (var p in itemProps)
-                            itemDoc[fieldNamingPolicy?.ConvertName(p.Name) ?? p.Name] = p.PropertyInfo?.GetValue(item);
-                        list.Add(itemDoc);
-                    }
+                        list.Add(SerializeOwnedItem(item, nav.TargetEntityType, fieldNamingPolicy));
                     doc[fieldName] = list;
                 }
                 else
@@ -295,6 +302,59 @@ public class CouchbaseDatabaseWrapper : Database
             else
             {
                 FillOwnsOneIntoDoc(doc, nav, navValue);
+            }
+        }
+
+        return doc;
+    }
+
+    /// <summary>
+    /// Recursively serializes a single owned-item CLR instance to a dictionary,
+    /// including any nested OwnsOne / OwnsMany navigations at arbitrary depth.
+    /// </summary>
+    private static Dictionary<string, object?> SerializeOwnedItem(
+        object item,
+        IEntityType entityType,
+        JsonNamingPolicy? fieldNamingPolicy)
+    {
+        var doc = new Dictionary<string, object?>();
+
+        foreach (var p in entityType.GetProperties())
+        {
+            if (p.IsShadowProperty()) continue;
+            doc[fieldNamingPolicy?.ConvertName(p.Name) ?? p.Name] = p.PropertyInfo?.GetValue(item);
+        }
+
+        foreach (var nav in entityType.GetNavigations())
+        {
+            if (!nav.TargetEntityType.IsOwned() || nav.PropertyInfo == null) continue;
+            var navValue = nav.PropertyInfo.GetValue(item);
+            var fieldName = fieldNamingPolicy?.ConvertName(nav.Name) ?? nav.Name;
+
+            if (nav.IsCollection)
+            {
+                if (navValue is IEnumerable nested)
+                {
+                    var list = new List<Dictionary<string, object?>>();
+                    foreach (var nestedItem in nested)
+                        list.Add(SerializeOwnedItem(nestedItem, nav.TargetEntityType, fieldNamingPolicy));
+                    doc[fieldName] = list;
+                }
+                else
+                {
+                    doc[fieldName] = null;
+                }
+            }
+            else
+            {
+                if (navValue == null)
+                {
+                    doc[fieldName] = null;
+                }
+                else
+                {
+                    doc[fieldName] = SerializeOwnedItem(navValue, nav.TargetEntityType, fieldNamingPolicy);
+                }
             }
         }
 

--- a/tests/Couchbase.EntityFrameworkCore.IntegrationTests/Fixtures/OwnedTypeFixture.cs
+++ b/tests/Couchbase.EntityFrameworkCore.IntegrationTests/Fixtures/OwnedTypeFixture.cs
@@ -111,4 +111,26 @@ public class OwnedTypeFixture : CouchbaseFixture<OwnedTypeDbContext>
         public string Key { get; set; } = "";
         public string Val { get; set; } = "";
     }
+
+    // -------------------------------------------------------------------------
+    // HashSet<T>-backed model — used by OwnedCollectionClearIntegrationTests
+    // -------------------------------------------------------------------------
+
+    /// <summary>
+    /// An entity whose OwnsMany navigation uses HashSet&lt;T&gt; instead of List&lt;T&gt;.
+    /// This exercises the ICollection&lt;T&gt; fallback clear path in MaterializeOwnedItem.
+    /// </summary>
+    public class HashSetCustomer
+    {
+        public int Id { get; set; }
+        public string Name { get; set; } = "";
+        /// <summary>Intentionally HashSet, not List — tests the non-IList clear path.</summary>
+        public HashSet<HashSetTag> Tags { get; set; } = [];
+    }
+
+    public class HashSetTag
+    {
+        public int Id { get; set; }
+        public string Value { get; set; } = "";
+    }
 }

--- a/tests/Couchbase.EntityFrameworkCore.IntegrationTests/Fixtures/OwnedTypeFixture.cs
+++ b/tests/Couchbase.EntityFrameworkCore.IntegrationTests/Fixtures/OwnedTypeFixture.cs
@@ -44,6 +44,35 @@ public class OwnedTypeFixture : CouchbaseFixture<OwnedTypeDbContext>
                 [
                     new ContactMethod { Id = 1, Type = "email", Value = "bob@example.com" }
                 ]
+            },
+            new Customer
+            {
+                CustomerId = 3,
+                Name = "Carol",
+                Address = new Address { Street = "3 Oak Ave", City = "Shelbyville" },
+                ContactMethods =
+                [
+                    new ContactMethod
+                    {
+                        Id = 1,
+                        Type = "email",
+                        Value = "carol@example.com",
+                        Label = new ContactLabel { DisplayName = "Work Email" },
+                        Tags =
+                        [
+                            new ContactTag { Id = 1, Key = "priority", Val = "high" },
+                            new ContactTag { Id = 2, Key = "verified", Val = "true" }
+                        ]
+                    },
+                    new ContactMethod
+                    {
+                        Id = 2,
+                        Type = "phone",
+                        Value = "555-0303",
+                        Label = new ContactLabel { DisplayName = "Mobile" },
+                        Tags = []
+                    }
+                ]
             });
         await ctx.SaveChangesAsync();
     }
@@ -67,5 +96,19 @@ public class OwnedTypeFixture : CouchbaseFixture<OwnedTypeDbContext>
         public int Id { get; set; }
         public string Type { get; set; } = "";
         public string Value { get; set; } = "";
+        public ContactLabel? Label { get; set; }
+        public List<ContactTag> Tags { get; set; } = [];
+    }
+
+    public class ContactLabel
+    {
+        public string? DisplayName { get; set; }
+    }
+
+    public class ContactTag
+    {
+        public int Id { get; set; }
+        public string Key { get; set; } = "";
+        public string Val { get; set; } = "";
     }
 }

--- a/tests/Couchbase.EntityFrameworkCore.IntegrationTests/Models/OwnedTypeDbContext.cs
+++ b/tests/Couchbase.EntityFrameworkCore.IntegrationTests/Models/OwnedTypeDbContext.cs
@@ -14,7 +14,11 @@ public class OwnedTypeDbContext(DbContextOptions<OwnedTypeDbContext> options) : 
         {
             b.ToCouchbaseCollection(this, "customer");
             b.OwnsOne(c => c.Address);
-            b.OwnsMany(c => c.ContactMethods);
+            b.OwnsMany(c => c.ContactMethods, cm =>
+            {
+                cm.OwnsOne(m => m.Label);
+                cm.OwnsMany(m => m.Tags);
+            });
         });
 
         modelBuilder.ConfigureToCouchbase(this, true);

--- a/tests/Couchbase.EntityFrameworkCore.IntegrationTests/Models/OwnedTypeDbContext.cs
+++ b/tests/Couchbase.EntityFrameworkCore.IntegrationTests/Models/OwnedTypeDbContext.cs
@@ -8,6 +8,12 @@ public class OwnedTypeDbContext(DbContextOptions<OwnedTypeDbContext> options) : 
 {
     public DbSet<OwnedTypeFixture.Customer> Customers { get; set; }
 
+    /// <summary>
+    /// HashSet&lt;T&gt;-backed entity — exercises the ICollection&lt;T&gt; fallback clear path
+    /// in MaterializeOwnedItem (the non-IList branch).
+    /// </summary>
+    public DbSet<OwnedTypeFixture.HashSetCustomer> HashSetCustomers { get; set; }
+
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
         modelBuilder.Entity<OwnedTypeFixture.Customer>(b =>
@@ -19,6 +25,13 @@ public class OwnedTypeDbContext(DbContextOptions<OwnedTypeDbContext> options) : 
                 cm.OwnsOne(m => m.Label);
                 cm.OwnsMany(m => m.Tags);
             });
+        });
+
+        modelBuilder.Entity<OwnedTypeFixture.HashSetCustomer>(b =>
+        {
+            b.ToCouchbaseCollection(this, "hashsetcustomer");
+            b.HasKey(c => c.Id);
+            b.OwnsMany(c => c.Tags, t => t.HasKey(t => t.Id));
         });
 
         modelBuilder.ConfigureToCouchbase(this, true);

--- a/tests/Couchbase.EntityFrameworkCore.IntegrationTests/Tests/OwnedTypeTests.cs
+++ b/tests/Couchbase.EntityFrameworkCore.IntegrationTests/Tests/OwnedTypeTests.cs
@@ -163,7 +163,7 @@ public class OwnedTypeTests(
         await using var ctx = fixture.GetDbContext();
         var customers = await ctx.Customers.ToListAsync();
 
-        Assert.Equal(2, customers.Count);
+        Assert.Equal(3, customers.Count);
         var alice = customers.Single(c => c.Name == "Alice");
         var bob   = customers.Single(c => c.Name == "Bob");
         Assert.Equal(2, alice.ContactMethods.Count);
@@ -403,6 +403,74 @@ public class OwnedTypeTests(
 
         var secondCount = await ctx.SaveChangesAsync();
         Assert.Equal(0, secondCount);
+    }
+
+    // -------------------------------------------------------------------------
+    // Nested owned-type materialisation (Phase 4.3)
+    // -------------------------------------------------------------------------
+
+    [Fact]
+    public async Task OwnsOne_Nested_InOwnsMany_IsPopulated()
+    {
+        // ContactMethod.Label is an OwnsOne nested inside an OwnsMany.
+        // MaterializeOwnedItem must recurse into the nested object and set the property.
+        await using var ctx = fixture.GetDbContext();
+        var customer = await ctx.Customers.FirstAsync(c => c.CustomerId == 3);
+
+        Assert.Equal(2, customer.ContactMethods.Count);
+        var email = customer.ContactMethods.First(cm => cm.Type == "email");
+        Assert.NotNull(email.Label);
+        Assert.Equal("Work Email", email.Label.DisplayName);
+        var phone = customer.ContactMethods.First(cm => cm.Type == "phone");
+        Assert.NotNull(phone.Label);
+        Assert.Equal("Mobile", phone.Label.DisplayName);
+    }
+
+    [Fact]
+    public async Task OwnsMany_Nested_InOwnsMany_IsPopulated()
+    {
+        // ContactMethod.Tags is an OwnsMany nested inside an OwnsMany.
+        // MaterializeOwnedItem must recurse into the nested array and materialise each element.
+        await using var ctx = fixture.GetDbContext();
+        var customer = await ctx.Customers.FirstAsync(c => c.CustomerId == 3);
+
+        var email = customer.ContactMethods.First(cm => cm.Type == "email");
+        Assert.Equal(2, email.Tags.Count);
+        Assert.Contains(email.Tags, t => t.Key == "priority" && t.Val == "high");
+        Assert.Contains(email.Tags, t => t.Key == "verified" && t.Val == "true");
+
+        var phone = customer.ContactMethods.First(cm => cm.Type == "phone");
+        Assert.Empty(phone.Tags);
+    }
+
+    [Fact]
+    public async Task OwnsOne_WithExplicitInclude_IsPopulated()
+    {
+        // Explicit .Include(c => c.Address) on an OwnsOne must not break materialisation.
+        // The EF Core relational shaper already projects OwnsOne columns, so Include is a no-op.
+        await using var ctx = fixture.GetDbContext();
+        var customer = await ctx.Customers
+            .Include(c => c.Address)
+            .FirstAsync(c => c.CustomerId == 1);
+
+        Assert.NotNull(customer.Address);
+        Assert.Equal("1 Main St", customer.Address.Street);
+        Assert.Equal("Springfield", customer.Address.City);
+    }
+
+    [Fact]
+    public async Task OwnsMany_NestedOwned_ExistingCustomers_HaveNullOrEmpty()
+    {
+        // Customers 1 and 2 were seeded without Label/Tags on their ContactMethods.
+        // Nested owned navigations must default to null / empty — not throw.
+        await using var ctx = fixture.GetDbContext();
+        var customer = await ctx.Customers.FirstAsync(c => c.CustomerId == 1);
+
+        Assert.All(customer.ContactMethods, cm =>
+        {
+            Assert.Null(cm.Label);
+            Assert.Empty(cm.Tags);
+        });
     }
 
     [Fact]

--- a/tests/Couchbase.EntityFrameworkCore.IntegrationTests/Tests/OwnedTypeTests.cs
+++ b/tests/Couchbase.EntityFrameworkCore.IntegrationTests/Tests/OwnedTypeTests.cs
@@ -499,4 +499,166 @@ public class OwnedTypeTests(
                 cm => cm.Type == "sms"   && cm.Value == "555-0300");
         }
     }
+
+    // -------------------------------------------------------------------------
+    // HashSet<T> collection type — ICollection<T> fallback clear path
+    // -------------------------------------------------------------------------
+    // These tests verify that MaterializeOwnedItem correctly clears and repopulates
+    // a HashSet<T>-backed OwnsMany navigation.  Before the fix, the non-IList branch
+    // silently skipped the clear, which could leave pre-populated items in the set.
+
+    [Fact]
+    public async Task OwnsMany_HashSet_IsPopulated_OnFirstRead()
+    {
+        // Baseline: a HashSet<T> navigation is populated correctly from JSON.
+        const int id = 200;
+        try
+        {
+            await using (var ctx = fixture.GetDbContext())
+            {
+                ctx.Update(new OwnedTypeFixture.HashSetCustomer
+                {
+                    Id = id,
+                    Name = "HashSet Alice",
+                    Tags =
+                    [
+                        new OwnedTypeFixture.HashSetTag { Id = 1, Value = "tag-a" },
+                        new OwnedTypeFixture.HashSetTag { Id = 2, Value = "tag-b" }
+                    ]
+                });
+                await ctx.SaveChangesAsync();
+            }
+
+            await using (var ctx = fixture.GetDbContext())
+            {
+                var customer = await ctx.HashSetCustomers.FirstAsync(c => c.Id == id);
+                Assert.Equal(2, customer.Tags.Count);
+                Assert.Contains(customer.Tags, t => t.Value == "tag-a");
+                Assert.Contains(customer.Tags, t => t.Value == "tag-b");
+            }
+        }
+        finally
+        {
+            await using var ctx = fixture.GetDbContext();
+            var customer = await ctx.HashSetCustomers.FirstOrDefaultAsync(c => c.Id == id);
+            if (customer != null) { ctx.Remove(customer); await ctx.SaveChangesAsync(); }
+        }
+    }
+
+    [Fact]
+    public async Task OwnsMany_HashSet_NoDuplicates_WhenQueriedMultipleTimes()
+    {
+        // Regression guard: querying the same HashSet<T>-backed entity multiple times
+        // must not accumulate duplicate items.  Before the fix, the non-IList clear
+        // was a no-op so each rematerialization appended to the existing set.
+        const int id = 201;
+        try
+        {
+            await using (var ctx = fixture.GetDbContext())
+            {
+                ctx.Update(new OwnedTypeFixture.HashSetCustomer
+                {
+                    Id = id,
+                    Name = "HashSet Bob",
+                    Tags =
+                    [
+                        new OwnedTypeFixture.HashSetTag { Id = 1, Value = "only-tag" }
+                    ]
+                });
+                await ctx.SaveChangesAsync();
+            }
+
+            // Query twice in the same logical scope (fresh context each time to
+            // rule out EF identity-cache short-circuits).
+            for (var pass = 1; pass <= 2; pass++)
+            {
+                await using var ctx = fixture.GetDbContext();
+                var customer = await ctx.HashSetCustomers.FirstAsync(c => c.Id == id);
+                Assert.Single(customer.Tags);
+                Assert.Equal("only-tag", customer.Tags.Single().Value);
+            }
+        }
+        finally
+        {
+            await using var ctx = fixture.GetDbContext();
+            var customer = await ctx.HashSetCustomers.FirstOrDefaultAsync(c => c.Id == id);
+            if (customer != null) { ctx.Remove(customer); await ctx.SaveChangesAsync(); }
+        }
+    }
+
+    [Fact]
+    public async Task OwnsMany_HashSet_Update_RoundTrips()
+    {
+        // Mutating a HashSet<T>-backed OwnsMany must persist and read back correctly.
+        const int id = 202;
+        try
+        {
+            await using (var ctx = fixture.GetDbContext())
+            {
+                ctx.Update(new OwnedTypeFixture.HashSetCustomer
+                {
+                    Id = id,
+                    Name = "HashSet Carol",
+                    Tags =
+                    [
+                        new OwnedTypeFixture.HashSetTag { Id = 1, Value = "original" }
+                    ]
+                });
+                await ctx.SaveChangesAsync();
+            }
+
+            await using (var ctx = fixture.GetDbContext())
+            {
+                var customer = await ctx.HashSetCustomers.FirstAsync(c => c.Id == id);
+                customer.Tags = [new OwnedTypeFixture.HashSetTag { Id = 1, Value = "updated" }];
+                await ctx.SaveChangesAsync();
+            }
+
+            await using (var ctx = fixture.GetDbContext())
+            {
+                var customer = await ctx.HashSetCustomers.FirstAsync(c => c.Id == id);
+                Assert.Single(customer.Tags);
+                Assert.Equal("updated", customer.Tags.Single().Value);
+            }
+        }
+        finally
+        {
+            await using var ctx = fixture.GetDbContext();
+            var customer = await ctx.HashSetCustomers.FirstOrDefaultAsync(c => c.Id == id);
+            if (customer != null) { ctx.Remove(customer); await ctx.SaveChangesAsync(); }
+        }
+    }
+
+    [Fact]
+    public async Task OwnsMany_HashSet_EmptyCollection_ReadsAsEmpty()
+    {
+        // A HashSet<T> navigation stored with zero items must read back as empty, not null.
+        const int id = 203;
+        try
+        {
+            await using (var ctx = fixture.GetDbContext())
+            {
+                ctx.Update(new OwnedTypeFixture.HashSetCustomer
+                {
+                    Id = id,
+                    Name = "HashSet Dave",
+                    Tags = []
+                });
+                await ctx.SaveChangesAsync();
+            }
+
+            await using (var ctx = fixture.GetDbContext())
+            {
+                var customer = await ctx.HashSetCustomers.FirstAsync(c => c.Id == id);
+                Assert.NotNull(customer.Tags);
+                Assert.Empty(customer.Tags);
+            }
+        }
+        finally
+        {
+            await using var ctx = fixture.GetDbContext();
+            var customer = await ctx.HashSetCustomers.FirstOrDefaultAsync(c => c.Id == id);
+            if (customer != null) { ctx.Remove(customer); await ctx.SaveChangesAsync(); }
+        }
+    }
 }

--- a/tests/Couchbase.EntityFrameworkCore.UnitTests/Couchbase/EntityFrameworkCore/Query/OwnedCollectionInjectionTests.cs
+++ b/tests/Couchbase.EntityFrameworkCore.UnitTests/Couchbase/EntityFrameworkCore/Query/OwnedCollectionInjectionTests.cs
@@ -38,36 +38,11 @@ public class CouchbaseQueryEnumerableTests
 
 public class NestedOwnedSqlGenerationTests
 {
+    // ---- ToList (no subquery) ----
     [Fact]
     public void NestedOwnsMany_ToList_GeneratesValidN1QL()
     {
         using var ctx = CreateContext();
-        var sql = ctx.Customers.AsQueryable().ToQueryString();
-        // Must not contain aliases from skipped owned JOINs
-        Assert.DoesNotContain("cm0", sql);
-        Assert.DoesNotContain("ct0", sql);
-        // Must not have a stray closing paren at start of a line
-        foreach (var line in sql.Split('\n'))
-            Assert.False(line.TrimStart().StartsWith(")") && line.Trim().Length == 1,
-                $"Stray closing paren found in N1QL:\n{sql}");
-    }
-
-
-    private static CustomerContext CreateContext()
-    {
-        var clusterOptions = new global::Couchbase.ClusterOptions()
-            .WithConnectionString("couchbase://localhost")
-            .WithPasswordAuthentication("Administrator", "password");
-        var builder = new Microsoft.EntityFrameworkCore.DbContextOptionsBuilder<CustomerContext>();
-        builder.UseCouchbaseProvider(clusterOptions);
-        return new CustomerContext(builder.Options);
-    }
-
-    // ---- ToList (no subquery) ----
-    [Fact]
-    public void NestedOwnsMany_WithOwnsOneRoot_ToList_GeneratesValidN1QL()
-    {
-        using var ctx = CreateContextWithOwnsOne();
         var sql = ctx.Customers.AsQueryable().ToQueryString();
         Assert.DoesNotContain("cm0", sql);
         Assert.DoesNotContain("ct0", sql);
@@ -77,9 +52,9 @@ public class NestedOwnedSqlGenerationTests
 
     // ---- First (subquery with LIMIT 1) ----
     [Fact]
-    public void NestedOwnsMany_WithOwnsOneRoot_First_GeneratesValidN1QL()
+    public void NestedOwnsMany_First_GeneratesValidN1QL()
     {
-        using var ctx = CreateContextWithOwnsOne();
+        using var ctx = CreateContext();
         var sql = ctx.Customers.Where(c => c.CustomerId == 1).Take(1).AsQueryable().ToQueryString();
         Assert.DoesNotContain("cm0", sql);
         Assert.DoesNotContain("ct0", sql);
@@ -87,7 +62,7 @@ public class NestedOwnedSqlGenerationTests
             Assert.False(line.TrimStart() == ")", $"Stray ) found:\n{sql}");
     }
 
-    private static CustomerContext CreateContextWithOwnsOne()
+    private static CustomerContext CreateContext()
     {
         var clusterOptions = new global::Couchbase.ClusterOptions()
             .WithConnectionString("couchbase://localhost")

--- a/tests/Couchbase.EntityFrameworkCore.UnitTests/Couchbase/EntityFrameworkCore/Query/OwnedCollectionInjectionTests.cs
+++ b/tests/Couchbase.EntityFrameworkCore.UnitTests/Couchbase/EntityFrameworkCore/Query/OwnedCollectionInjectionTests.cs
@@ -44,10 +44,10 @@ public class NestedOwnedSqlGenerationTests
     {
         using var ctx = CreateContext();
         var sql = ctx.Customers.AsQueryable().ToQueryString();
-        Assert.DoesNotContain("cm0", sql);
-        Assert.DoesNotContain("ct0", sql);
-        foreach (var line in sql.Split('\n'))
-            Assert.False(line.Trim() == ")", $"Stray ) found:\n{sql}");
+        // Owned types are embedded JSON — no JOIN should be emitted.
+        Assert.DoesNotContain("JOIN", sql, StringComparison.OrdinalIgnoreCase);
+        // Parentheses must be balanced (catches stray-paren regressions regardless of formatting).
+        Assert.Equal(sql.Count(c => c == '('), sql.Count(c => c == ')'));
     }
 
     // ---- First (subquery with LIMIT 1) ----
@@ -56,10 +56,8 @@ public class NestedOwnedSqlGenerationTests
     {
         using var ctx = CreateContext();
         var sql = ctx.Customers.Where(c => c.CustomerId == 1).Take(1).AsQueryable().ToQueryString();
-        Assert.DoesNotContain("cm0", sql);
-        Assert.DoesNotContain("ct0", sql);
-        foreach (var line in sql.Split('\n'))
-            Assert.False(line.Trim() == ")", $"Stray ) found:\n{sql}");
+        Assert.DoesNotContain("JOIN", sql, StringComparison.OrdinalIgnoreCase);
+        Assert.Equal(sql.Count(c => c == '('), sql.Count(c => c == ')'));
     }
 
     private static CustomerContext CreateContext()

--- a/tests/Couchbase.EntityFrameworkCore.UnitTests/Couchbase/EntityFrameworkCore/Query/OwnedCollectionInjectionTests.cs
+++ b/tests/Couchbase.EntityFrameworkCore.UnitTests/Couchbase/EntityFrameworkCore/Query/OwnedCollectionInjectionTests.cs
@@ -52,15 +52,6 @@ public class NestedOwnedSqlGenerationTests
                 $"Stray closing paren found in N1QL:\n{sql}");
     }
 
-    [Fact]
-    public void NestedOwnsMany_ToList_CaptureSQL()
-    {
-        using var ctx = CreateContext();
-        var sql = ctx.Customers.AsQueryable().ToQueryString();
-        // Output the SQL so it appears in the test runner log
-        Assert.NotNull(sql);
-        _ = sql; // set breakpoint here to inspect
-    }
 
     private static CustomerContext CreateContext()
     {

--- a/tests/Couchbase.EntityFrameworkCore.UnitTests/Couchbase/EntityFrameworkCore/Query/OwnedCollectionInjectionTests.cs
+++ b/tests/Couchbase.EntityFrameworkCore.UnitTests/Couchbase/EntityFrameworkCore/Query/OwnedCollectionInjectionTests.cs
@@ -1,5 +1,6 @@
 using System.Text.Json;
 using Couchbase.EntityFrameworkCore.Extensions;
+using Microsoft.EntityFrameworkCore;
 using Xunit;
 
 namespace Couchbase.EntityFrameworkCore.UnitTests.Couchbase.EntityFrameworkCore.Query;
@@ -32,5 +33,120 @@ public class CouchbaseQueryEnumerableTests
         var found = doc.RootElement.TryGetPropertyCI("anything", out var val);
         Assert.False(found);
         Assert.Equal(JsonValueKind.Undefined, val.ValueKind);
+    }
+}
+
+public class NestedOwnedSqlGenerationTests
+{
+    [Fact]
+    public void NestedOwnsMany_ToList_GeneratesValidN1QL()
+    {
+        using var ctx = CreateContext();
+        var sql = ctx.Customers.AsQueryable().ToQueryString();
+        // Must not contain aliases from skipped owned JOINs
+        Assert.DoesNotContain("cm0", sql);
+        Assert.DoesNotContain("ct0", sql);
+        // Must not have a stray closing paren at start of a line
+        foreach (var line in sql.Split('\n'))
+            Assert.False(line.TrimStart().StartsWith(")") && line.Trim().Length == 1,
+                $"Stray closing paren found in N1QL:\n{sql}");
+    }
+
+    [Fact]
+    public void NestedOwnsMany_ToList_CaptureSQL()
+    {
+        using var ctx = CreateContext();
+        var sql = ctx.Customers.AsQueryable().ToQueryString();
+        // Output the SQL so it appears in the test runner log
+        Assert.NotNull(sql);
+        _ = sql; // set breakpoint here to inspect
+    }
+
+    private static CustomerContext CreateContext()
+    {
+        var clusterOptions = new global::Couchbase.ClusterOptions()
+            .WithConnectionString("couchbase://localhost")
+            .WithPasswordAuthentication("Administrator", "password");
+        var builder = new Microsoft.EntityFrameworkCore.DbContextOptionsBuilder<CustomerContext>();
+        builder.UseCouchbaseProvider(clusterOptions);
+        return new CustomerContext(builder.Options);
+    }
+
+    // ---- ToList (no subquery) ----
+    [Fact]
+    public void NestedOwnsMany_WithOwnsOneRoot_ToList_GeneratesValidN1QL()
+    {
+        using var ctx = CreateContextWithOwnsOne();
+        var sql = ctx.Customers.AsQueryable().ToQueryString();
+        Assert.DoesNotContain("cm0", sql);
+        Assert.DoesNotContain("ct0", sql);
+        foreach (var line in sql.Split('\n'))
+            Assert.False(line.TrimStart() == ")", $"Stray ) found:\n{sql}");
+    }
+
+    // ---- First (subquery with LIMIT 1) ----
+    [Fact]
+    public void NestedOwnsMany_WithOwnsOneRoot_First_GeneratesValidN1QL()
+    {
+        using var ctx = CreateContextWithOwnsOne();
+        var sql = ctx.Customers.Where(c => c.CustomerId == 1).Take(1).AsQueryable().ToQueryString();
+        Assert.DoesNotContain("cm0", sql);
+        Assert.DoesNotContain("ct0", sql);
+        foreach (var line in sql.Split('\n'))
+            Assert.False(line.TrimStart() == ")", $"Stray ) found:\n{sql}");
+    }
+
+    private static CustomerContext CreateContextWithOwnsOne()
+    {
+        var clusterOptions = new global::Couchbase.ClusterOptions()
+            .WithConnectionString("couchbase://localhost")
+            .WithPasswordAuthentication("Administrator", "password");
+        var builder = new Microsoft.EntityFrameworkCore.DbContextOptionsBuilder<CustomerContext>();
+        builder.UseCouchbaseProvider(clusterOptions);
+        return new CustomerContext(builder.Options);
+    }
+
+    private class Customer
+    {
+        public int CustomerId { get; set; }
+        public string Name { get; set; } = "";
+        public Address Address { get; set; } = new();
+        public List<ContactMethod> ContactMethods { get; set; } = [];
+    }
+    private class Address { public string? Street { get; set; } public string? City { get; set; } }
+    private class ContactMethod
+    {
+        public int Id { get; set; }
+        public string Type { get; set; } = "";
+        public ContactLabel? Label { get; set; }
+        public List<ContactTag> Tags { get; set; } = [];
+    }
+    private class ContactLabel { public string? DisplayName { get; set; } }
+    private class ContactTag
+    {
+        public int Id { get; set; }
+        public string Key { get; set; } = "";
+        public string Val { get; set; } = "";
+    }
+
+    private class CustomerContext(Microsoft.EntityFrameworkCore.DbContextOptions<CustomerContext> options)
+        : Microsoft.EntityFrameworkCore.DbContext(options)
+    {
+        public Microsoft.EntityFrameworkCore.DbSet<Customer> Customers { get; set; } = null!;
+        protected override void OnModelCreating(Microsoft.EntityFrameworkCore.ModelBuilder modelBuilder)
+        {
+            modelBuilder.Entity<Customer>(b =>
+            {
+                b.ToCouchbaseCollection("bucket", "scope", "customer");
+                b.HasKey(c => c.CustomerId);
+                b.OwnsOne(c => c.Address);
+                b.OwnsMany(c => c.ContactMethods, cm =>
+                {
+                    cm.HasKey(m => m.Id);
+                    cm.OwnsOne(m => m.Label);
+                    cm.OwnsMany(m => m.Tags, t => t.HasKey(tg => tg.Id));
+                });
+            });
+        }
     }
 }

--- a/tests/Couchbase.EntityFrameworkCore.UnitTests/Couchbase/EntityFrameworkCore/Query/OwnedCollectionInjectionTests.cs
+++ b/tests/Couchbase.EntityFrameworkCore.UnitTests/Couchbase/EntityFrameworkCore/Query/OwnedCollectionInjectionTests.cs
@@ -47,7 +47,7 @@ public class NestedOwnedSqlGenerationTests
         Assert.DoesNotContain("cm0", sql);
         Assert.DoesNotContain("ct0", sql);
         foreach (var line in sql.Split('\n'))
-            Assert.False(line.TrimStart() == ")", $"Stray ) found:\n{sql}");
+            Assert.False(line.Trim() == ")", $"Stray ) found:\n{sql}");
     }
 
     // ---- First (subquery with LIMIT 1) ----
@@ -59,7 +59,7 @@ public class NestedOwnedSqlGenerationTests
         Assert.DoesNotContain("cm0", sql);
         Assert.DoesNotContain("ct0", sql);
         foreach (var line in sql.Split('\n'))
-            Assert.False(line.TrimStart() == ")", $"Stray ) found:\n{sql}");
+            Assert.False(line.Trim() == ")", $"Stray ) found:\n{sql}");
     }
 
     private static CustomerContext CreateContext()

--- a/tests/Couchbase.EntityFrameworkCore.UnitTests/Couchbase/EntityFrameworkCore/Query/OwnedCollectionInjectionTests.cs
+++ b/tests/Couchbase.EntityFrameworkCore.UnitTests/Couchbase/EntityFrameworkCore/Query/OwnedCollectionInjectionTests.cs
@@ -1,9 +1,103 @@
+using System.Collections;
+using System.Collections.ObjectModel;
 using System.Text.Json;
 using Couchbase.EntityFrameworkCore.Extensions;
 using Microsoft.EntityFrameworkCore;
 using Xunit;
 
 namespace Couchbase.EntityFrameworkCore.UnitTests.Couchbase.EntityFrameworkCore.Query;
+
+/// <summary>
+/// Unit tests for the owned-collection clear logic in MaterializeOwnedItem.
+/// These tests verify that the IList fast-path and the ICollection&lt;T&gt; fallback
+/// both empty the collection correctly for all common mutable collection types.
+/// </summary>
+public class OwnedCollectionClearTests
+{
+    // ---------------------------------------------------------------------------
+    // Helper — mirrors the exact clearing logic in MaterializeOwnedItem
+    // ---------------------------------------------------------------------------
+    private static void ClearOwnedCollection(object coll, Type elementType)
+    {
+        if (coll is IList list)
+            list.Clear();
+        else if (coll != null)
+            typeof(ICollection<>).MakeGenericType(elementType)
+                .GetMethod("Clear")!
+                .Invoke(coll, null);
+    }
+
+    // ---------------------------------------------------------------------------
+    // IList fast-path  (List<T>, ObservableCollection<T>, BindingList<T> …)
+    // ---------------------------------------------------------------------------
+
+    [Fact]
+    public void Clear_ListOfT_Empties()
+    {
+        var col = new List<string> { "a", "b", "c" };
+        ClearOwnedCollection(col, typeof(string));
+        Assert.Empty(col);
+    }
+
+    [Fact]
+    public void Clear_ObservableCollection_Empties()
+    {
+        var col = new ObservableCollection<string> { "x", "y" };
+        ClearOwnedCollection(col, typeof(string));
+        Assert.Empty(col);
+    }
+
+    // ---------------------------------------------------------------------------
+    // ICollection<T> fallback  (HashSet<T>, SortedSet<T> …)
+    // ---------------------------------------------------------------------------
+
+    [Fact]
+    public void Clear_HashSetOfT_Empties()
+    {
+        var col = new HashSet<string> { "a", "b", "c" };
+        ClearOwnedCollection(col, typeof(string));
+        Assert.Empty(col);
+    }
+
+    [Fact]
+    public void Clear_SortedSetOfT_Empties()
+    {
+        var col = new SortedSet<string> { "alpha", "beta", "gamma" };
+        ClearOwnedCollection(col, typeof(string));
+        Assert.Empty(col);
+    }
+
+    // ---------------------------------------------------------------------------
+    // Already-empty collections — must not throw
+    // ---------------------------------------------------------------------------
+
+    [Fact]
+    public void Clear_EmptyList_DoesNotThrow()
+    {
+        var col = new List<int>();
+        var ex = Record.Exception(() => ClearOwnedCollection(col, typeof(int)));
+        Assert.Null(ex);
+    }
+
+    [Fact]
+    public void Clear_EmptyHashSet_DoesNotThrow()
+    {
+        var col = new HashSet<int>();
+        var ex = Record.Exception(() => ClearOwnedCollection(col, typeof(int)));
+        Assert.Null(ex);
+    }
+
+    // ---------------------------------------------------------------------------
+    // Null guard — must not throw
+    // ---------------------------------------------------------------------------
+
+    [Fact]
+    public void Clear_NullCollection_DoesNotThrow()
+    {
+        var ex = Record.Exception(() => ClearOwnedCollection(null!, typeof(string)));
+        Assert.Null(ex);
+    }
+}
 
 public class CouchbaseQueryEnumerableTests
 {


### PR DESCRIPTION
Completes Phase 4 of the Couchbase EF Core eager loading implementation.

Extracted a recursive MaterializeOwnedItem helper to correctly read OwnsOne/OwnsMany at arbitrary nesting depth from embedded JSON
Fixed SQL generation to skip lateral-join subqueries EF Core emits for nested owned navigations
Fixed the write-path ownership-chain walk to traverse all levels, preventing "Invalid keyspace format" errors on nested owned types
Added SerializeOwnedItem recursive helper for nested owned write serialisation
Fixed MaterializeOwnedItem to clear non-IList collections (e.g. HashSet<T>) via ICollection<T> before repopulation
Hardened assertions and fixed shadow-property / null-PropertyInfo edge cases
Added unit and integration test coverage for all of the above