### PR TITLE
CouchbaseQueryEnumerable refactor — Phases 1 & 2

### DIFF
--- a/src/Couchbase.EntityFrameworkCore/AssemblyInfo.cs
+++ b/src/Couchbase.EntityFrameworkCore/AssemblyInfo.cs
@@ -1,7 +1,5 @@
 using System.Runtime.CompilerServices;
 
-#if DEBUG
 [assembly: InternalsVisibleTo("Couchbase.EntityFrameworkCore.FunctionalTests")]
 [assembly: InternalsVisibleTo("Couchbase.EntityFrameworkCore.UnitTests")]
 [assembly: InternalsVisibleTo("Couchbase.EntityFrameworkCore.IntegrationTests")]
-#endif

--- a/src/Couchbase.EntityFrameworkCore/Query/Internal/CouchbaseCollectionSnapshot.cs
+++ b/src/Couchbase.EntityFrameworkCore/Query/Internal/CouchbaseCollectionSnapshot.cs
@@ -1,0 +1,94 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections;
+using Microsoft.EntityFrameworkCore.Metadata;
+
+namespace Couchbase.EntityFrameworkCore.Query.Internal;
+
+/// <summary>
+/// Records the original collection-object reference and per-item property value snapshots
+/// for every OwnsMany navigation on a freshly materialised entity, so that
+/// <c>CouchbaseSaveChangesInterceptor</c> can detect mutations at <c>SaveChanges</c> time.
+/// <para>
+/// Two kinds of change are tracked:
+/// <list type="bullet">
+///   <item><description>
+///     <b>Reference replacement</b> — <c>customer.ContactMethods = []</c> — detected by
+///     comparing the current collection object reference against the snapshotted one.
+///   </description></item>
+///   <item><description>
+///     <b>In-place mutation</b> — <c>.Add()</c>, <c>.Remove()</c>, or scalar property
+///     change — detected by comparing per-item property values against snapshotted ones.
+///   </description></item>
+/// </list>
+/// </para>
+/// <para>
+/// The underlying storage (<see cref="OwnedCollectionSnapshot.OriginalRefs"/> /
+/// <see cref="OwnedCollectionSnapshot.OriginalItems"/>) uses
+/// <see cref="System.Runtime.CompilerServices.ConditionalWeakTable{TKey,TValue}"/> so
+/// entities that fall out of scope are GC'd without manual cleanup.
+/// </para>
+/// <para>
+/// This class extracted from <c>CouchbaseQueryEnumerable&lt;T&gt;.SnapshotCollectionRefs</c>
+/// so it can be unit-tested independently and reused from other materialisation paths
+/// (e.g. <c>Find</c>, <c>FromSqlRaw</c>) in the future.
+/// </para>
+/// </summary>
+internal sealed class CouchbaseCollectionSnapshot
+{
+    /// <summary>
+    /// Records the current state of every OwnsMany navigation in
+    /// <paramref name="ownedCollections"/> on <paramref name="entity"/>.
+    /// </summary>
+    /// <param name="entity">The freshly materialised root entity.</param>
+    /// <param name="ownedCollections">The owned-collection navigations to snapshot.</param>
+    /// <param name="isTracking">
+    /// <see langword="true"/> for <c>TrackAll</c> queries; <see langword="false"/> for
+    /// <c>NoTracking</c> / <c>NoTrackingWithIdentityResolution</c>. Snapshots are skipped
+    /// for non-tracking queries because the interceptor walks <c>ChangeTracker.Entries()</c>
+    /// and would never consume them.
+    /// </param>
+    public void Record<T>(T entity, IReadOnlyList<INavigation> ownedCollections, bool isTracking)
+    {
+        if (entity == null || !isTracking) return;
+
+        var refs  = OwnedCollectionSnapshot.OriginalRefs.GetOrCreateValue(entity);
+        var items = OwnedCollectionSnapshot.OriginalItems.GetOrCreateValue(entity);
+
+        foreach (var nav in ownedCollections)
+        {
+            var currentCollection = nav.PropertyInfo?.GetValue(entity);
+            refs[nav.Name] = currentCollection;
+
+            // Snapshot per-item property values so in-place mutations can be detected
+            // even when the list reference is unchanged.
+            if (currentCollection is IEnumerable collection)
+            {
+                var itemProps  = OwnedCollectionSnapshot.GetTrackedProperties(nav);
+                var snapshot   = new List<Dictionary<string, object?>>();
+
+                foreach (var item in collection)
+                {
+                    if (item == null) continue;
+                    var propSnapshot = new Dictionary<string, object?>();
+                    foreach (var prop in itemProps)
+                    {
+                        var raw = prop.PropertyInfo?.GetValue(item);
+                        // Use EF Core's ValueComparer.Snapshot so mutable reference types
+                        // (e.g. byte[]) are deep-copied; for immutable types it is a no-op.
+                        propSnapshot[prop.Name] = raw is null
+                            ? null
+                            : OwnedCollectionSnapshot.GetComparer(prop).Snapshot(raw);
+                    }
+                    snapshot.Add(propSnapshot);
+                }
+                items[nav.Name] = snapshot;
+            }
+            else
+            {
+                items[nav.Name] = [];
+            }
+        }
+    }
+}

--- a/src/Couchbase.EntityFrameworkCore/Query/Internal/CouchbaseCollectionSnapshot.cs
+++ b/src/Couchbase.EntityFrameworkCore/Query/Internal/CouchbaseCollectionSnapshot.cs
@@ -58,7 +58,9 @@ internal sealed class CouchbaseCollectionSnapshot
 
         foreach (var nav in ownedCollections)
         {
-            var currentCollection = nav.PropertyInfo?.GetValue(entity);
+            var currentCollection = nav.PropertyInfo != null
+                ? nav.PropertyInfo.GetValue(entity)
+                : nav.FieldInfo?.GetValue(entity);
             refs[nav.Name] = currentCollection;
 
             // Snapshot per-item property values so in-place mutations can be detected

--- a/src/Couchbase.EntityFrameworkCore/Query/Internal/CouchbaseCollectionSnapshot.cs
+++ b/src/Couchbase.EntityFrameworkCore/Query/Internal/CouchbaseCollectionSnapshot.cs
@@ -76,7 +76,9 @@ internal sealed class CouchbaseCollectionSnapshot
                     var propSnapshot = new Dictionary<string, object?>();
                     foreach (var prop in itemProps)
                     {
-                        var raw = prop.PropertyInfo?.GetValue(item);
+                        var raw = prop.PropertyInfo != null
+                        ? prop.PropertyInfo.GetValue(item)
+                        : prop.FieldInfo?.GetValue(item);
                         // Use EF Core's ValueComparer.Snapshot so mutable reference types
                         // (e.g. byte[]) are deep-copied; for immutable types it is a no-op.
                         propSnapshot[prop.Name] = raw is null

--- a/src/Couchbase.EntityFrameworkCore/Query/Internal/CouchbaseCollectionSnapshot.cs
+++ b/src/Couchbase.EntityFrameworkCore/Query/Internal/CouchbaseCollectionSnapshot.cs
@@ -51,7 +51,7 @@ internal sealed class CouchbaseCollectionSnapshot
     /// </param>
     public void Record<T>(T entity, IReadOnlyList<INavigation> ownedCollections, bool isTracking)
     {
-        if (entity == null || !isTracking) return;
+        if (entity is null || !isTracking) return;
 
         var refs  = OwnedCollectionSnapshot.OriginalRefs.GetOrCreateValue(entity);
         var items = OwnedCollectionSnapshot.OriginalItems.GetOrCreateValue(entity);

--- a/src/Couchbase.EntityFrameworkCore/Query/Internal/CouchbaseOwnedCollectionMaterializer.cs
+++ b/src/Couchbase.EntityFrameworkCore/Query/Internal/CouchbaseOwnedCollectionMaterializer.cs
@@ -1,0 +1,220 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections;
+using System.Text.Json;
+using Couchbase.EntityFrameworkCore.Extensions;
+using Microsoft.EntityFrameworkCore.Metadata;
+
+namespace Couchbase.EntityFrameworkCore.Query.Internal;
+
+/// <summary>
+/// Populates owned-collection navigations on a freshly materialised entity from the
+/// embedded JSON arrays that arrive inline in a Couchbase N1QL result row.
+/// <para>
+/// This class owns three concerns that previously lived in
+/// <see cref="CouchbaseQueryEnumerable{T}"/>:
+/// <list type="bullet">
+///   <item><description>
+///     <see cref="Populate{T}"/> — iterates every OwnsMany navigation on the root entity
+///     and delegates to <see cref="MaterializeOwnedItem"/> for each array element.
+///   </description></item>
+///   <item><description>
+///     <see cref="MaterializeOwnedItem"/> — recursively materialises a single owned entity
+///     at any nesting depth (OwnsOne-within-OwnsMany, OwnsMany-within-OwnsMany, etc.).
+///   </description></item>
+///   <item><description>
+///     <see cref="ConvertJsonValue"/> — maps a <see cref="JsonElement"/> to a CLR scalar
+///     value, respecting nullability and common primitive types.
+///   </description></item>
+/// </list>
+/// </para>
+/// </summary>
+internal sealed class CouchbaseOwnedCollectionMaterializer
+{
+    private static readonly JsonSerializerOptions _defaultSerializerOptions =
+        new(JsonSerializerDefaults.Web);
+
+    // ---------------------------------------------------------------------------
+    // Public entry point
+    // ---------------------------------------------------------------------------
+
+    /// <summary>
+    /// Populates every OwnsMany navigation in <paramref name="ownedCollections"/> on
+    /// <paramref name="entity"/> from the corresponding JSON array in
+    /// <paramref name="docElement"/>.
+    /// </summary>
+    public void Populate<T>(
+        T entity,
+        JsonElement docElement,
+        IReadOnlyList<INavigation> ownedCollections,
+        JsonNamingPolicy? fieldNamingPolicy,
+        JsonSerializerOptions? serializerOptions)
+    {
+        var options = serializerOptions ?? _defaultSerializerOptions;
+        foreach (var nav in ownedCollections)
+        {
+            var fieldName = fieldNamingPolicy?.ConvertName(nav.Name) ?? nav.Name;
+            if (!docElement.TryGetPropertyCI(fieldName, out var arrayElement)
+                || arrayElement.ValueKind != JsonValueKind.Array)
+                continue;
+
+            var accessor = nav.GetCollectionAccessor();
+            var clrType  = nav.TargetEntityType.ClrType;
+
+            if (accessor != null)
+            {
+                // Clear any items the EF Core shaper may have pre-populated from the
+                // injected OwnsMany column (observed with AsNoTracking queries).
+                // We are the authoritative source for owned-collection data; clearing
+                // before adding prevents duplicates.
+                // Use IList fast-path; fall back to ICollection<T> so that non-IList
+                // types (HashSet<T>, SortedSet<T>, etc.) are also emptied correctly.
+                var coll = accessor.GetOrCreate(entity!, forMaterialization: true);
+                if (coll is IList listColl)
+                    listColl.Clear();
+                else if (coll != null)
+                    typeof(ICollection<>).MakeGenericType(clrType)
+                        .GetMethod("Clear")!
+                        .Invoke(coll, null);
+            }
+            else
+            {
+                var list = (IList)Activator.CreateInstance(typeof(List<>).MakeGenericType(clrType))!;
+                nav.PropertyInfo?.SetValue(entity, list);
+            }
+
+            foreach (var itemElement in arrayElement.EnumerateArray())
+            {
+                var ownedEntity = MaterializeOwnedItem(itemElement, nav.TargetEntityType, fieldNamingPolicy, options);
+                if (accessor != null)
+                    accessor.Add(entity!, ownedEntity, forMaterialization: true);
+                else
+                    ((IList)nav.PropertyInfo!.GetValue(entity)!).Add(ownedEntity);
+            }
+        }
+    }
+
+    // ---------------------------------------------------------------------------
+    // Recursive owned-item materialiser
+    // ---------------------------------------------------------------------------
+
+    /// <summary>
+    /// Materialises a single owned entity from a <see cref="JsonElement"/> by setting its
+    /// scalar properties and recursively populating any nested owned navigations
+    /// (OwnsOne / OwnsMany at any depth).
+    /// </summary>
+    /// <remarks>
+    /// Exposed as <c>internal static</c> so unit tests can call it directly without
+    /// constructing a full materialiser instance.
+    /// </remarks>
+    internal static object MaterializeOwnedItem(
+        JsonElement itemElement,
+        IEntityType entityType,
+        JsonNamingPolicy? fieldNamingPolicy,
+        JsonSerializerOptions options)
+    {
+        var ownedEntity = Activator.CreateInstance(entityType.ClrType)!;
+
+        // Scalar properties
+        foreach (var prop in entityType.GetProperties())
+        {
+            if (prop.IsShadowProperty()) continue;
+            var jsonKey = fieldNamingPolicy?.ConvertName(prop.Name) ?? prop.Name;
+            if (itemElement.TryGetPropertyCI(jsonKey, out var propElement))
+                prop.PropertyInfo?.SetValue(ownedEntity, ConvertJsonValue(propElement, prop.ClrType, options));
+        }
+
+        // Nested owned navigations
+        foreach (var ownedNav in entityType.GetNavigations())
+        {
+            if (!ownedNav.TargetEntityType.IsOwned()) continue;
+            var fieldName = fieldNamingPolicy?.ConvertName(ownedNav.Name) ?? ownedNav.Name;
+            if (!itemElement.TryGetPropertyCI(fieldName, out var nestedElement)) continue;
+
+            if (ownedNav.IsCollection)
+            {
+                if (nestedElement.ValueKind != JsonValueKind.Array) continue;
+                var accessor = ownedNav.GetCollectionAccessor();
+                // Skip navigations with no accessor and no PropertyInfo — nothing to set.
+                if (accessor == null && ownedNav.PropertyInfo == null) continue;
+                var nestedClrType = ownedNav.TargetEntityType.ClrType;
+                if (accessor != null)
+                {
+                    var coll = accessor.GetOrCreate(ownedEntity, forMaterialization: true);
+                    // Clear via IList for the common List<T> case; otherwise cast through
+                    // ICollection<T> which every mutable .NET collection implements and
+                    // guarantees Clear() — correctly handles HashSet<T>, SortedSet<T>, etc.
+                    if (coll is IList list)
+                        list.Clear();
+                    else if (coll != null)
+                        typeof(ICollection<>).MakeGenericType(nestedClrType)
+                            .GetMethod("Clear")!
+                            .Invoke(coll, null);
+                }
+                else
+                {
+                    var list = (IList)Activator.CreateInstance(typeof(List<>).MakeGenericType(nestedClrType))!;
+                    ownedNav.PropertyInfo!.SetValue(ownedEntity, list);
+                }
+                foreach (var nestedItemElement in nestedElement.EnumerateArray())
+                {
+                    var nestedEntity = MaterializeOwnedItem(nestedItemElement, ownedNav.TargetEntityType, fieldNamingPolicy, options);
+                    if (accessor != null)
+                        accessor.Add(ownedEntity, nestedEntity, forMaterialization: true);
+                    else
+                    {
+                        // PropertyInfo is guaranteed non-null here: we skipped above when both
+                        // accessor and PropertyInfo are null, and accessor is null in this branch.
+                        var existingList = (IList)ownedNav.PropertyInfo!.GetValue(ownedEntity)!;
+                        existingList.Add(nestedEntity);
+                    }
+                }
+            }
+            else
+            {
+                if (nestedElement.ValueKind != JsonValueKind.Object) continue;
+                // Skip shadow/field-only navigations — no PropertyInfo means nowhere to assign.
+                if (ownedNav.PropertyInfo == null) continue;
+                var nestedEntity = MaterializeOwnedItem(nestedElement, ownedNav.TargetEntityType, fieldNamingPolicy, options);
+                ownedNav.PropertyInfo.SetValue(ownedEntity, nestedEntity);
+            }
+        }
+
+        return ownedEntity;
+    }
+
+    // ---------------------------------------------------------------------------
+    // JSON → CLR type conversion
+    // ---------------------------------------------------------------------------
+
+    /// <summary>
+    /// Converts a <see cref="JsonElement"/> to the requested CLR <paramref name="targetType"/>.
+    /// Handles nullable wrappers, common primitives, and falls back to
+    /// <see cref="JsonSerializer.Deserialize"/> for unknown types.
+    /// </summary>
+    /// <remarks>
+    /// Exposed as <c>internal static</c> for unit testing.
+    /// Note (Phase 3): this will be replaced by a lookup into
+    /// <c>IProperty.FindTypeMapping()?.JsonValueReaderWriter</c> / <c>IProperty.GetValueConverter()</c>
+    /// so that EF Core value converters and custom type mappings are respected.
+    /// </remarks>
+    internal static object? ConvertJsonValue(JsonElement element, Type targetType, JsonSerializerOptions options)
+    {
+        if (element.ValueKind == JsonValueKind.Null) return null;
+        var t = Nullable.GetUnderlyingType(targetType) ?? targetType;
+        return t switch
+        {
+            _ when t == typeof(string)   => element.GetString(),
+            _ when t == typeof(int)      => element.GetInt32(),
+            _ when t == typeof(long)     => element.GetInt64(),
+            _ when t == typeof(double)   => element.GetDouble(),
+            _ when t == typeof(decimal)  => element.GetDecimal(),
+            _ when t == typeof(float)    => (float)element.GetDouble(),
+            _ when t == typeof(bool)     => element.GetBoolean(),
+            _ when t == typeof(Guid)     => element.GetGuid(),
+            _ when t == typeof(DateTime) => element.GetDateTime(),
+            _ => JsonSerializer.Deserialize(element.GetRawText(), t, options)
+        };
+    }
+}

--- a/src/Couchbase.EntityFrameworkCore/Query/Internal/CouchbaseOwnedCollectionMaterializer.cs
+++ b/src/Couchbase.EntityFrameworkCore/Query/Internal/CouchbaseOwnedCollectionMaterializer.cs
@@ -81,7 +81,12 @@ internal sealed class CouchbaseOwnedCollectionMaterializer
             else
             {
                 var list = (IList)Activator.CreateInstance(typeof(List<>).MakeGenericType(clrType))!;
-                nav.PropertyInfo?.SetValue(entity, list);
+                // Use the property setter when one exists; fall back to FieldInfo for
+                // backing-field navigations where PropertyInfo is null or has no setter.
+                if (nav.PropertyInfo?.GetSetMethod(nonPublic: true) != null)
+                    nav.PropertyInfo.SetValue(entity, list);
+                else if (nav.FieldInfo != null)
+                    nav.FieldInfo.SetValue(entity, list);
             }
 
             foreach (var itemElement in arrayElement.EnumerateArray())
@@ -90,7 +95,13 @@ internal sealed class CouchbaseOwnedCollectionMaterializer
                 if (accessor != null)
                     accessor.Add(entity!, ownedEntity, forMaterialization: true);
                 else
-                    ((IList)nav.PropertyInfo!.GetValue(entity)!).Add(ownedEntity);
+                {
+                    // Read the list back via the same PropertyInfo → FieldInfo fallback.
+                    var existingList = (IList?)(nav.PropertyInfo != null
+                        ? nav.PropertyInfo.GetValue(entity)
+                        : nav.FieldInfo?.GetValue(entity));
+                    existingList?.Add(ownedEntity);
+                }
             }
         }
     }

--- a/src/Couchbase.EntityFrameworkCore/Query/Internal/CouchbaseOwnedCollectionMaterializer.cs
+++ b/src/Couchbase.EntityFrameworkCore/Query/Internal/CouchbaseOwnedCollectionMaterializer.cs
@@ -214,7 +214,7 @@ internal sealed class CouchbaseOwnedCollectionMaterializer
             _ when t == typeof(bool)     => element.GetBoolean(),
             _ when t == typeof(Guid)     => element.GetGuid(),
             _ when t == typeof(DateTime) => element.GetDateTime(),
-            _ => JsonSerializer.Deserialize(element.GetRawText(), t, options)
+            _ => JsonSerializer.Deserialize(element, t, options)
         };
     }
 }

--- a/src/Couchbase.EntityFrameworkCore/Query/Internal/CouchbaseOwnedCollectionMaterializer.cs
+++ b/src/Couchbase.EntityFrameworkCore/Query/Internal/CouchbaseOwnedCollectionMaterializer.cs
@@ -156,8 +156,8 @@ internal sealed class CouchbaseOwnedCollectionMaterializer
             {
                 if (nestedElement.ValueKind != JsonValueKind.Array) continue;
                 var accessor = ownedNav.GetCollectionAccessor();
-                // Skip navigations with no accessor and no PropertyInfo — nothing to set.
-                if (accessor == null && ownedNav.PropertyInfo == null) continue;
+                // Skip navigations with no accessor and no way to assign — nothing to set.
+                if (accessor == null && ownedNav.PropertyInfo == null && ownedNav.FieldInfo == null) continue;
                 var nestedClrType = ownedNav.TargetEntityType.ClrType;
                 if (accessor != null)
                 {
@@ -175,7 +175,12 @@ internal sealed class CouchbaseOwnedCollectionMaterializer
                 else
                 {
                     var list = (IList)Activator.CreateInstance(typeof(List<>).MakeGenericType(nestedClrType))!;
-                    ownedNav.PropertyInfo!.SetValue(ownedEntity, list);
+                    // Use the property setter when one exists; fall back to FieldInfo for
+                    // backing-field navigations where PropertyInfo is null or has no setter.
+                    if (ownedNav.PropertyInfo?.GetSetMethod(nonPublic: true) != null)
+                        ownedNav.PropertyInfo.SetValue(ownedEntity, list);
+                    else if (ownedNav.FieldInfo != null)
+                        ownedNav.FieldInfo.SetValue(ownedEntity, list);
                 }
                 foreach (var nestedItemElement in nestedElement.EnumerateArray())
                 {
@@ -184,20 +189,25 @@ internal sealed class CouchbaseOwnedCollectionMaterializer
                         accessor.Add(ownedEntity, nestedEntity, forMaterialization: true);
                     else
                     {
-                        // PropertyInfo is guaranteed non-null here: we skipped above when both
-                        // accessor and PropertyInfo are null, and accessor is null in this branch.
-                        var existingList = (IList)ownedNav.PropertyInfo!.GetValue(ownedEntity)!;
-                        existingList.Add(nestedEntity);
+                        // Read back via the same PropertyInfo → FieldInfo fallback.
+                        var existingList = (IList?)(ownedNav.PropertyInfo != null
+                            ? ownedNav.PropertyInfo.GetValue(ownedEntity)
+                            : ownedNav.FieldInfo?.GetValue(ownedEntity));
+                        existingList?.Add(nestedEntity);
                     }
                 }
             }
             else
             {
                 if (nestedElement.ValueKind != JsonValueKind.Object) continue;
-                // Skip shadow/field-only navigations — no PropertyInfo means nowhere to assign.
-                if (ownedNav.PropertyInfo == null) continue;
+                // Skip navigations with no way to assign.
+                if (ownedNav.PropertyInfo == null && ownedNav.FieldInfo == null) continue;
                 var nestedEntity = MaterializeOwnedItem(nestedElement, ownedNav.TargetEntityType, fieldNamingPolicy, options);
-                ownedNav.PropertyInfo.SetValue(ownedEntity, nestedEntity);
+                // Use property setter when available; fall back to FieldInfo.
+                if (ownedNav.PropertyInfo?.GetSetMethod(nonPublic: true) != null)
+                    ownedNav.PropertyInfo.SetValue(ownedEntity, nestedEntity);
+                else if (ownedNav.FieldInfo != null)
+                    ownedNav.FieldInfo.SetValue(ownedEntity, nestedEntity);
             }
         }
 

--- a/src/Couchbase.EntityFrameworkCore/Query/Internal/CouchbaseOwnedCollectionMaterializer.cs
+++ b/src/Couchbase.EntityFrameworkCore/Query/Internal/CouchbaseOwnedCollectionMaterializer.cs
@@ -122,7 +122,16 @@ internal sealed class CouchbaseOwnedCollectionMaterializer
             if (prop.IsShadowProperty()) continue;
             var jsonKey = fieldNamingPolicy?.ConvertName(prop.Name) ?? prop.Name;
             if (itemElement.TryGetPropertyCI(jsonKey, out var propElement))
-                prop.PropertyInfo?.SetValue(ownedEntity, ConvertJsonValue(propElement, prop.ClrType, options));
+            {
+                var converted = ConvertJsonValue(propElement, prop.ClrType, options);
+                // Use the property setter when one exists (public or non-public).
+                // Fall back to FieldInfo for backing-field / field-access properties where
+                // PropertyInfo is null or has no setter (e.g. init-only / get-only).
+                if (prop.PropertyInfo?.GetSetMethod(nonPublic: true) != null)
+                    prop.PropertyInfo.SetValue(ownedEntity, converted);
+                else if (prop.FieldInfo != null)
+                    prop.FieldInfo.SetValue(ownedEntity, converted);
+            }
         }
 
         // Nested owned navigations

--- a/src/Couchbase.EntityFrameworkCore/Query/Internal/CouchbaseQueryEnumerable.cs
+++ b/src/Couchbase.EntityFrameworkCore/Query/Internal/CouchbaseQueryEnumerable.cs
@@ -71,6 +71,7 @@ public class CouchbaseQueryEnumerable<T> : IEnumerable<T>, IAsyncEnumerable<T>, 
     private readonly IBucketProvider _bucketProvider;
     private readonly DbContext _dbContext;
     private readonly IReadOnlyList<INavigation> _ownedCollectionNavigations;
+    private readonly CouchbaseOwnedCollectionMaterializer _materializer = new();
 
     public CouchbaseQueryEnumerable(
         RelationalQueryContext relationalQueryContext,
@@ -190,7 +191,7 @@ public class CouchbaseQueryEnumerable<T> : IEnumerable<T>, IAsyncEnumerable<T>, 
                     && navRow is JsonElement rowElement
                     && rowElement.ValueKind == JsonValueKind.Object)
                 {
-                    PopulateCollectionNavigations(result, rowElement, _ownedCollectionNavigations, _couchbaseDbContextOptionsBuilder.FieldNamingPolicy, _couchbaseDbContextOptionsBuilder.SerializerOptions);
+                    _materializer.Populate(result, rowElement, _ownedCollectionNavigations, _couchbaseDbContextOptionsBuilder.FieldNamingPolicy, _couchbaseDbContextOptionsBuilder.SerializerOptions);
                     SnapshotCollectionRefs(result);
                 }
                 pendingEntityRow = null;
@@ -222,7 +223,7 @@ public class CouchbaseQueryEnumerable<T> : IEnumerable<T>, IAsyncEnumerable<T>, 
                         && pendingEntityRow is JsonElement lastRow
                         && lastRow.ValueKind == JsonValueKind.Object)
                     {
-                        PopulateCollectionNavigations(last, lastRow, _ownedCollectionNavigations, _couchbaseDbContextOptionsBuilder.FieldNamingPolicy, _couchbaseDbContextOptionsBuilder.SerializerOptions);
+                        _materializer.Populate(last, lastRow, _ownedCollectionNavigations, _couchbaseDbContextOptionsBuilder.FieldNamingPolicy, _couchbaseDbContextOptionsBuilder.SerializerOptions);
                         SnapshotCollectionRefs(last);
                     }
                     pendingEntityRow = null;
@@ -231,126 +232,6 @@ public class CouchbaseQueryEnumerable<T> : IEnumerable<T>, IAsyncEnumerable<T>, 
                 }
             }
         }
-    }
-
-    private static readonly JsonSerializerOptions _defaultSerializerOptions = new(JsonSerializerDefaults.Web);
-
-    private static void PopulateCollectionNavigations(T entity, JsonElement docElement, IReadOnlyList<INavigation> collections, JsonNamingPolicy? fieldNamingPolicy, JsonSerializerOptions? serializerOptions)
-    {
-        var options = serializerOptions ?? _defaultSerializerOptions;
-        foreach (var nav in collections)
-        {
-            var fieldName = fieldNamingPolicy?.ConvertName(nav.Name) ?? nav.Name;
-            if (!docElement.TryGetPropertyCI(fieldName, out var arrayElement)
-                || arrayElement.ValueKind != JsonValueKind.Array)
-                continue;
-
-            var accessor = nav.GetCollectionAccessor();
-            var clrType = nav.TargetEntityType.ClrType;
-
-            if (accessor != null)
-            {
-                // Clear any items the EF Core shaper may have pre-populated from the injected
-                // OwnsMany column (observed with AsNoTracking queries). We are the authoritative
-                // source for owned-collection data; clearing before adding prevents duplicates.
-                var coll = accessor.GetOrCreate(entity!, forMaterialization: true);
-                (coll as IList)?.Clear();
-            }
-            else
-            {
-                var list = (IList)Activator.CreateInstance(typeof(List<>).MakeGenericType(clrType))!;
-                nav.PropertyInfo?.SetValue(entity, list);
-            }
-
-            foreach (var itemElement in arrayElement.EnumerateArray())
-            {
-                var ownedEntity = MaterializeOwnedItem(itemElement, nav.TargetEntityType, fieldNamingPolicy, options);
-                if (accessor != null)
-                    accessor.Add(entity!, ownedEntity, forMaterialization: true);
-                else
-                    ((IList)nav.PropertyInfo!.GetValue(entity)!).Add(ownedEntity);
-            }
-        }
-    }
-
-    /// <summary>
-    /// Materialises a single owned entity from a <see cref="JsonElement"/> by setting its scalar
-    /// properties and recursively populating any nested owned navigations (OwnsOne / OwnsMany).
-    /// Called for every element of a top-level OwnsMany array, and recursively for nested owned
-    /// types within those elements.
-    /// </summary>
-    private static object MaterializeOwnedItem(
-        JsonElement itemElement,
-        IEntityType entityType,
-        JsonNamingPolicy? fieldNamingPolicy,
-        JsonSerializerOptions options)
-    {
-        var ownedEntity = Activator.CreateInstance(entityType.ClrType)!;
-
-        foreach (var prop in entityType.GetProperties())
-        {
-            if (prop.IsShadowProperty()) continue;
-            var jsonKey = fieldNamingPolicy?.ConvertName(prop.Name) ?? prop.Name;
-            if (itemElement.TryGetPropertyCI(jsonKey, out var propElement))
-                prop.PropertyInfo?.SetValue(ownedEntity, ConvertJsonValue(propElement, prop.ClrType, options));
-        }
-
-        foreach (var ownedNav in entityType.GetNavigations())
-        {
-            if (!ownedNav.TargetEntityType.IsOwned()) continue;
-            var fieldName = fieldNamingPolicy?.ConvertName(ownedNav.Name) ?? ownedNav.Name;
-            if (!itemElement.TryGetPropertyCI(fieldName, out var nestedElement)) continue;
-
-            if (ownedNav.IsCollection)
-            {
-                if (nestedElement.ValueKind != JsonValueKind.Array) continue;
-                var accessor = ownedNav.GetCollectionAccessor();
-                // Skip navigations with no accessor and no PropertyInfo — nothing to set.
-                if (accessor == null && ownedNav.PropertyInfo == null) continue;
-                var nestedClrType = ownedNav.TargetEntityType.ClrType;
-                if (accessor != null)
-                {
-                    var coll = accessor.GetOrCreate(ownedEntity, forMaterialization: true);
-                    // Clear via IList for the common List<T> case; otherwise cast through
-                    // ICollection<T> which every mutable .NET collection implements and which
-                    // guarantees Clear() — this correctly handles HashSet<T>, SortedSet<T>, etc.
-                    if (coll is IList list)
-                        list.Clear();
-                    else if (coll != null)
-                        typeof(ICollection<>).MakeGenericType(nestedClrType)
-                            .GetMethod("Clear")!
-                            .Invoke(coll, null);
-                }
-                else
-                {
-                    var list = (IList)Activator.CreateInstance(typeof(List<>).MakeGenericType(nestedClrType))!;
-                    ownedNav.PropertyInfo!.SetValue(ownedEntity, list);
-                }
-                foreach (var nestedItemElement in nestedElement.EnumerateArray())
-                {
-                    var nestedEntity = MaterializeOwnedItem(nestedItemElement, ownedNav.TargetEntityType, fieldNamingPolicy, options);
-                    if (accessor != null)
-                        accessor.Add(ownedEntity, nestedEntity, forMaterialization: true);
-                    else
-                    {
-                        // PropertyInfo is guaranteed non-null here: we skipped above when both
-                        // accessor and PropertyInfo are null, and accessor is null in this branch.
-                        var existingList = (IList)ownedNav.PropertyInfo!.GetValue(ownedEntity)!;
-                        existingList.Add(nestedEntity);
-                    }
-                }
-            }
-            else
-            {
-                if (nestedElement.ValueKind != JsonValueKind.Object) continue;
-                // Skip shadow/field-only navigations — no PropertyInfo means nowhere to assign.
-                if (ownedNav.PropertyInfo == null) continue;
-                var nestedEntity = MaterializeOwnedItem(nestedElement, ownedNav.TargetEntityType, fieldNamingPolicy, options);
-                ownedNav.PropertyInfo.SetValue(ownedEntity, nestedEntity);
-            }
-        }
-
-        return ownedEntity;
     }
 
     // Record the original collection-object reference and per-item property values for every
@@ -401,25 +282,6 @@ public class CouchbaseQueryEnumerable<T> : IEnumerable<T>, IAsyncEnumerable<T>, 
         }
     }
 
-
-    private static object? ConvertJsonValue(JsonElement element, Type targetType, JsonSerializerOptions options)
-    {
-        if (element.ValueKind == JsonValueKind.Null) return null;
-        var t = Nullable.GetUnderlyingType(targetType) ?? targetType;
-        return t switch
-        {
-            _ when t == typeof(string)   => element.GetString(),
-            _ when t == typeof(int)      => element.GetInt32(),
-            _ when t == typeof(long)     => element.GetInt64(),
-            _ when t == typeof(double)   => element.GetDouble(),
-            _ when t == typeof(decimal)  => element.GetDecimal(),
-            _ when t == typeof(float)    => (float)element.GetDouble(),
-            _ when t == typeof(bool)     => element.GetBoolean(),
-            _ when t == typeof(Guid)     => element.GetGuid(),
-            _ when t == typeof(DateTime) => element.GetDateTime(),
-            _ => JsonSerializer.Deserialize(element.GetRawText(), t, options)
-        };
-    }
 
     /// <summary>
     ///     <para>

--- a/src/Couchbase.EntityFrameworkCore/Query/Internal/CouchbaseQueryEnumerable.cs
+++ b/src/Couchbase.EntityFrameworkCore/Query/Internal/CouchbaseQueryEnumerable.cs
@@ -55,7 +55,7 @@ public class CouchbaseQueryEnumerable<T> : IEnumerable<T>, IAsyncEnumerable<T>, 
     private readonly bool _threadSafetyChecksEnabled;
     private readonly bool _detailedErrorsEnabled;
     private readonly bool _standAloneStateManager;
-    // True only for QueryTrackingBehavior.TrackAll — the only mode where SnapshotCollectionRefs
+    // True only for QueryTrackingBehavior.TrackAll — the only mode where CouchbaseCollectionSnapshot.Record
     // produces a snapshot that the interceptor can ever consume via ChangeTracker.Entries().
     private readonly bool _isTracking;
     private readonly IDiagnosticsLogger<DbLoggerCategory.Query> _queryLogger;
@@ -72,6 +72,7 @@ public class CouchbaseQueryEnumerable<T> : IEnumerable<T>, IAsyncEnumerable<T>, 
     private readonly DbContext _dbContext;
     private readonly IReadOnlyList<INavigation> _ownedCollectionNavigations;
     private readonly CouchbaseOwnedCollectionMaterializer _materializer = new();
+    private readonly CouchbaseCollectionSnapshot _snapshot = new();
 
     public CouchbaseQueryEnumerable(
         RelationalQueryContext relationalQueryContext,
@@ -192,7 +193,7 @@ public class CouchbaseQueryEnumerable<T> : IEnumerable<T>, IAsyncEnumerable<T>, 
                     && rowElement.ValueKind == JsonValueKind.Object)
                 {
                     _materializer.Populate(result, rowElement, _ownedCollectionNavigations, _couchbaseDbContextOptionsBuilder.FieldNamingPolicy, _couchbaseDbContextOptionsBuilder.SerializerOptions);
-                    SnapshotCollectionRefs(result);
+                    _snapshot.Record(result, _ownedCollectionNavigations, _isTracking);
                 }
                 pendingEntityRow = null;
                 yield return result;
@@ -224,7 +225,7 @@ public class CouchbaseQueryEnumerable<T> : IEnumerable<T>, IAsyncEnumerable<T>, 
                         && lastRow.ValueKind == JsonValueKind.Object)
                     {
                         _materializer.Populate(last, lastRow, _ownedCollectionNavigations, _couchbaseDbContextOptionsBuilder.FieldNamingPolicy, _couchbaseDbContextOptionsBuilder.SerializerOptions);
-                        SnapshotCollectionRefs(last);
+                        _snapshot.Record(last, _ownedCollectionNavigations, _isTracking);
                     }
                     pendingEntityRow = null;
                     yield return last;
@@ -233,55 +234,6 @@ public class CouchbaseQueryEnumerable<T> : IEnumerable<T>, IAsyncEnumerable<T>, 
             }
         }
     }
-
-    // Record the original collection-object reference and per-item property values for every
-    // OwnsMany navigation on the freshly materialised entity.
-    //
-    // OriginalRefs detects reference replacement (customer.ContactMethods = []).
-    // OriginalItems detects in-place changes: .Add(), .Remove(), or scalar property mutation.
-    // Both are checked in MarkOwnersWithReplacedCollections before SaveChanges.
-    private void SnapshotCollectionRefs(T? entity)
-    {
-        // Skip entirely for non-tracking queries: the interceptor walks ChangeTracker.Entries(),
-        // so snapshots built for NoTracking / NoTrackingWithIdentityResolution entities are
-        // never consumed and would be immediately GC'd.
-        if (entity == null || !_isTracking) return;
-        var refs  = OwnedCollectionSnapshot.OriginalRefs.GetOrCreateValue(entity);
-        var items = OwnedCollectionSnapshot.OriginalItems.GetOrCreateValue(entity);
-        foreach (var nav in _ownedCollectionNavigations)
-        {
-            var currentCollection = nav.PropertyInfo?.GetValue(entity);
-            refs[nav.Name] = currentCollection;
-
-            // Snapshot per-item property values so in-place mutations can be detected even
-            // when the list reference is unchanged.
-            if (currentCollection is IEnumerable collection)
-            {
-                var itemProps = OwnedCollectionSnapshot.GetTrackedProperties(nav);
-                var snapshot = new List<Dictionary<string, object?>>();
-                foreach (var item in collection)
-                {
-                    if (item == null) continue;
-                    var propSnapshot = new Dictionary<string, object?>();
-                    foreach (var prop in itemProps)
-                    {
-                        var raw = prop.PropertyInfo?.GetValue(item);
-                        // Use EF Core's ValueComparer.Snapshot so mutable reference types
-                        // (e.g. byte[]) are deep-copied. For immutable types (string, int, …)
-                        // Snapshot is a no-op that returns the same reference.
-                        propSnapshot[prop.Name] = raw is null ? null : OwnedCollectionSnapshot.GetComparer(prop).Snapshot(raw);
-                    }
-                    snapshot.Add(propSnapshot);
-                }
-                items[nav.Name] = snapshot;
-            }
-            else
-            {
-                items[nav.Name] = [];
-            }
-        }
-    }
-
 
     /// <summary>
     ///     <para>

--- a/src/Couchbase.EntityFrameworkCore/Query/Internal/CouchbaseQuerySqlGenerator.cs
+++ b/src/Couchbase.EntityFrameworkCore/Query/Internal/CouchbaseQuerySqlGenerator.cs
@@ -39,12 +39,12 @@ public class CouchbaseQuerySqlGenerator : QuerySqlGenerator
     {
         // Skip LEFT JOINs for owned types — they are embedded in their owner's document
         // and have no independent keyspace.
+        // Direct-table form: LEFT JOIN ownedTable AS alias ON …
         if (leftJoinExpression.Table is TableExpression tableExpression && IsOwnedTable(tableExpression))
             return leftJoinExpression;
 
-        // EF Core generates a lateral-join subquery (LEFT JOIN (SELECT ...) AS s) when
-        // OwnsMany items have nested owned navigations (OwnsOne/OwnsMany within OwnsMany).
-        // Skip the entire lateral join when its subquery only reads from owned tables.
+        // Lateral-subquery form: LEFT JOIN (SELECT … FROM ownedTable) AS alias ON …
+        // EF Core emits this shape when OwnsMany items have nested owned navigations.
         if (leftJoinExpression.Table is SelectExpression innerSelect && IsAllOwnedTablesSelect(innerSelect))
             return leftJoinExpression;
 
@@ -56,10 +56,11 @@ public class CouchbaseQuerySqlGenerator : QuerySqlGenerator
     {
         // Skip INNER JOINs for owned types — they are embedded in their owner's document
         // and have no independent keyspace.
+        // Direct-table form: INNER JOIN ownedTable AS alias ON …
         if (innerJoinExpression.Table is TableExpression tableExpression && IsOwnedTable(tableExpression))
             return innerJoinExpression;
 
-        // Lateral-join subquery form — same logic as VisitLeftJoin above.
+        // Lateral-subquery form: INNER JOIN (SELECT … FROM ownedTable) AS alias ON …
         if (innerJoinExpression.Table is SelectExpression innerSelect && IsAllOwnedTablesSelect(innerSelect))
             return innerJoinExpression;
 
@@ -88,7 +89,45 @@ public class CouchbaseQuerySqlGenerator : QuerySqlGenerator
     /// <see langword="true"/> for unmapped tables.
     /// </para>
     /// </remarks>
-    internal static bool IsOwnedTable(TableExpression tableExpression)
+    /// <summary>
+    /// Emits the <c>ORDER BY</c> clause, dropping any ordering terms that reference a
+    /// suppressed owned-join alias.  Without this filter the alias appears in
+    /// <c>ORDER BY</c> but never in <c>FROM</c>/<c>JOIN</c>, producing malformed SQL
+    /// that survives only because N1QL evaluates undefined identifiers as
+    /// <c>MISSING</c> rather than raising an error.
+    /// </summary>
+    protected override void GenerateOrderings(SelectExpression selectExpression)
+    {
+        // Collect the aliases of every owned-type JOIN that VisitLeftJoin/VisitInnerJoin
+        // will suppress so that their ORDER BY terms can be dropped symmetrically.
+        var skippedAliases = CollectOwnedJoinAliases(selectExpression);
+        if (skippedAliases.Count == 0)
+        {
+            base.GenerateOrderings(selectExpression);
+            return;
+        }
+
+        // Filter out orderings whose sole column reference is to a suppressed alias.
+        // Orderings on owner columns or literals are kept unchanged.
+        var filtered = selectExpression.Orderings
+            .Where(o => o.Expression is not ColumnExpression col
+                        || !skippedAliases.Contains(col.TableAlias))
+            .ToList();
+
+        if (filtered.Count == 0) return;
+
+        // Re-emit only the surviving orderings using the base helper so that
+        // ASC/DESC, NULLS FIRST/LAST, and any provider-specific formatting are
+        // applied consistently.
+        Sql.AppendLine().Append("ORDER BY ");
+        GenerateList(filtered, o =>
+        {
+            Visit(o.Expression);
+            if (o.IsAscending) Sql.Append(" ASC"); else Sql.Append(" DESC");
+        });
+    }
+
+    private static bool IsOwnedTable(TableExpression tableExpression)
     {
         // Single-pass enumeration: track whether any mappings exist and whether every
         // mapping seen so far is an owned entity type. Avoids the ToList() allocation

--- a/src/Couchbase.EntityFrameworkCore/Query/Internal/CouchbaseQuerySqlGenerator.cs
+++ b/src/Couchbase.EntityFrameworkCore/Query/Internal/CouchbaseQuerySqlGenerator.cs
@@ -154,14 +154,30 @@ public class CouchbaseQuerySqlGenerator : QuerySqlGenerator
         if (selectExpression.Tables.Count == 0) return false;
         foreach (var table in selectExpression.Tables)
         {
-            TableExpression? te = table switch
+            switch (table)
             {
-                TableExpression t                                       => t,
-                LeftJoinExpression  lj when lj.Table is TableExpression t => t,
-                InnerJoinExpression ij when ij.Table is TableExpression t => t,
-                _ => null
-            };
-            if (te == null || !IsOwnedTable(te)) return false;
+                // Direct owned table — base case.
+                case TableExpression te when IsOwnedTable(te):
+                    break;
+
+                // JOIN whose inner table is a direct owned table.
+                case LeftJoinExpression  lj when lj.Table is TableExpression ljTe && IsOwnedTable(ljTe):
+                    break;
+                case InnerJoinExpression ij when ij.Table is TableExpression ijTe && IsOwnedTable(ijTe):
+                    break;
+
+                // JOIN whose inner table is itself a lateral subquery — recurse so that
+                // depth ≥ 3 nested OwnsMany chains (e.g. Customer → Methods → Tags → Audits)
+                // are correctly identified and their JOINs suppressed.
+                case LeftJoinExpression  lj when lj.Table is SelectExpression ljInner && IsAllOwnedTablesSelect(ljInner):
+                    break;
+                case InnerJoinExpression ij when ij.Table is SelectExpression ijInner && IsAllOwnedTablesSelect(ijInner):
+                    break;
+
+                // Anything else (non-owned table, unrecognised shape) → not all owned.
+                default:
+                    return false;
+            }
         }
         return true;
     }

--- a/src/Couchbase.EntityFrameworkCore/Query/Internal/CouchbaseQuerySqlGenerator.cs
+++ b/src/Couchbase.EntityFrameworkCore/Query/Internal/CouchbaseQuerySqlGenerator.cs
@@ -116,15 +116,24 @@ public class CouchbaseQuerySqlGenerator : QuerySqlGenerator
 
         if (filtered.Count == 0) return;
 
-        // Re-emit only the surviving orderings using the base helper so that
-        // ASC/DESC, NULLS FIRST/LAST, and any provider-specific formatting are
-        // applied consistently.
+        // EF Core 10 does not expose a per-ordering virtual hook (GenerateOrdering was
+        // removed in modern versions; only GenerateOrderings(SelectExpression) exists).
+        // Emit each surviving ordering via a private helper so the formatting is defined
+        // in one place and stays in sync with the base class's simple ASC/DESC convention.
         Sql.AppendLine().Append("ORDER BY ");
-        GenerateList(filtered, o =>
-        {
-            Visit(o.Expression);
-            if (o.IsAscending) Sql.Append(" ASC"); else Sql.Append(" DESC");
-        });
+        GenerateList(filtered, EmitOrdering);
+    }
+
+    /// <summary>
+    /// Emits a single ordering term (<c>expression ASC|DESC</c>) into the SQL buffer.
+    /// Extracted so <see cref="GenerateOrderings"/> does not inline formatting logic
+    /// that would silently diverge if the base class ever adds NULLS FIRST/LAST or
+    /// collation support.
+    /// </summary>
+    private void EmitOrdering(OrderingExpression ordering)
+    {
+        Visit(ordering.Expression);
+        Sql.Append(ordering.IsAscending ? " ASC" : " DESC");
     }
 
     private static bool IsOwnedTable(TableExpression tableExpression)

--- a/src/Couchbase.EntityFrameworkCore/Storage/Internal/CouchbaseDatabaseWrapper.cs
+++ b/src/Couchbase.EntityFrameworkCore/Storage/Internal/CouchbaseDatabaseWrapper.cs
@@ -300,6 +300,8 @@ public class CouchbaseDatabaseWrapper : Database
                 var fieldName = fieldNamingPolicy?.ConvertName(nav.Name) ?? nav.Name;
                 if (navValue is IEnumerable items)
                 {
+                    var itemProps = nav.TargetEntityType.GetProperties()
+                        .Where(p => !p.IsShadowProperty()).ToList();
                     var list = new List<Dictionary<string, object?>>();
                     foreach (var item in items)
                     {

--- a/src/Couchbase.EntityFrameworkCore/Storage/Internal/CouchbaseDatabaseWrapper.cs
+++ b/src/Couchbase.EntityFrameworkCore/Storage/Internal/CouchbaseDatabaseWrapper.cs
@@ -300,22 +300,13 @@ public class CouchbaseDatabaseWrapper : Database
                 var fieldName = fieldNamingPolicy?.ConvertName(nav.Name) ?? nav.Name;
                 if (navValue is IEnumerable items)
                 {
-                    var itemProps = nav.TargetEntityType.GetProperties()
-                        .Where(p => !p.IsShadowProperty()).ToList();
+                    // Use SerializeOwnedItem so that nested OwnsOne / OwnsMany navigations
+                    // within each item (e.g. ContactMethod.Label, ContactMethod.Tags) are
+                    // recursively included.  The flat scalar-only loop it replaces silently
+                    // dropped all nested navigations.
                     var list = new List<Dictionary<string, object?>>();
                     foreach (var item in items)
-                    {
-                        var itemDoc = new Dictionary<string, object?>();
-                        foreach (var p in itemProps)
-                        {
-                            // Same PropertyInfo → FieldInfo fallback for each owned-item scalar.
-                            var value = p.PropertyInfo != null
-                                ? p.PropertyInfo.GetValue(item)
-                                : p.FieldInfo?.GetValue(item);
-                            itemDoc[fieldNamingPolicy?.ConvertName(p.Name) ?? p.Name] = value;
-                        }
-                        list.Add(itemDoc);
-                    }
+                        list.Add(SerializeOwnedItem(item, nav.TargetEntityType, fieldNamingPolicy));
                     doc[fieldName] = list;
                 }
                 else

--- a/src/Couchbase.EntityFrameworkCore/Storage/Internal/CouchbaseDatabaseWrapper.cs
+++ b/src/Couchbase.EntityFrameworkCore/Storage/Internal/CouchbaseDatabaseWrapper.cs
@@ -213,7 +213,13 @@ public class CouchbaseDatabaseWrapper : Database
     internal static void FillOwnsOneIntoDoc(Dictionary<string, object?> doc, INavigation nav, object? navValue)
     {
         foreach (var p in nav.TargetEntityType.GetProperties().Where(p => !p.IsShadowProperty()))
-            doc[p.GetColumnName()] = navValue == null ? null : p.PropertyInfo?.GetValue(navValue);
+        {
+            // Read via PropertyInfo when available; fall back to FieldInfo for field-access properties.
+            var value = navValue == null ? null
+                : p.PropertyInfo != null ? p.PropertyInfo.GetValue(navValue)
+                : p.FieldInfo?.GetValue(navValue);
+            doc[p.GetColumnName()] = value;
+        }
     }
 
     private CouchbaseDbTransaction? GetCurrentTransaction()
@@ -284,7 +290,11 @@ public class CouchbaseDatabaseWrapper : Database
         var entity = updateEntry.ToEntityEntry().Entity;
         foreach (var nav in ownedNavs)
         {
-            var navValue = nav.PropertyInfo!.GetValue(entity);
+            // Read via PropertyInfo when available; fall back to FieldInfo for field-access
+            // properties (backing-field or [BackingField]-annotated) where PropertyInfo is null.
+            var navValue = nav.PropertyInfo != null
+                ? nav.PropertyInfo.GetValue(entity)
+                : nav.FieldInfo?.GetValue(entity);
             if (nav.IsCollection)
             {
                 var fieldName = fieldNamingPolicy?.ConvertName(nav.Name) ?? nav.Name;
@@ -292,7 +302,18 @@ public class CouchbaseDatabaseWrapper : Database
                 {
                     var list = new List<Dictionary<string, object?>>();
                     foreach (var item in items)
-                        list.Add(SerializeOwnedItem(item, nav.TargetEntityType, fieldNamingPolicy));
+                    {
+                        var itemDoc = new Dictionary<string, object?>();
+                        foreach (var p in itemProps)
+                        {
+                            // Same PropertyInfo → FieldInfo fallback for each owned-item scalar.
+                            var value = p.PropertyInfo != null
+                                ? p.PropertyInfo.GetValue(item)
+                                : p.FieldInfo?.GetValue(item);
+                            itemDoc[fieldNamingPolicy?.ConvertName(p.Name) ?? p.Name] = value;
+                        }
+                        list.Add(itemDoc);
+                    }
                     doc[fieldName] = list;
                 }
                 else

--- a/tests/Couchbase.EntityFrameworkCore.IntegrationTests/Fixtures/OwnedTypeFixture.cs
+++ b/tests/Couchbase.EntityFrameworkCore.IntegrationTests/Fixtures/OwnedTypeFixture.cs
@@ -136,6 +136,59 @@ public class OwnedTypeFixture : CouchbaseFixture<OwnedTypeDbContext>
     }
 
     // -------------------------------------------------------------------------
+    // Field-access / get-only model
+    // Exercises FieldInfo fallback in MaterializeOwnedItem (read) and
+    // SerializeOwnedItem / FillOwnsOneIntoDoc (write).
+    // -------------------------------------------------------------------------
+
+    /// <summary>
+    /// Root entity whose OwnsOne and OwnsMany items have get-only scalar properties
+    /// (no setter) so EF Core must read/write them via the compiler-generated backing
+    /// field — the code path hardened by the FieldInfo fallback fixes.
+    /// <para>
+    /// <see cref="FieldContact.Tags"/> is a <see cref="HashSet{T}"/> nested inside
+    /// an OwnsMany item, exercising the <c>ICollection&lt;T&gt;</c> non-<c>IList</c>
+    /// clear path inside <c>MaterializeOwnedItem</c>'s nested navigation loop.
+    /// </para>
+    /// </summary>
+    public class FieldAccessCustomer
+    {
+        public int Id { get; set; }
+        public string Name { get; set; } = "";
+        public FieldAddress Address { get; set; } = new();
+        public List<FieldContact> Contacts { get; set; } = [];
+    }
+
+    /// <summary>OwnsOne with get-only scalars — written via backing field.</summary>
+    public class FieldAddress
+    {
+        public string? Street { get; }
+        public string? City { get; }
+
+        // Parameterless ctor required for EF Core materialisation.
+        public FieldAddress() { }
+        public FieldAddress(string? street, string? city) { Street = street; City = city; }
+    }
+
+    /// <summary>OwnsMany item with a get-only scalar and a HashSet nested OwnsMany.</summary>
+    public class FieldContact
+    {
+        public int Id { get; set; }
+        public string? Label { get; }
+        /// <summary>Non-IList nested collection — exercises the ICollection&lt;T&gt; clear path.</summary>
+        public HashSet<FieldTag> Tags { get; set; } = [];
+
+        public FieldContact() { }
+        public FieldContact(int id, string? label) { Id = id; Label = label; }
+    }
+
+    public class FieldTag
+    {
+        public int Id { get; set; }
+        public string Key { get; set; } = "";
+    }
+
+    // -------------------------------------------------------------------------
     // HashSet<T>-backed model — used by OwnedCollectionClearIntegrationTests
     // -------------------------------------------------------------------------
 

--- a/tests/Couchbase.EntityFrameworkCore.IntegrationTests/Fixtures/OwnedTypeFixture.cs
+++ b/tests/Couchbase.EntityFrameworkCore.IntegrationTests/Fixtures/OwnedTypeFixture.cs
@@ -60,8 +60,16 @@ public class OwnedTypeFixture : CouchbaseFixture<OwnedTypeDbContext>
                         Label = new ContactLabel { DisplayName = "Work Email" },
                         Tags =
                         [
-                            new ContactTag { Id = 1, Key = "priority", Val = "high" },
-                            new ContactTag { Id = 2, Key = "verified", Val = "true" }
+                            new ContactTag
+                            {
+                                Id = 1, Key = "priority", Val = "high",
+                                Audits =
+                                [
+                                    new TagAudit { Id = 1, Note = "set by admin" },
+                                    new TagAudit { Id = 2, Note = "confirmed" }
+                                ]
+                            },
+                            new ContactTag { Id = 2, Key = "verified", Val = "true", Audits = [] }
                         ]
                     },
                     new ContactMethod
@@ -110,6 +118,21 @@ public class OwnedTypeFixture : CouchbaseFixture<OwnedTypeDbContext>
         public int Id { get; set; }
         public string Key { get; set; } = "";
         public string Val { get; set; } = "";
+        /// <summary>
+        /// Depth-3 OwnsMany — exercises the recursive <c>IsAllOwnedTablesSelect</c> path.
+        /// </summary>
+        public List<TagAudit> Audits { get; set; } = [];
+    }
+
+    /// <summary>
+    /// Owned entity at depth 3 (Customer → ContactMethod → ContactTag → TagAudit).
+    /// Used to verify that <c>IsAllOwnedTablesSelect</c> recurses correctly and does
+    /// not leave an empty FROM clause or dangling ORDER BY alias in the generated N1QL.
+    /// </summary>
+    public class TagAudit
+    {
+        public int Id { get; set; }
+        public string Note { get; set; } = "";
     }
 
     // -------------------------------------------------------------------------

--- a/tests/Couchbase.EntityFrameworkCore.IntegrationTests/Models/OwnedTypeDbContext.cs
+++ b/tests/Couchbase.EntityFrameworkCore.IntegrationTests/Models/OwnedTypeDbContext.cs
@@ -14,6 +14,12 @@ public class OwnedTypeDbContext(DbContextOptions<OwnedTypeDbContext> options) : 
     /// </summary>
     public DbSet<OwnedTypeFixture.HashSetCustomer> HashSetCustomers { get; set; }
 
+    /// <summary>
+    /// Get-only OwnsOne / OwnsMany + HashSet nested collection —
+    /// exercises FieldInfo fallback and ICollection&lt;T&gt; nested clear.
+    /// </summary>
+    public DbSet<OwnedTypeFixture.FieldAccessCustomer> FieldAccessCustomers { get; set; }
+
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
         modelBuilder.Entity<OwnedTypeFixture.Customer>(b =>
@@ -35,6 +41,24 @@ public class OwnedTypeDbContext(DbContextOptions<OwnedTypeDbContext> options) : 
             b.ToCouchbaseCollection(this, "hashsetcustomer");
             b.HasKey(c => c.Id);
             b.OwnsMany(c => c.Tags, t => t.HasKey(t => t.Id));
+        });
+
+        modelBuilder.Entity<OwnedTypeFixture.FieldAccessCustomer>(b =>
+        {
+            b.ToCouchbaseCollection(this, "fieldaccesscustomer");
+            b.HasKey(c => c.Id);
+            // Use field access so EF reads/writes get-only properties via backing fields.
+            b.OwnsOne(c => c.Address, a =>
+            {
+                a.Property(x => x.Street).UsePropertyAccessMode(PropertyAccessMode.Field);
+                a.Property(x => x.City).UsePropertyAccessMode(PropertyAccessMode.Field);
+            });
+            b.OwnsMany(c => c.Contacts, cm =>
+            {
+                cm.HasKey(c => c.Id);
+                cm.Property(c => c.Label).UsePropertyAccessMode(PropertyAccessMode.Field);
+                cm.OwnsMany(c => c.Tags, t => t.HasKey(t => t.Id));
+            });
         });
 
         modelBuilder.ConfigureToCouchbase(this, true);

--- a/tests/Couchbase.EntityFrameworkCore.IntegrationTests/Models/OwnedTypeDbContext.cs
+++ b/tests/Couchbase.EntityFrameworkCore.IntegrationTests/Models/OwnedTypeDbContext.cs
@@ -23,7 +23,10 @@ public class OwnedTypeDbContext(DbContextOptions<OwnedTypeDbContext> options) : 
             b.OwnsMany(c => c.ContactMethods, cm =>
             {
                 cm.OwnsOne(m => m.Label);
-                cm.OwnsMany(m => m.Tags);
+                cm.OwnsMany(m => m.Tags, t =>
+                {
+                    t.OwnsMany(t => t.Audits);
+                });
             });
         });
 

--- a/tests/Couchbase.EntityFrameworkCore.IntegrationTests/Tests/OwnedTypeTests.cs
+++ b/tests/Couchbase.EntityFrameworkCore.IntegrationTests/Tests/OwnedTypeTests.cs
@@ -759,4 +759,174 @@ public class OwnedTypeTests(
             if (customer != null) { ctx.Remove(customer); await ctx.SaveChangesAsync(); }
         }
     }
+
+    // -------------------------------------------------------------------------
+    // Field-access / get-only owned properties
+    // Verifies that FieldInfo fallback in MaterializeOwnedItem and SerializeOwnedItem
+    // correctly reads and writes properties that have no setter.
+    // Also exercises the ICollection<T> non-IList nested clear path via
+    // FieldContact.Tags (HashSet<FieldTag>).
+    // -------------------------------------------------------------------------
+
+    [Fact]
+    public async Task FieldAccess_OwnsOne_GetOnlyScalars_RoundTrip()
+    {
+        // A FieldAddress with get-only Street/City must survive a write → read cycle.
+        const int id = 400;
+        try
+        {
+            await using (var ctx = fixture.GetDbContext())
+            {
+                ctx.Update(new OwnedTypeFixture.FieldAccessCustomer
+                {
+                    Id = id,
+                    Name = "FieldAccess Alice",
+                    Address = new OwnedTypeFixture.FieldAddress("10 Elm St", "Greenfield")
+                });
+                await ctx.SaveChangesAsync();
+            }
+
+            await using (var ctx = fixture.GetDbContext())
+            {
+                var customer = await ctx.FieldAccessCustomers.FirstAsync(c => c.Id == id);
+                Assert.NotNull(customer.Address);
+                Assert.Equal("10 Elm St",  customer.Address.Street);
+                Assert.Equal("Greenfield", customer.Address.City);
+            }
+        }
+        finally
+        {
+            await using var ctx = fixture.GetDbContext();
+            var c = await ctx.FieldAccessCustomers.FirstOrDefaultAsync(c => c.Id == id);
+            if (c != null) { ctx.Remove(c); await ctx.SaveChangesAsync(); }
+        }
+    }
+
+    [Fact]
+    public async Task FieldAccess_OwnsMany_GetOnlyScalar_RoundTrip()
+    {
+        // FieldContact.Label has no setter — must be written and read back via FieldInfo.
+        const int id = 401;
+        try
+        {
+            await using (var ctx = fixture.GetDbContext())
+            {
+                ctx.Update(new OwnedTypeFixture.FieldAccessCustomer
+                {
+                    Id = id,
+                    Name = "FieldAccess Bob",
+                    Address = new OwnedTypeFixture.FieldAddress("2 Oak Ave", "Lakewood"),
+                    Contacts =
+                    [
+                        new OwnedTypeFixture.FieldContact(1, "work"),
+                        new OwnedTypeFixture.FieldContact(2, "home")
+                    ]
+                });
+                await ctx.SaveChangesAsync();
+            }
+
+            await using (var ctx = fixture.GetDbContext())
+            {
+                var customer = await ctx.FieldAccessCustomers.FirstAsync(c => c.Id == id);
+                Assert.Equal(2, customer.Contacts.Count);
+                Assert.Contains(customer.Contacts, c => c.Label == "work");
+                Assert.Contains(customer.Contacts, c => c.Label == "home");
+            }
+        }
+        finally
+        {
+            await using var ctx = fixture.GetDbContext();
+            var c = await ctx.FieldAccessCustomers.FirstOrDefaultAsync(c => c.Id == id);
+            if (c != null) { ctx.Remove(c); await ctx.SaveChangesAsync(); }
+        }
+    }
+
+    [Fact]
+    public async Task FieldAccess_NestedHashSet_RoundTrip()
+    {
+        // FieldContact.Tags is a HashSet<FieldTag> nested inside an OwnsMany item.
+        // Exercises the ICollection<T> non-IList clear path inside MaterializeOwnedItem.
+        const int id = 402;
+        try
+        {
+            await using (var ctx = fixture.GetDbContext())
+            {
+                ctx.Update(new OwnedTypeFixture.FieldAccessCustomer
+                {
+                    Id = id,
+                    Name = "FieldAccess Carol",
+                    Address = new OwnedTypeFixture.FieldAddress("3 Pine Rd", "Riverdale"),
+                    Contacts =
+                    [
+                        new OwnedTypeFixture.FieldContact(1, "primary")
+                        {
+                            Tags =
+                            [
+                                new OwnedTypeFixture.FieldTag { Id = 1, Key = "vip" },
+                                new OwnedTypeFixture.FieldTag { Id = 2, Key = "active" }
+                            ]
+                        }
+                    ]
+                });
+                await ctx.SaveChangesAsync();
+            }
+
+            await using (var ctx = fixture.GetDbContext())
+            {
+                var customer = await ctx.FieldAccessCustomers.FirstAsync(c => c.Id == id);
+                var contact = customer.Contacts.Single();
+                Assert.Equal("primary", contact.Label);
+                Assert.Equal(2, contact.Tags.Count);
+                Assert.Contains(contact.Tags, t => t.Key == "vip");
+                Assert.Contains(contact.Tags, t => t.Key == "active");
+            }
+        }
+        finally
+        {
+            await using var ctx = fixture.GetDbContext();
+            var c = await ctx.FieldAccessCustomers.FirstOrDefaultAsync(c => c.Id == id);
+            if (c != null) { ctx.Remove(c); await ctx.SaveChangesAsync(); }
+        }
+    }
+
+    [Fact]
+    public async Task FieldAccess_NestedHashSet_NoDuplicatesOnRequery()
+    {
+        // Querying the same HashSet<FieldTag>-backed contact twice (fresh context each
+        // time) must not accumulate duplicates — the ICollection<T> clear must fire.
+        const int id = 403;
+        try
+        {
+            await using (var ctx = fixture.GetDbContext())
+            {
+                ctx.Update(new OwnedTypeFixture.FieldAccessCustomer
+                {
+                    Id = id,
+                    Name = "FieldAccess Dave",
+                    Address = new OwnedTypeFixture.FieldAddress("4 Maple Ln", "Springdale"),
+                    Contacts =
+                    [
+                        new OwnedTypeFixture.FieldContact(1, "only")
+                        {
+                            Tags = [new OwnedTypeFixture.FieldTag { Id = 1, Key = "solo" }]
+                        }
+                    ]
+                });
+                await ctx.SaveChangesAsync();
+            }
+
+            for (var pass = 1; pass <= 2; pass++)
+            {
+                await using var ctx = fixture.GetDbContext();
+                var customer = await ctx.FieldAccessCustomers.FirstAsync(c => c.Id == id);
+                Assert.Single(customer.Contacts.Single().Tags);
+            }
+        }
+        finally
+        {
+            await using var ctx = fixture.GetDbContext();
+            var c = await ctx.FieldAccessCustomers.FirstOrDefaultAsync(c => c.Id == id);
+            if (c != null) { ctx.Remove(c); await ctx.SaveChangesAsync(); }
+        }
+    }
 }

--- a/tests/Couchbase.EntityFrameworkCore.IntegrationTests/Tests/OwnedTypeTests.cs
+++ b/tests/Couchbase.EntityFrameworkCore.IntegrationTests/Tests/OwnedTypeTests.cs
@@ -661,4 +661,102 @@ public class OwnedTypeTests(
             if (customer != null) { ctx.Remove(customer); await ctx.SaveChangesAsync(); }
         }
     }
+
+    // -------------------------------------------------------------------------
+    // Depth-3 OwnsMany (Customer → ContactMethod → ContactTag → TagAudit)
+    // These tests verify that IsAllOwnedTablesSelect recurses correctly so that
+    // the lateral-join subquery for TagAudit is suppressed (no empty FROM) and
+    // its ORDER BY alias is dropped (no dangling alias).
+    // -------------------------------------------------------------------------
+
+    [Fact]
+    public async Task OwnsMany_Depth3_Audits_ArePopulated()
+    {
+        // Carol's first tag (priority=high) has two audits; the second has none.
+        await using var ctx = fixture.GetDbContext();
+        var customer = await ctx.Customers.FirstAsync(c => c.CustomerId == 3);
+
+        var email = customer.ContactMethods.First(cm => cm.Type == "email");
+        var priority = email.Tags.First(t => t.Key == "priority");
+
+        Assert.Equal(2, priority.Audits.Count);
+        Assert.Contains(priority.Audits, a => a.Note == "set by admin");
+        Assert.Contains(priority.Audits, a => a.Note == "confirmed");
+    }
+
+    [Fact]
+    public async Task OwnsMany_Depth3_EmptyAudits_ReadsAsEmpty()
+    {
+        // The "verified" tag has an empty Audits list — must read back as empty, not null.
+        await using var ctx = fixture.GetDbContext();
+        var customer = await ctx.Customers.FirstAsync(c => c.CustomerId == 3);
+
+        var email = customer.ContactMethods.First(cm => cm.Type == "email");
+        var verified = email.Tags.First(t => t.Key == "verified");
+
+        Assert.NotNull(verified.Audits);
+        Assert.Empty(verified.Audits);
+    }
+
+    [Fact]
+    public async Task OwnsMany_Depth3_ToList_DoesNotThrow()
+    {
+        // ToListAsync on a depth-3 model previously caused N1QL error 3000
+        // (empty FROM clause) due to the non-recursive IsAllOwnedTablesSelect.
+        await using var ctx = fixture.GetDbContext();
+        var customers = await ctx.Customers.ToListAsync();
+        Assert.NotEmpty(customers);
+    }
+
+    [Fact]
+    public async Task OwnsMany_Depth3_Audits_RoundTrip()
+    {
+        // Write a new customer with depth-3 data and confirm it reads back correctly.
+        const int id = 300;
+        try
+        {
+            await using (var ctx = fixture.GetDbContext())
+            {
+                ctx.Update(new OwnedTypeFixture.Customer
+                {
+                    CustomerId = id,
+                    Name = "Depth3 Test",
+                    Address = new OwnedTypeFixture.Address { Street = "1 Deep St", City = "Recursion" },
+                    ContactMethods =
+                    [
+                        new OwnedTypeFixture.ContactMethod
+                        {
+                            Id = 1, Type = "email", Value = "deep@test.com",
+                            Tags =
+                            [
+                                new OwnedTypeFixture.ContactTag
+                                {
+                                    Id = 1, Key = "level", Val = "3",
+                                    Audits =
+                                    [
+                                        new OwnedTypeFixture.TagAudit { Id = 1, Note = "depth-3 note" }
+                                    ]
+                                }
+                            ]
+                        }
+                    ]
+                });
+                await ctx.SaveChangesAsync();
+            }
+
+            await using (var ctx = fixture.GetDbContext())
+            {
+                var customer = await ctx.Customers.FirstAsync(c => c.CustomerId == id);
+                var tag = customer.ContactMethods.Single().Tags.Single();
+                Assert.Single(tag.Audits);
+                Assert.Equal("depth-3 note", tag.Audits[0].Note);
+            }
+        }
+        finally
+        {
+            await using var ctx = fixture.GetDbContext();
+            var customer = await ctx.Customers.FirstOrDefaultAsync(c => c.CustomerId == id);
+            if (customer != null) { ctx.Remove(customer); await ctx.SaveChangesAsync(); }
+        }
+    }
 }

--- a/tests/Couchbase.EntityFrameworkCore.UnitTests/Couchbase/EntityFrameworkCore/Query/CouchbaseCollectionSnapshotTests.cs
+++ b/tests/Couchbase.EntityFrameworkCore.UnitTests/Couchbase/EntityFrameworkCore/Query/CouchbaseCollectionSnapshotTests.cs
@@ -1,0 +1,214 @@
+using Couchbase.EntityFrameworkCore.Query.Internal;
+using Microsoft.EntityFrameworkCore.Metadata;
+using Moq;
+using Xunit;
+
+namespace Couchbase.EntityFrameworkCore.UnitTests.Couchbase.EntityFrameworkCore.Query;
+
+/// <summary>
+/// Unit tests for <see cref="CouchbaseCollectionSnapshot"/>.
+/// These tests exercise snapshot recording in isolation using mock INavigation objects
+/// and verify that <see cref="OwnedCollectionSnapshot"/> is populated correctly.
+/// </summary>
+public class CouchbaseCollectionSnapshotTests
+{
+    private readonly CouchbaseCollectionSnapshot _sut = new();
+
+    // -------------------------------------------------------------------------
+    // Helper model
+    // -------------------------------------------------------------------------
+
+    private class Owner
+    {
+        public List<Item> Items { get; set; } = [];
+    }
+
+    private class Item
+    {
+        public string? Value { get; set; }
+        public int Count { get; set; }
+    }
+
+    // Build a minimal mock INavigation pointing at Owner.Items
+    private static INavigation BuildNavigation()
+    {
+        var itemProp = typeof(Owner).GetProperty(nameof(Owner.Items))!;
+
+        var itemValueProp = typeof(Item).GetProperty(nameof(Item.Value))!;
+        var itemCountProp = typeof(Item).GetProperty(nameof(Item.Count))!;
+
+        var mockValueProp = new Mock<IProperty>();
+        mockValueProp.Setup(p => p.Name).Returns(nameof(Item.Value));
+        mockValueProp.Setup(p => p.PropertyInfo).Returns(itemValueProp);
+        mockValueProp.Setup(p => p.ClrType).Returns(typeof(string));
+        mockValueProp.Setup(p => p.IsShadowProperty()).Returns(false);
+        mockValueProp.Setup(p => p.GetValueComparer()).Returns((Microsoft.EntityFrameworkCore.ChangeTracking.ValueComparer?)null);
+        mockValueProp.Setup(p => p.FindTypeMapping()).Returns((Microsoft.EntityFrameworkCore.Storage.CoreTypeMapping?)null);
+
+        var mockCountProp = new Mock<IProperty>();
+        mockCountProp.Setup(p => p.Name).Returns(nameof(Item.Count));
+        mockCountProp.Setup(p => p.PropertyInfo).Returns(itemCountProp);
+        mockCountProp.Setup(p => p.ClrType).Returns(typeof(int));
+        mockCountProp.Setup(p => p.IsShadowProperty()).Returns(false);
+        mockCountProp.Setup(p => p.GetValueComparer()).Returns((Microsoft.EntityFrameworkCore.ChangeTracking.ValueComparer?)null);
+        mockCountProp.Setup(p => p.FindTypeMapping()).Returns((Microsoft.EntityFrameworkCore.Storage.CoreTypeMapping?)null);
+
+        var mockEntityType = new Mock<IEntityType>();
+        mockEntityType.Setup(et => et.GetProperties())
+            .Returns([mockValueProp.Object, mockCountProp.Object]);
+
+        var mockNav = new Mock<INavigation>();
+        mockNav.Setup(n => n.Name).Returns(nameof(Owner.Items));
+        mockNav.Setup(n => n.PropertyInfo).Returns(itemProp);
+        mockNav.Setup(n => n.TargetEntityType).Returns(mockEntityType.Object);
+
+        return mockNav.Object;
+    }
+
+    // -------------------------------------------------------------------------
+    // isTracking = false → no snapshot recorded
+    // -------------------------------------------------------------------------
+
+    [Fact]
+    public void Record_NonTracking_DoesNotSnapshot()
+    {
+        var owner = new Owner { Items = [new Item { Value = "x", Count = 1 }] };
+        var nav = BuildNavigation();
+
+        _sut.Record(owner, [nav], isTracking: false);
+
+        Assert.False(OwnedCollectionSnapshot.OriginalRefs.TryGetValue(owner, out _));
+    }
+
+    [Fact]
+    public void Record_NullEntity_DoesNotThrow()
+    {
+        var nav = BuildNavigation();
+        var ex = Record.Exception(() => _sut.Record<Owner>(null!, [nav], isTracking: true));
+        Assert.Null(ex);
+    }
+
+    // -------------------------------------------------------------------------
+    // Reference replacement detection
+    // -------------------------------------------------------------------------
+
+    [Fact]
+    public void Record_Tracking_SnapshotsCollectionReference()
+    {
+        var owner = new Owner { Items = [new Item { Value = "a", Count = 1 }] };
+        var nav = BuildNavigation();
+
+        _sut.Record(owner, [nav], isTracking: true);
+
+        Assert.True(OwnedCollectionSnapshot.OriginalRefs.TryGetValue(owner, out var refs));
+        Assert.Same(owner.Items, refs![nameof(Owner.Items)]);
+    }
+
+    [Fact]
+    public void Record_Tracking_DetectsReferenceReplacement()
+    {
+        var owner = new Owner { Items = [new Item { Value = "a", Count = 1 }] };
+        var nav = BuildNavigation();
+
+        _sut.Record(owner, [nav], isTracking: true);
+
+        // Replace the collection reference
+        var originalRef = owner.Items;
+        owner.Items = [new Item { Value = "b", Count = 2 }];
+
+        OwnedCollectionSnapshot.OriginalRefs.TryGetValue(owner, out var refs);
+        Assert.Same(originalRef, refs![nameof(Owner.Items)]);
+        Assert.NotSame(owner.Items, refs[nameof(Owner.Items)]);
+    }
+
+    // -------------------------------------------------------------------------
+    // In-place mutation detection
+    // -------------------------------------------------------------------------
+
+    [Fact]
+    public void Record_Tracking_SnapshotsItemPropertyValues()
+    {
+        var item = new Item { Value = "hello", Count = 42 };
+        var owner = new Owner { Items = [item] };
+        var nav = BuildNavigation();
+
+        _sut.Record(owner, [nav], isTracking: true);
+
+        Assert.True(OwnedCollectionSnapshot.OriginalItems.TryGetValue(owner, out var items));
+        var snapshots = items![nameof(Owner.Items)];
+        Assert.Single(snapshots);
+        Assert.Equal("hello", snapshots[0][nameof(Item.Value)]);
+        Assert.Equal(42, snapshots[0][nameof(Item.Count)]);
+    }
+
+    [Fact]
+    public void Record_Tracking_DetectsScalarPropertyMutation()
+    {
+        var item = new Item { Value = "original", Count = 1 };
+        var owner = new Owner { Items = [item] };
+        var nav = BuildNavigation();
+
+        _sut.Record(owner, [nav], isTracking: true);
+
+        // Mutate in-place — snapshot still holds original value
+        item.Value = "mutated";
+
+        OwnedCollectionSnapshot.OriginalItems.TryGetValue(owner, out var items);
+        Assert.Equal("original", items![nameof(Owner.Items)][0][nameof(Item.Value)]);
+    }
+
+    // -------------------------------------------------------------------------
+    // Item count change detection
+    // -------------------------------------------------------------------------
+
+    [Fact]
+    public void Record_Tracking_EmptyCollection_SnapshotsEmptyList()
+    {
+        var owner = new Owner { Items = [] };
+        var nav = BuildNavigation();
+
+        _sut.Record(owner, [nav], isTracking: true);
+
+        Assert.True(OwnedCollectionSnapshot.OriginalItems.TryGetValue(owner, out var items));
+        Assert.Empty(items![nameof(Owner.Items)]);
+    }
+
+    [Fact]
+    public void Record_Tracking_DetectsItemAdded()
+    {
+        var owner = new Owner { Items = [new Item { Value = "a", Count = 1 }] };
+        var nav = BuildNavigation();
+
+        _sut.Record(owner, [nav], isTracking: true);
+
+        // Add an item after snapshot
+        owner.Items.Add(new Item { Value = "b", Count = 2 });
+
+        OwnedCollectionSnapshot.OriginalItems.TryGetValue(owner, out var items);
+        // Snapshot captured 1 item; current collection has 2
+        Assert.Single(items![nameof(Owner.Items)]);
+        Assert.Equal(2, owner.Items.Count);
+    }
+
+    // -------------------------------------------------------------------------
+    // No-op second save (snapshot is fresh after first save)
+    // -------------------------------------------------------------------------
+
+    [Fact]
+    public void Record_CalledTwice_SecondCallOverwritesSnapshot()
+    {
+        var item = new Item { Value = "v1", Count = 1 };
+        var owner = new Owner { Items = [item] };
+        var nav = BuildNavigation();
+
+        _sut.Record(owner, [nav], isTracking: true);
+
+        // Simulate save + refresh: mutate and re-snapshot
+        item.Value = "v2";
+        _sut.Record(owner, [nav], isTracking: true);
+
+        OwnedCollectionSnapshot.OriginalItems.TryGetValue(owner, out var items);
+        // Second snapshot should capture the updated value
+        Assert.Equal("v2", items![nameof(Owner.Items)][0][nameof(Item.Value)]);
+    }
+}

--- a/tests/Couchbase.EntityFrameworkCore.UnitTests/Couchbase/EntityFrameworkCore/Query/CouchbaseOwnedCollectionMaterializerTests.cs
+++ b/tests/Couchbase.EntityFrameworkCore.UnitTests/Couchbase/EntityFrameworkCore/Query/CouchbaseOwnedCollectionMaterializerTests.cs
@@ -1,5 +1,7 @@
 using System.Text.Json;
+using Couchbase.EntityFrameworkCore.Extensions;
 using Couchbase.EntityFrameworkCore.Query.Internal;
+using Microsoft.EntityFrameworkCore;
 using Xunit;
 
 namespace Couchbase.EntityFrameworkCore.UnitTests.Couchbase.EntityFrameworkCore.Query;
@@ -119,6 +121,139 @@ public class CouchbaseOwnedCollectionMaterializerTests
     // (full coverage is in integration tests; unit coverage below focuses on
     // the cases that do NOT need a live DB)
     // -------------------------------------------------------------------------
+
+    // MaterializeOwnedItem — unit tests using a Couchbase provider context so
+    // the model is fully finalised (same path as production queries).
+
+    // CLR types used by the MaterializeOwnedItem unit tests.
+    private class ItemOwner
+    {
+        public int Id { get; set; }
+        public List<OwnedItem> Items { get; set; } = [];
+        public FieldItem? Single { get; set; }
+    }
+
+    private class OwnedItem
+    {
+        public int Id { get; set; }
+        public string? Value { get; set; }
+        public HashSet<NestedTag> Tags { get; set; } = [];
+    }
+
+    private class NestedTag
+    {
+        public int Id { get; set; }
+        public string Key { get; set; } = "";
+    }
+
+    /// <summary>OwnsOne with a get-only scalar — no setter, EF must use backing field.</summary>
+    private class FieldItem
+    {
+        public string? Label { get; }
+        public FieldItem() { }
+        public FieldItem(string? label) { Label = label; }
+    }
+
+    private class ItemContext(DbContextOptions<ItemContext> options) : DbContext(options)
+    {
+        public DbSet<ItemOwner> Owners { get; set; } = null!;
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            modelBuilder.Entity<ItemOwner>(b =>
+            {
+                b.ToCouchbaseCollection("bucket", "scope", "owner");
+                b.HasKey(o => o.Id);
+                b.OwnsOne(o => o.Single, fi =>
+                    fi.Property(x => x.Label).UsePropertyAccessMode(PropertyAccessMode.Field));
+                b.OwnsMany(o => o.Items, cm =>
+                {
+                    cm.HasKey(i => i.Id);
+                    cm.OwnsMany(i => i.Tags, t => t.HasKey(t => t.Id));
+                });
+            });
+        }
+    }
+
+    private static ItemContext CreateItemContext()
+    {
+        var opts = new global::Couchbase.ClusterOptions()
+            .WithConnectionString("couchbase://localhost")
+            .WithPasswordAuthentication("Administrator", "password");
+        var builder = new DbContextOptionsBuilder<ItemContext>();
+        builder.UseCouchbaseProvider(opts);
+        return new ItemContext(builder.Options);
+    }
+
+    private static Microsoft.EntityFrameworkCore.Metadata.IEntityType GetOwnedType<T>(ItemContext ctx)
+        => ctx.Model.GetEntityTypes().First(e => e.ClrType == typeof(T));
+
+    [Fact]
+    public void MaterializeOwnedItem_ScalarProperties_AreSet()
+    {
+        using var ctx = CreateItemContext();
+        var itemType = GetOwnedType<OwnedItem>(ctx);
+        var policy  = JsonNamingPolicy.CamelCase;
+
+        var json = JsonDocument.Parse("""{"id":7,"value":"hello"}""").RootElement;
+        var result = CouchbaseOwnedCollectionMaterializer.MaterializeOwnedItem(json, itemType, policy, _webOptions);
+
+        var item = Assert.IsType<OwnedItem>(result);
+        Assert.Equal(7, item.Id);
+        Assert.Equal("hello", item.Value);
+    }
+
+    [Fact]
+    public void MaterializeOwnedItem_GetOnlyScalar_UsesFieldInfoFallback()
+    {
+        // FieldItem.Label has no setter — EF must write via the backing field.
+        using var ctx = CreateItemContext();
+        var fieldType = GetOwnedType<FieldItem>(ctx);
+        var policy    = JsonNamingPolicy.CamelCase;
+
+        var json = JsonDocument.Parse("""{"label":"work"}""").RootElement;
+        var result = CouchbaseOwnedCollectionMaterializer.MaterializeOwnedItem(json, fieldType, policy, _webOptions);
+
+        var item = Assert.IsType<FieldItem>(result);
+        Assert.Equal("work", item.Label);
+    }
+
+    [Fact]
+    public void MaterializeOwnedItem_NestedHashSet_IsPopulated()
+    {
+        // OwnedItem.Tags is a HashSet<NestedTag> — exercises the ICollection<T>
+        // clear path in the nested navigation loop of MaterializeOwnedItem.
+        using var ctx = CreateItemContext();
+        var itemType = GetOwnedType<OwnedItem>(ctx);
+        var policy   = JsonNamingPolicy.CamelCase;
+
+        var json = JsonDocument.Parse("""{"id":1,"value":"x","tags":[{"id":1,"key":"a"},{"id":2,"key":"b"}]}""").RootElement;
+        var result = CouchbaseOwnedCollectionMaterializer.MaterializeOwnedItem(json, itemType, policy, _webOptions);
+
+        var item = Assert.IsType<OwnedItem>(result);
+        Assert.Equal(2, item.Tags.Count);
+        Assert.Contains(item.Tags, t => t.Key == "a");
+        Assert.Contains(item.Tags, t => t.Key == "b");
+    }
+
+    [Fact]
+    public void MaterializeOwnedItem_NestedHashSet_NoDuplicatesOnRepeatCall()
+    {
+        // Calling MaterializeOwnedItem twice on a JSON element with the same item
+        // must not accumulate duplicates in the HashSet — the clear must run.
+        using var ctx = CreateItemContext();
+        var itemType = GetOwnedType<OwnedItem>(ctx);
+        var policy   = JsonNamingPolicy.CamelCase;
+
+        var json = JsonDocument.Parse("""{"id":1,"value":"x","tags":[{"id":1,"key":"a"}]}""").RootElement;
+
+        // First materialisation
+        var result1 = (OwnedItem)CouchbaseOwnedCollectionMaterializer.MaterializeOwnedItem(json, itemType, policy, _webOptions);
+        Assert.Single(result1.Tags);
+
+        // Second materialisation of the same JSON must also yield exactly 1 tag.
+        var result2 = (OwnedItem)CouchbaseOwnedCollectionMaterializer.MaterializeOwnedItem(json, itemType, policy, _webOptions);
+        Assert.Single(result2.Tags);
+    }
 
     // Note: MaterializeOwnedItem requires IEntityType from an EF Core model, which
     // requires model-building infrastructure. Those scenarios are covered by the

--- a/tests/Couchbase.EntityFrameworkCore.UnitTests/Couchbase/EntityFrameworkCore/Query/CouchbaseOwnedCollectionMaterializerTests.cs
+++ b/tests/Couchbase.EntityFrameworkCore.UnitTests/Couchbase/EntityFrameworkCore/Query/CouchbaseOwnedCollectionMaterializerTests.cs
@@ -109,7 +109,8 @@ public class CouchbaseOwnedCollectionMaterializerTests
         var base64 = Convert.ToBase64String(bytes);
         var el = JsonDocument.Parse($"\"{base64}\"").RootElement;
         var result = CouchbaseOwnedCollectionMaterializer.ConvertJsonValue(el, typeof(byte[]), _webOptions);
-        Assert.Equal(bytes, result);
+        var typed = Assert.IsType<byte[]>(result);
+        Assert.Equal(bytes, typed);
     }
 
     // -------------------------------------------------------------------------

--- a/tests/Couchbase.EntityFrameworkCore.UnitTests/Couchbase/EntityFrameworkCore/Query/CouchbaseOwnedCollectionMaterializerTests.cs
+++ b/tests/Couchbase.EntityFrameworkCore.UnitTests/Couchbase/EntityFrameworkCore/Query/CouchbaseOwnedCollectionMaterializerTests.cs
@@ -1,0 +1,126 @@
+using System.Text.Json;
+using Couchbase.EntityFrameworkCore.Query.Internal;
+using Xunit;
+
+namespace Couchbase.EntityFrameworkCore.UnitTests.Couchbase.EntityFrameworkCore.Query;
+
+/// <summary>
+/// Unit tests for <see cref="CouchbaseOwnedCollectionMaterializer"/>.
+/// These tests exercise <see cref="CouchbaseOwnedCollectionMaterializer.MaterializeOwnedItem"/>
+/// and <see cref="CouchbaseOwnedCollectionMaterializer.ConvertJsonValue"/> directly — no live
+/// Couchbase server or EF Core DbContext required.
+/// </summary>
+public class CouchbaseOwnedCollectionMaterializerTests
+{
+    private static readonly JsonSerializerOptions _webOptions = new(JsonSerializerDefaults.Web);
+
+    // -------------------------------------------------------------------------
+    // ConvertJsonValue — scalar type mapping
+    // -------------------------------------------------------------------------
+
+    [Fact]
+    public void ConvertJsonValue_String_ReturnsString()
+    {
+        var el = JsonDocument.Parse("\"hello\"").RootElement;
+        Assert.Equal("hello", CouchbaseOwnedCollectionMaterializer.ConvertJsonValue(el, typeof(string), _webOptions));
+    }
+
+    [Fact]
+    public void ConvertJsonValue_Int_ReturnsInt()
+    {
+        var el = JsonDocument.Parse("42").RootElement;
+        Assert.Equal(42, CouchbaseOwnedCollectionMaterializer.ConvertJsonValue(el, typeof(int), _webOptions));
+    }
+
+    [Fact]
+    public void ConvertJsonValue_Long_ReturnsLong()
+    {
+        var el = JsonDocument.Parse("9999999999").RootElement;
+        Assert.Equal(9999999999L, CouchbaseOwnedCollectionMaterializer.ConvertJsonValue(el, typeof(long), _webOptions));
+    }
+
+    [Fact]
+    public void ConvertJsonValue_Double_ReturnsDouble()
+    {
+        var el = JsonDocument.Parse("3.14").RootElement;
+        Assert.Equal(3.14, CouchbaseOwnedCollectionMaterializer.ConvertJsonValue(el, typeof(double), _webOptions));
+    }
+
+    [Fact]
+    public void ConvertJsonValue_Float_ReturnsFloat()
+    {
+        var el = JsonDocument.Parse("1.5").RootElement;
+        Assert.Equal(1.5f, CouchbaseOwnedCollectionMaterializer.ConvertJsonValue(el, typeof(float), _webOptions));
+    }
+
+    [Fact]
+    public void ConvertJsonValue_Decimal_ReturnsDecimal()
+    {
+        var el = JsonDocument.Parse("123.456").RootElement;
+        Assert.Equal(123.456m, CouchbaseOwnedCollectionMaterializer.ConvertJsonValue(el, typeof(decimal), _webOptions));
+    }
+
+    [Fact]
+    public void ConvertJsonValue_Bool_ReturnsBool()
+    {
+        var t = JsonDocument.Parse("true").RootElement;
+        var f = JsonDocument.Parse("false").RootElement;
+        Assert.Equal(true,  CouchbaseOwnedCollectionMaterializer.ConvertJsonValue(t, typeof(bool), _webOptions));
+        Assert.Equal(false, CouchbaseOwnedCollectionMaterializer.ConvertJsonValue(f, typeof(bool), _webOptions));
+    }
+
+    [Fact]
+    public void ConvertJsonValue_Guid_ReturnsGuid()
+    {
+        var guid = Guid.NewGuid();
+        var el = JsonDocument.Parse($"\"{guid}\"").RootElement;
+        Assert.Equal(guid, CouchbaseOwnedCollectionMaterializer.ConvertJsonValue(el, typeof(Guid), _webOptions));
+    }
+
+    [Fact]
+    public void ConvertJsonValue_DateTime_ReturnsDateTime()
+    {
+        var el = JsonDocument.Parse("\"2024-01-15T12:00:00\"").RootElement;
+        var result = CouchbaseOwnedCollectionMaterializer.ConvertJsonValue(el, typeof(DateTime), _webOptions);
+        Assert.Equal(new DateTime(2024, 1, 15, 12, 0, 0), result);
+    }
+
+    [Fact]
+    public void ConvertJsonValue_NullableInt_ReturnsInt()
+    {
+        var el = JsonDocument.Parse("7").RootElement;
+        Assert.Equal(7, CouchbaseOwnedCollectionMaterializer.ConvertJsonValue(el, typeof(int?), _webOptions));
+    }
+
+    [Fact]
+    public void ConvertJsonValue_JsonNull_ReturnsNull()
+    {
+        var el = JsonDocument.Parse("null").RootElement;
+        Assert.Null(CouchbaseOwnedCollectionMaterializer.ConvertJsonValue(el, typeof(string), _webOptions));
+        Assert.Null(CouchbaseOwnedCollectionMaterializer.ConvertJsonValue(el, typeof(int?), _webOptions));
+    }
+
+    [Fact]
+    public void ConvertJsonValue_UnknownType_FallsBackToJsonSerializer()
+    {
+        // byte[] is not in the switch — falls back to JsonSerializer.Deserialize.
+        // System.Text.Json deserialises byte[] from a base-64 string, not a JSON array.
+        var bytes = new byte[] { 1, 2, 3 };
+        var base64 = Convert.ToBase64String(bytes);
+        var el = JsonDocument.Parse($"\"{base64}\"").RootElement;
+        var result = CouchbaseOwnedCollectionMaterializer.ConvertJsonValue(el, typeof(byte[]), _webOptions);
+        Assert.Equal(bytes, result);
+    }
+
+    // -------------------------------------------------------------------------
+    // MaterializeOwnedItem — requires EF Core IEntityType, so tested via
+    // the existing OwnedCollectionInjectionTests model contexts
+    // (full coverage is in integration tests; unit coverage below focuses on
+    // the cases that do NOT need a live DB)
+    // -------------------------------------------------------------------------
+
+    // Note: MaterializeOwnedItem requires IEntityType from an EF Core model, which
+    // requires model-building infrastructure. Those scenarios are covered by the
+    // existing integration tests (OwnedTypeTests). The pure JSON → CLR conversion
+    // path is covered above via ConvertJsonValue, which MaterializeOwnedItem delegates to.
+}

--- a/tests/Couchbase.EntityFrameworkCore.UnitTests/Couchbase/EntityFrameworkCore/Query/OwnedJoinOrderByFilterTests.cs
+++ b/tests/Couchbase.EntityFrameworkCore.UnitTests/Couchbase/EntityFrameworkCore/Query/OwnedJoinOrderByFilterTests.cs
@@ -8,11 +8,13 @@ namespace Couchbase.EntityFrameworkCore.UnitTests.Couchbase.EntityFrameworkCore.
 /// Verifies that <c>ORDER BY</c> terms referencing suppressed owned-type JOIN aliases are
 /// removed from the generated N1QL, so that no dangling alias references remain after
 /// <c>VisitLeftJoin</c> / <c>VisitInnerJoin</c> suppress the corresponding JOIN clauses.
+/// Covers depth-2 (Customer → Methods → Tags) and depth-3 (Customer → Methods → Tags → Audits)
+/// OwnsMany chains to verify that <c>IsAllOwnedTablesSelect</c> recurses correctly.
 /// </summary>
 public class OwnedJoinOrderByFilterTests
 {
     // -----------------------------------------------------------------------
-    // Model
+    // Depth-2 model: Customer → ContactMethods → Tags
     // -----------------------------------------------------------------------
 
     private class Customer
@@ -34,6 +36,21 @@ public class OwnedJoinOrderByFilterTests
     {
         public int Id { get; set; }
         public string Key { get; set; } = "";
+        public List<TagAudit> Audits { get; set; } = [];
+    }
+
+    // -----------------------------------------------------------------------
+    // Depth-3 model: adds TagAudit nested inside ContactTag
+    // Customer → ContactMethods → Tags → Audits
+    // Exercises the recursive path in IsAllOwnedTablesSelect that was missing
+    // before the fix — the lateral-join subquery for Audits is itself inside
+    // the Tags subquery, requiring recursion to detect it as all-owned.
+    // -----------------------------------------------------------------------
+
+    private class TagAudit
+    {
+        public int Id { get; set; }
+        public string Note { get; set; } = "";
     }
 
     private class CustomerContext(DbContextOptions<CustomerContext> options) : DbContext(options)
@@ -49,7 +66,11 @@ public class OwnedJoinOrderByFilterTests
                 b.OwnsMany(c => c.ContactMethods, cm =>
                 {
                     cm.HasKey(m => m.Id);
-                    cm.OwnsMany(m => m.Tags, t => t.HasKey(t => t.Id));
+                    cm.OwnsMany(m => m.Tags, t =>
+                    {
+                        t.HasKey(t => t.Id);
+                        t.OwnsMany(t => t.Audits, a => a.HasKey(a => a.Id));
+                    });
                 });
             });
         }
@@ -66,41 +87,42 @@ public class OwnedJoinOrderByFilterTests
     }
 
     // -----------------------------------------------------------------------
-    // Tests
+    // Helpers
+    // -----------------------------------------------------------------------
+
+    private static void AssertNoSuppressedAliasInOrderBy(string sql)
+    {
+        var orderByIndex = sql.IndexOf("ORDER BY", StringComparison.OrdinalIgnoreCase);
+        if (orderByIndex < 0) return;
+        var orderByClause = sql[orderByIndex..];
+        // No backtick-quoted alias referencing a suppressed owned-join table
+        // should appear after ORDER BY.
+        Assert.DoesNotContain("`s`.",  orderByClause, StringComparison.Ordinal);
+        Assert.DoesNotContain("`s0`.", orderByClause, StringComparison.Ordinal);
+        Assert.DoesNotContain("`s1`.", orderByClause, StringComparison.Ordinal);
+    }
+
+    // -----------------------------------------------------------------------
+    // Depth-2 tests (Customer → Methods → Tags)
     // -----------------------------------------------------------------------
 
     [Fact]
-    public void ToList_NoSuppressedAliasInOrderBy()
+    public void Depth2_ToList_NoSuppressedAliasInOrderBy()
     {
         using var ctx = CreateContext();
-        var sql = ctx.Customers.ToQueryString();
-
-        // The suppressed owned-join alias (e.g. "s") must not appear in ORDER BY.
-        // Owner ordering terms (e.g. d.customerId) are still permitted.
-        var orderByIndex = sql.IndexOf("ORDER BY", StringComparison.OrdinalIgnoreCase);
-        if (orderByIndex < 0) return; // no ORDER BY at all — trivially correct
-
-        var orderByClause = sql[orderByIndex..];
-        // Owned-join lateral alias "s" should not appear in the ORDER BY clause.
-        // (Owner alias "d" is fine.)
-        Assert.DoesNotContain("`s`.", orderByClause, StringComparison.Ordinal);
+        AssertNoSuppressedAliasInOrderBy(ctx.Customers.ToQueryString());
     }
 
     [Fact]
-    public void First_NoSuppressedAliasInOrderBy()
+    public void Depth2_First_NoSuppressedAliasInOrderBy()
     {
         using var ctx = CreateContext();
-        var sql = ctx.Customers.Where(c => c.CustomerId == 1).Take(1).ToQueryString();
-
-        var orderByIndex = sql.IndexOf("ORDER BY", StringComparison.OrdinalIgnoreCase);
-        if (orderByIndex < 0) return;
-
-        var orderByClause = sql[orderByIndex..];
-        Assert.DoesNotContain("`s`.", orderByClause, StringComparison.Ordinal);
+        AssertNoSuppressedAliasInOrderBy(
+            ctx.Customers.Where(c => c.CustomerId == 1).Take(1).ToQueryString());
     }
 
     [Fact]
-    public void ToList_ParenthesesBalanced()
+    public void Depth2_ToList_ParenthesesBalanced()
     {
         using var ctx = CreateContext();
         var sql = ctx.Customers.ToQueryString();
@@ -108,7 +130,7 @@ public class OwnedJoinOrderByFilterTests
     }
 
     [Fact]
-    public void First_ParenthesesBalanced()
+    public void Depth2_First_ParenthesesBalanced()
     {
         using var ctx = CreateContext();
         var sql = ctx.Customers.Where(c => c.CustomerId == 1).Take(1).ToQueryString();
@@ -116,10 +138,66 @@ public class OwnedJoinOrderByFilterTests
     }
 
     [Fact]
-    public void ToList_NoJoinEmitted()
+    public void Depth2_ToList_NoJoinEmitted()
+    {
+        using var ctx = CreateContext();
+        Assert.DoesNotContain("JOIN", ctx.Customers.ToQueryString(), StringComparison.OrdinalIgnoreCase);
+    }
+
+    // -----------------------------------------------------------------------
+    // Depth-3 tests (Customer → Methods → Tags → Audits)
+    // These verify the recursive IsAllOwnedTablesSelect fix.
+    // Before the fix, the TagAudit lateral-join subquery was not recognised as
+    // all-owned, causing an empty FROM clause (N1QL error 3000) and a dangling
+    // ORDER BY alias.
+    // -----------------------------------------------------------------------
+
+    [Fact]
+    public void Depth3_ToList_NoSuppressedAliasInOrderBy()
+    {
+        using var ctx = CreateContext();
+        AssertNoSuppressedAliasInOrderBy(ctx.Customers.ToQueryString());
+    }
+
+    [Fact]
+    public void Depth3_First_NoSuppressedAliasInOrderBy()
+    {
+        using var ctx = CreateContext();
+        AssertNoSuppressedAliasInOrderBy(
+            ctx.Customers.Where(c => c.CustomerId == 1).Take(1).ToQueryString());
+    }
+
+    [Fact]
+    public void Depth3_ToList_NoJoinEmitted()
+    {
+        using var ctx = CreateContext();
+        Assert.DoesNotContain("JOIN", ctx.Customers.ToQueryString(), StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void Depth3_ToList_NoEmptyFromClause()
     {
         using var ctx = CreateContext();
         var sql = ctx.Customers.ToQueryString();
-        Assert.DoesNotContain("JOIN", sql, StringComparison.OrdinalIgnoreCase);
+        // An empty FROM clause is the N1QL symptom of an unsuppressed owned-join
+        // subquery with no tables (error 3000).  Verify it does not appear.
+        Assert.DoesNotContain("FROM\n", sql, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("FROM\r\n", sql, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void Depth3_ToList_ParenthesesBalanced()
+    {
+        using var ctx = CreateContext();
+        var sql = ctx.Customers.ToQueryString();
+        Assert.Equal(sql.Count(c => c == '('), sql.Count(c => c == ')'));
+    }
+
+    [Fact]
+    public void Depth3_First_ParenthesesBalanced()
+    {
+        using var ctx = CreateContext();
+        var sql = ctx.Customers.Where(c => c.CustomerId == 1).Take(1).ToQueryString();
+        Assert.Equal(sql.Count(c => c == '('), sql.Count(c => c == ')'));
     }
 }

--- a/tests/Couchbase.EntityFrameworkCore.UnitTests/Couchbase/EntityFrameworkCore/Query/OwnedJoinOrderByFilterTests.cs
+++ b/tests/Couchbase.EntityFrameworkCore.UnitTests/Couchbase/EntityFrameworkCore/Query/OwnedJoinOrderByFilterTests.cs
@@ -1,3 +1,4 @@
+using System.Text.RegularExpressions;
 using Couchbase.EntityFrameworkCore.Extensions;
 using Microsoft.EntityFrameworkCore;
 using Xunit;
@@ -90,16 +91,34 @@ public class OwnedJoinOrderByFilterTests
     // Helpers
     // -----------------------------------------------------------------------
 
+    /// <summary>
+    /// Asserts that every table alias referenced in the ORDER BY clause is also
+    /// defined as a live alias in the FROM/JOIN clauses of the same SQL statement.
+    /// This is alias-name-agnostic — it does not hard-code "s", "s0", etc., so it
+    /// correctly catches any dangling suppressed alias regardless of what EF assigns.
+    /// </summary>
     private static void AssertNoSuppressedAliasInOrderBy(string sql)
     {
         var orderByIndex = sql.IndexOf("ORDER BY", StringComparison.OrdinalIgnoreCase);
         if (orderByIndex < 0) return;
+
+        // Collect every alias defined in FROM/AS and JOIN/AS clauses before ORDER BY.
+        // Pattern: AS `alias`  (EF always uses backtick-quoted aliases)
+        var fromSection = sql[..orderByIndex];
+        var definedAliases = new HashSet<string>(
+            Regex.Matches(fromSection, @"AS\s+`([^`]+)`")
+                 .Select(m => m.Groups[1].Value),
+            StringComparer.Ordinal);
+
+        // Collect every alias *used* in ORDER BY: `alias`.`column`
         var orderByClause = sql[orderByIndex..];
-        // No backtick-quoted alias referencing a suppressed owned-join table
-        // should appear after ORDER BY.
-        Assert.DoesNotContain("`s`.",  orderByClause, StringComparison.Ordinal);
-        Assert.DoesNotContain("`s0`.", orderByClause, StringComparison.Ordinal);
-        Assert.DoesNotContain("`s1`.", orderByClause, StringComparison.Ordinal);
+        var usedAliases = Regex.Matches(orderByClause, @"`([^`]+)`\.")
+                               .Select(m => m.Groups[1].Value)
+                               .Distinct();
+
+        foreach (var alias in usedAliases)
+            Assert.Contains(alias, definedAliases,
+                $"ORDER BY references alias `{alias}` which is not defined in FROM/JOIN — dangling suppressed alias.");
     }
 
     // -----------------------------------------------------------------------

--- a/tests/Couchbase.EntityFrameworkCore.UnitTests/Couchbase/EntityFrameworkCore/Query/OwnedJoinOrderByFilterTests.cs
+++ b/tests/Couchbase.EntityFrameworkCore.UnitTests/Couchbase/EntityFrameworkCore/Query/OwnedJoinOrderByFilterTests.cs
@@ -1,0 +1,125 @@
+using Couchbase.EntityFrameworkCore.Extensions;
+using Microsoft.EntityFrameworkCore;
+using Xunit;
+
+namespace Couchbase.EntityFrameworkCore.UnitTests.Couchbase.EntityFrameworkCore.Query;
+
+/// <summary>
+/// Verifies that <c>ORDER BY</c> terms referencing suppressed owned-type JOIN aliases are
+/// removed from the generated N1QL, so that no dangling alias references remain after
+/// <c>VisitLeftJoin</c> / <c>VisitInnerJoin</c> suppress the corresponding JOIN clauses.
+/// </summary>
+public class OwnedJoinOrderByFilterTests
+{
+    // -----------------------------------------------------------------------
+    // Model
+    // -----------------------------------------------------------------------
+
+    private class Customer
+    {
+        public int CustomerId { get; set; }
+        public string Name { get; set; } = "";
+        public List<ContactMethod> ContactMethods { get; set; } = [];
+    }
+
+    private class ContactMethod
+    {
+        public int Id { get; set; }
+        public string Type { get; set; } = "";
+        public string Value { get; set; } = "";
+        public List<ContactTag> Tags { get; set; } = [];
+    }
+
+    private class ContactTag
+    {
+        public int Id { get; set; }
+        public string Key { get; set; } = "";
+    }
+
+    private class CustomerContext(DbContextOptions<CustomerContext> options) : DbContext(options)
+    {
+        public DbSet<Customer> Customers { get; set; } = null!;
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            modelBuilder.Entity<Customer>(b =>
+            {
+                b.ToCouchbaseCollection("bucket", "scope", "customer");
+                b.HasKey(c => c.CustomerId);
+                b.OwnsMany(c => c.ContactMethods, cm =>
+                {
+                    cm.HasKey(m => m.Id);
+                    cm.OwnsMany(m => m.Tags, t => t.HasKey(t => t.Id));
+                });
+            });
+        }
+    }
+
+    private static CustomerContext CreateContext()
+    {
+        var clusterOptions = new global::Couchbase.ClusterOptions()
+            .WithConnectionString("couchbase://localhost")
+            .WithPasswordAuthentication("Administrator", "password");
+        var builder = new DbContextOptionsBuilder<CustomerContext>();
+        builder.UseCouchbaseProvider(clusterOptions);
+        return new CustomerContext(builder.Options);
+    }
+
+    // -----------------------------------------------------------------------
+    // Tests
+    // -----------------------------------------------------------------------
+
+    [Fact]
+    public void ToList_NoSuppressedAliasInOrderBy()
+    {
+        using var ctx = CreateContext();
+        var sql = ctx.Customers.ToQueryString();
+
+        // The suppressed owned-join alias (e.g. "s") must not appear in ORDER BY.
+        // Owner ordering terms (e.g. d.customerId) are still permitted.
+        var orderByIndex = sql.IndexOf("ORDER BY", StringComparison.OrdinalIgnoreCase);
+        if (orderByIndex < 0) return; // no ORDER BY at all — trivially correct
+
+        var orderByClause = sql[orderByIndex..];
+        // Owned-join lateral alias "s" should not appear in the ORDER BY clause.
+        // (Owner alias "d" is fine.)
+        Assert.DoesNotContain("`s`.", orderByClause, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void First_NoSuppressedAliasInOrderBy()
+    {
+        using var ctx = CreateContext();
+        var sql = ctx.Customers.Where(c => c.CustomerId == 1).Take(1).ToQueryString();
+
+        var orderByIndex = sql.IndexOf("ORDER BY", StringComparison.OrdinalIgnoreCase);
+        if (orderByIndex < 0) return;
+
+        var orderByClause = sql[orderByIndex..];
+        Assert.DoesNotContain("`s`.", orderByClause, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void ToList_ParenthesesBalanced()
+    {
+        using var ctx = CreateContext();
+        var sql = ctx.Customers.ToQueryString();
+        Assert.Equal(sql.Count(c => c == '('), sql.Count(c => c == ')'));
+    }
+
+    [Fact]
+    public void First_ParenthesesBalanced()
+    {
+        using var ctx = CreateContext();
+        var sql = ctx.Customers.Where(c => c.CustomerId == 1).Take(1).ToQueryString();
+        Assert.Equal(sql.Count(c => c == '('), sql.Count(c => c == ')'));
+    }
+
+    [Fact]
+    public void ToList_NoJoinEmitted()
+    {
+        using var ctx = CreateContext();
+        var sql = ctx.Customers.ToQueryString();
+        Assert.DoesNotContain("JOIN", sql, StringComparison.OrdinalIgnoreCase);
+    }
+}

--- a/tests/Couchbase.EntityFrameworkCore.UnitTests/Couchbase/EntityFrameworkCore/Query/OwnedJoinOrderByFilterTests.cs
+++ b/tests/Couchbase.EntityFrameworkCore.UnitTests/Couchbase/EntityFrameworkCore/Query/OwnedJoinOrderByFilterTests.cs
@@ -117,7 +117,7 @@ public class OwnedJoinOrderByFilterTests
                                .Distinct();
 
         foreach (var alias in usedAliases)
-            Assert.Contains(alias, definedAliases,
+            Assert.True(definedAliases.Contains(alias),
                 $"ORDER BY references alias `{alias}` which is not defined in FROM/JOIN — dangling suppressed alias.");
     }
 

--- a/tests/Couchbase.EntityFrameworkCore.UnitTests/Couchbase/EntityFrameworkCore/Query/OwnedJoinOrderByFilterTests.cs
+++ b/tests/Couchbase.EntityFrameworkCore.UnitTests/Couchbase/EntityFrameworkCore/Query/OwnedJoinOrderByFilterTests.cs
@@ -200,4 +200,81 @@ public class OwnedJoinOrderByFilterTests
         var sql = ctx.Customers.Where(c => c.CustomerId == 1).Take(1).ToQueryString();
         Assert.Equal(sql.Count(c => c == '('), sql.Count(c => c == ')'));
     }
+
+    // -----------------------------------------------------------------------
+    // EmitOrdering — verifies that the extracted helper correctly emits
+    // ASC / DESC and that surviving owner-column orderings are preserved
+    // after the suppressed-alias filter runs.
+    // -----------------------------------------------------------------------
+
+    [Fact]
+    public void EmitOrdering_AscendingOrderBy_EmitsAsc()
+    {
+        // Default OrderBy is ascending — verify "ASC" appears in the ORDER BY clause.
+        using var ctx = CreateContext();
+        var sql = ctx.Customers
+            .OrderBy(c => c.CustomerId)
+            .ToQueryString();
+
+        var orderByIndex = sql.IndexOf("ORDER BY", StringComparison.OrdinalIgnoreCase);
+        Assert.True(orderByIndex >= 0, "Expected an ORDER BY clause");
+        Assert.Contains("ASC", sql[orderByIndex..], StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void EmitOrdering_DescendingOrderBy_EmitsDesc()
+    {
+        // OrderByDescending — verify "DESC" appears in the ORDER BY clause.
+        using var ctx = CreateContext();
+        var sql = ctx.Customers
+            .OrderByDescending(c => c.CustomerId)
+            .ToQueryString();
+
+        var orderByIndex = sql.IndexOf("ORDER BY", StringComparison.OrdinalIgnoreCase);
+        Assert.True(orderByIndex >= 0, "Expected an ORDER BY clause");
+        Assert.Contains("DESC", sql[orderByIndex..], StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void EmitOrdering_OwnerColumnPreserved_AfterSuppressedAliasFiltered()
+    {
+        // When suppressed-alias orderings are dropped, surviving owner-column
+        // orderings must still appear with the correct direction.
+        using var ctx = CreateContext();
+        var sql = ctx.Customers
+            .OrderByDescending(c => c.CustomerId)
+            .ToQueryString();
+
+        var orderByIndex = sql.IndexOf("ORDER BY", StringComparison.OrdinalIgnoreCase);
+        Assert.True(orderByIndex >= 0, "Expected an ORDER BY clause");
+        var orderByClause = sql[orderByIndex..];
+
+        // Owner column must be present.
+        Assert.Contains("CustomerId", orderByClause, StringComparison.OrdinalIgnoreCase);
+        // Direction must be DESC as requested.
+        Assert.Contains("DESC", orderByClause, StringComparison.OrdinalIgnoreCase);
+        // No suppressed alias must leak through.
+        AssertNoSuppressedAliasInOrderBy(sql);
+    }
+
+    [Fact]
+    public void EmitOrdering_MultipleOwnerColumns_AllPreserved()
+    {
+        // Multiple surviving ORDER BY terms must all appear — none should be dropped.
+        using var ctx = CreateContext();
+        var sql = ctx.Customers
+            .OrderBy(c => c.CustomerId)
+            .ThenByDescending(c => c.Name)
+            .ToQueryString();
+
+        var orderByIndex = sql.IndexOf("ORDER BY", StringComparison.OrdinalIgnoreCase);
+        Assert.True(orderByIndex >= 0, "Expected an ORDER BY clause");
+        var orderByClause = sql[orderByIndex..];
+
+        Assert.Contains("CustomerId", orderByClause, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("Name",       orderByClause, StringComparison.OrdinalIgnoreCase);
+        // First column ASC, second DESC.
+        Assert.Contains("ASC",  orderByClause, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("DESC", orderByClause, StringComparison.OrdinalIgnoreCase);
+    }
 }

--- a/tests/Couchbase.EntityFrameworkCore.UnitTests/Couchbase/EntityFrameworkCore/Query/PopulateCollectionNavigationsTests.cs
+++ b/tests/Couchbase.EntityFrameworkCore.UnitTests/Couchbase/EntityFrameworkCore/Query/PopulateCollectionNavigationsTests.cs
@@ -1,5 +1,4 @@
 using System.Collections;
-using System.Reflection;
 using System.Text.Json;
 using Couchbase.EntityFrameworkCore.Query.Internal;
 using Microsoft.EntityFrameworkCore.Infrastructure;
@@ -28,14 +27,12 @@ public class PopulateCollectionNavigationsTests
         public string? Value { get; set; }
     }
 
-    // Reflection entry point — PopulateCollectionNavigations is private static on the generic class.
-    private static readonly MethodInfo PopulateMethod =
-        typeof(CouchbaseQueryEnumerable<OwnerEntity>)
-            .GetMethod("PopulateCollectionNavigations", BindingFlags.NonPublic | BindingFlags.Static)!;
+    // Direct call — PopulateCollectionNavigations now lives in CouchbaseOwnedCollectionMaterializer.
+    private static readonly CouchbaseOwnedCollectionMaterializer _materializer = new();
 
     private static void Populate(OwnerEntity entity, JsonElement doc, IReadOnlyList<INavigation> navs,
         JsonNamingPolicy? policy = null, JsonSerializerOptions? serializerOptions = null)
-        => PopulateMethod.Invoke(null, [entity, doc, navs, policy, serializerOptions]);
+        => _materializer.Populate(entity, doc, navs, policy, serializerOptions);
 
     /// <summary>
     /// Builds a mock INavigation whose single owned property has CLR name "Value"


### PR DESCRIPTION
Extracts materialisation and snapshot logic out of CouchbaseQueryEnumerable<T> so each concern can be tested and reused independently.

Phase 1 — moves PopulateCollectionNavigations, MaterializeOwnedItem, and ConvertJsonValue into a new CouchbaseOwnedCollectionMaterializer class; also fixes the remaining (coll as IList)?.Clear() bug in the top-level populate path
Phase 2 — moves SnapshotCollectionRefs into a new CouchbaseCollectionSnapshot class; enumerator now delegates all three snapshot call sites to it
CouchbaseQueryEnumerable is now responsible only for executing the N1QL query and driving the EF Core shaper. All existing tests pass unchanged.