### PR TITLE
Add HasMany/WithMany (ISkipNavigation) many-to-many support

### DIFF
--- a/src/Couchbase.EntityFrameworkCore/Extensions/EntityTypeExtensions.cs
+++ b/src/Couchbase.EntityFrameworkCore/Extensions/EntityTypeExtensions.cs
@@ -44,9 +44,13 @@ public static class EntityTypeExtensions
     /// </summary>
     public static string GetPrimaryKey(this IEntityType entityType, Microsoft.EntityFrameworkCore.Update.IUpdateEntry updateEntry)
     {
-        var keys = entityType.FindPrimaryKey().Properties.ToArray();
+        var primaryKey = entityType.FindPrimaryKey()
+            ?? throw new InvalidOperationException(
+                $"Entity type '{entityType.DisplayName()}' has no primary key defined. " +
+                "Keyless entity types cannot be used with GetPrimaryKey.");
+
         var compositeKey = new StringBuilder();
-        foreach (var key in keys)
+        foreach (var key in primaryKey.Properties)
         {
             if (compositeKey.Length > 0)
                 compositeKey.Append('_');

--- a/src/Couchbase.EntityFrameworkCore/Extensions/EntityTypeExtensions.cs
+++ b/src/Couchbase.EntityFrameworkCore/Extensions/EntityTypeExtensions.cs
@@ -34,6 +34,26 @@ public static class EntityTypeExtensions
 
         return compositeKey.ToString();
     }
+
+    /// <summary>
+    /// Returns the document key for <paramref name="updateEntry"/>, reading PK values
+    /// from the update entry directly.  This handles shared entity types (e.g. the hidden
+    /// join table created by <c>HasMany().WithMany()</c>) whose PK columns are shadow
+    /// properties — <see cref="GetPrimaryKey(IEntityType,object)"/> cannot read these via
+    /// CLR <c>PropertyInfo</c>.
+    /// </summary>
+    public static string GetPrimaryKey(this IEntityType entityType, Microsoft.EntityFrameworkCore.Update.IUpdateEntry updateEntry)
+    {
+        var keys = entityType.FindPrimaryKey().Properties.ToArray();
+        var compositeKey = new StringBuilder();
+        foreach (var key in keys)
+        {
+            if (compositeKey.Length > 0)
+                compositeKey.Append('_');
+            compositeKey.Append(updateEntry.GetCurrentValue(key));
+        }
+        return compositeKey.ToString();
+    }
 }
 
 /* ************************************************************

--- a/src/Couchbase.EntityFrameworkCore/Query/Internal/CouchbaseShapedQueryCompilingExpressionVisitor.cs
+++ b/src/Couchbase.EntityFrameworkCore/Query/Internal/CouchbaseShapedQueryCompilingExpressionVisitor.cs
@@ -83,17 +83,20 @@ public class CouchbaseShapedQueryCompilingExpressionVisitor : RelationalShapedQu
 
         while (current is IncludeExpression include)
         {
-            // ISkipNavigation (many-to-many) is intentionally excluded here — Phase 4 will
-            // address skip navigations as a distinct case with their own representation.
+            // Both INavigation (FK-based) and ISkipNavigation (HasMany/WithMany) are recorded.
+            // The EF Core shaper handles collection accumulation for both via the standard
+            // SingleQueryResultCoordinator path — no custom population code is needed.
             //
             // Filter is always null here: by the time VisitShapedQuery runs, any filter
             // lambda from a filtered include (.Include(b => b.Posts.Where(...))) has already
             // been translated into a SQL predicate inside the SelectExpression and is no
             // longer recoverable as a LambdaExpression from IncludeExpression.NavigationExpression.
-            // Phase 4 must detect filtered includes by inspecting RelationalCollectionShaperExpression
+            // Filtered includes must be detected by inspecting RelationalCollectionShaperExpression
             // or the inner SelectExpression's WHERE clause rather than relying on Filter here.
             if (include.Navigation is INavigation nav)
                 collected.Add(new NavigationInclude(nav, null, ExtractChildren(include.NavigationExpression)));
+            else if (include.Navigation is ISkipNavigation skipNav)
+                collected.Add(new NavigationInclude(skipNav, null, ExtractChildren(include.NavigationExpression)));
 
             current = include.EntityExpression;
         }

--- a/src/Couchbase.EntityFrameworkCore/Query/Internal/NavigationInclude.cs
+++ b/src/Couchbase.EntityFrameworkCore/Query/Internal/NavigationInclude.cs
@@ -8,9 +8,14 @@ namespace Couchbase.EntityFrameworkCore.Query.Internal;
 
 /// <summary>
 /// Records a single navigation include (from .Include() or .ThenInclude()) for use
-/// during result shaping in Phase 4. Children represent ThenInclude chains.
+/// during result shaping. Children represent ThenInclude chains.
+/// <para>
+/// <see cref="Navigation"/> may be an <see cref="INavigation"/> (FK-based) or an
+/// <see cref="ISkipNavigation"/> (HasMany/WithMany transparent join table) — both
+/// implement <see cref="INavigationBase"/>.
+/// </para>
 /// </summary>
 public record NavigationInclude(
-    INavigation Navigation,
+    INavigationBase Navigation,
     LambdaExpression? Filter,
     List<NavigationInclude> Children);

--- a/src/Couchbase.EntityFrameworkCore/Storage/Internal/CouchbaseDatabaseWrapper.cs
+++ b/src/Couchbase.EntityFrameworkCore/Storage/Internal/CouchbaseDatabaseWrapper.cs
@@ -70,7 +70,12 @@ public class CouchbaseDatabaseWrapper : Database
                 continue;
             }
 
-            var primaryKey = entityType.GetPrimaryKey(entity);
+            // Shared entity types (e.g. hidden join table from HasMany().WithMany()) have
+            // all PK columns as shadow properties — use the IUpdateEntry overload so the
+            // values are read from the entry rather than the CLR Dictionary<string,object>.
+            var primaryKey = entityType.HasSharedClrType
+                ? entityType.GetPrimaryKey(updateEntry)
+                : entityType.GetPrimaryKey(entity);
             var keyspace = entityType.GetCollectionName()
                 ?? throw new InvalidOperationException(
                     $"Entity type '{entityType.ClrType.Name}' has no mapped table name. " +
@@ -241,8 +246,29 @@ public class CouchbaseDatabaseWrapper : Database
 
         // No owned navigations: use CLR instance so the SDK's camelCase serializer produces
         // the same field names that already work for all existing entity types.
+        //
+        // Exception: shared entity types (HasSharedClrType == true, e.g. the hidden join
+        // entity for skip navigations / HasMany().WithMany()) use Dictionary<string,object>
+        // as their CLR type.  All their FK properties are shadow properties — the standard
+        // IsShadowProperty filter would produce an empty document.  Additionally, Dictionary's
+        // indexer throws TargetParameterCountException when PropertyInfo.SetValue is called
+        // without index arguments.  For shared types we therefore build a plain dictionary
+        // keyed by column name from ALL (including shadow) properties.
         if (ownedNavs.Count == 0)
         {
+            if (entityType.HasSharedClrType)
+            {
+                // Shared entity type (skip-navigation join table): all FK columns are shadow
+                // properties — write every property value by column name.
+                var joinDoc = new Dictionary<string, object?>();
+                foreach (var property in entityType.GetProperties())
+                {
+                    var fieldName = fieldNamingPolicy?.ConvertName(property.GetColumnName()) ?? property.GetColumnName();
+                    joinDoc[fieldName] = updateEntry.GetCurrentValue(property);
+                }
+                return joinDoc;
+            }
+
             var obj = Activator.CreateInstance(entityType.ClrType)!;
             foreach (var property in entityType.GetProperties())
             {

--- a/src/Couchbase.EntityFrameworkCore/Storage/Internal/CouchbaseDatabaseWrapper.cs
+++ b/src/Couchbase.EntityFrameworkCore/Storage/Internal/CouchbaseDatabaseWrapper.cs
@@ -236,7 +236,7 @@ public class CouchbaseDatabaseWrapper : Database
         return null;
     }
 
-    private static object HydrateObjectFromEntity(IUpdateEntry updateEntry, JsonNamingPolicy? fieldNamingPolicy = null)
+    internal static object HydrateObjectFromEntity(IUpdateEntry updateEntry, JsonNamingPolicy? fieldNamingPolicy = null)
     {
         var entityType = updateEntry.EntityType;
 
@@ -263,8 +263,12 @@ public class CouchbaseDatabaseWrapper : Database
                 var joinDoc = new Dictionary<string, object?>();
                 foreach (var property in entityType.GetProperties())
                 {
-                    var fieldName = fieldNamingPolicy?.ConvertName(property.GetColumnName()) ?? property.GetColumnName();
-                    joinDoc[fieldName] = updateEntry.GetCurrentValue(property);
+                    // Use GetColumnName() verbatim — do NOT apply fieldNamingPolicy here.
+                    // The SQL generation path projects these columns by their exact column
+                    // name (e.g. "PostsPostId", "TagsTagId"), so the written document keys
+                    // must match. Applying a naming policy would silently diverge from the
+                    // SQL projection and make join documents unreadable on the query path.
+                    joinDoc[property.GetColumnName()] = updateEntry.GetCurrentValue(property);
                 }
                 return joinDoc;
             }

--- a/tests/Couchbase.EntityFrameworkCore.IntegrationTests/Fixtures/BloggingFixture.cs
+++ b/tests/Couchbase.EntityFrameworkCore.IntegrationTests/Fixtures/BloggingFixture.cs
@@ -14,6 +14,8 @@ public class BloggingFixture : CouchbaseFixture<BloggingDbContext>
     public override async Task InitializeAsync()
     {
         await base.InitializeAsync();
+        await using var ctx = GetDbContext();
+        await ctx.Database.EnsureCreatedAsync();
         await LoadDataAsync();
     }
 
@@ -156,6 +158,9 @@ public class BloggingFixture : CouchbaseFixture<BloggingDbContext>
         public Person Author { get; set; }
 
         public List<PostTag> Tags { get; set; }
+
+        /// <summary>Skip navigation — Post ↔ Tag via EF Core's transparent join table.</summary>
+        public ICollection<Tag> DirectTags { get; set; } = [];
     }
 
     public class Person
@@ -184,6 +189,9 @@ public class BloggingFixture : CouchbaseFixture<BloggingDbContext>
         public string TagId { get; set; }
 
         public List<PostTag> Posts { get; set; }
+
+        /// <summary>Inverse skip navigation for Post.DirectTags.</summary>
+        public ICollection<Post> DirectPosts { get; set; } = [];
     }
 
     public class PostTag

--- a/tests/Couchbase.EntityFrameworkCore.IntegrationTests/Models/BloggingDbContext.cs
+++ b/tests/Couchbase.EntityFrameworkCore.IntegrationTests/Models/BloggingDbContext.cs
@@ -113,11 +113,22 @@ public class BloggingDbContext(DbContextOptions<BloggingDbContext> options) : Db
                 });
 
         modelBuilder.Entity<BloggingFixture.Tag>()
+            .ToCouchbaseCollection(this, "tag")
             .HasData(
                 new BloggingFixture.Tag { TagId = "general" },
                 new BloggingFixture.Tag { TagId = "classic" },
                 new BloggingFixture.Tag { TagId = "opinion" },
                 new BloggingFixture.Tag { TagId = "informative" });
+
+        // Skip navigation: Post ↔ Tag via EF Core's transparent join table.
+        // ConfigureToCouchbase (called below) automatically maps the hidden join
+        // entity to bucket.scope.postdirecttag using EF Core's default naming.
+        // "PostDirectTag" avoids collision with the explicit PostTag join entity.
+        // ConfigureToCouchbase maps it to bucket.scope.postdirecttag automatically.
+        modelBuilder.Entity<BloggingFixture.Post>()
+            .HasMany(p => p.DirectTags)
+            .WithMany(t => t.DirectPosts)
+            .UsingEntity("PostDirectTag");
 
         modelBuilder.Entity<BloggingFixture.PostTag>()
             .HasData(

--- a/tests/Couchbase.EntityFrameworkCore.IntegrationTests/Models/BloggingDbContext.cs
+++ b/tests/Couchbase.EntityFrameworkCore.IntegrationTests/Models/BloggingDbContext.cs
@@ -121,10 +121,9 @@ public class BloggingDbContext(DbContextOptions<BloggingDbContext> options) : Db
                 new BloggingFixture.Tag { TagId = "informative" });
 
         // Skip navigation: Post ↔ Tag via EF Core's transparent join table.
-        // ConfigureToCouchbase (called below) automatically maps the hidden join
-        // entity to bucket.scope.postdirecttag using EF Core's default naming.
+        // ConfigureToCouchbase (called below) maps the hidden join entity to
+        // bucket.scope.postdirecttag using EF Core's default naming.
         // "PostDirectTag" avoids collision with the explicit PostTag join entity.
-        // ConfigureToCouchbase maps it to bucket.scope.postdirecttag automatically.
         modelBuilder.Entity<BloggingFixture.Post>()
             .HasMany(p => p.DirectTags)
             .WithMany(t => t.DirectPosts)

--- a/tests/Couchbase.EntityFrameworkCore.IntegrationTests/Tests/EagerLoadingTests.cs
+++ b/tests/Couchbase.EntityFrameworkCore.IntegrationTests/Tests/EagerLoadingTests.cs
@@ -30,6 +30,31 @@ public class EagerLoadingTests(BloggingFixture fixture) : IAsyncLifetime
         ctx.Update(new BloggingFixture.PersonPhoto { PersonPhotoId = 1, Caption = "SN", Photo = [0x00, 0x01] });
         ctx.Update(new BloggingFixture.PersonPhoto { PersonPhotoId = 2, Caption = "PF", Photo = [0x01, 0x02, 0x03] });
         ctx.Update(new BloggingFixture.PersonPhoto { PersonPhotoId = 3, Caption = "JD", Photo = [0x01, 0x01, 0x01] });
+        ctx.Update(new BloggingFixture.Tag { TagId = "general" });
+        ctx.Update(new BloggingFixture.Tag { TagId = "classic" });
+        ctx.Update(new BloggingFixture.Tag { TagId = "opinion" });
+        ctx.Update(new BloggingFixture.Tag { TagId = "informative" });
+        ctx.Update(new BloggingFixture.PostTag { PostTagId = 1, PostId = 1, TagId = "general" });
+        ctx.Update(new BloggingFixture.PostTag { PostTagId = 2, PostId = 1, TagId = "informative" });
+        ctx.Update(new BloggingFixture.PostTag { PostTagId = 3, PostId = 2, TagId = "classic" });
+        ctx.Update(new BloggingFixture.PostTag { PostTagId = 4, PostId = 3, TagId = "opinion" });
+        ctx.Update(new BloggingFixture.PostTag { PostTagId = 5, PostId = 4, TagId = "opinion" });
+        ctx.Update(new BloggingFixture.PostTag { PostTagId = 6, PostId = 4, TagId = "informative" });
+        await ctx.SaveChangesAsync();
+
+        // Seed skip-navigation join table data (mirrors the explicit PostTag data).
+        // Load with Include so Clear() can remove existing join entries (idempotent reseed).
+        var post1 = await ctx.Posts.Include(p => p.DirectTags).FirstAsync(p => p.PostId == 1);
+        var post4 = await ctx.Posts.Include(p => p.DirectTags).FirstAsync(p => p.PostId == 4);
+        var tagGeneral     = await ctx.Set<BloggingFixture.Tag>().FindAsync("general");
+        var tagInformative = await ctx.Set<BloggingFixture.Tag>().FindAsync("informative");
+        var tagOpinion     = await ctx.Set<BloggingFixture.Tag>().FindAsync("opinion");
+        post1.DirectTags.Clear();
+        post1.DirectTags.Add(tagGeneral!);
+        post1.DirectTags.Add(tagInformative!);
+        post4.DirectTags.Clear();
+        post4.DirectTags.Add(tagOpinion!);
+        post4.DirectTags.Add(tagInformative!);
         await ctx.SaveChangesAsync();
     }
 
@@ -193,4 +218,230 @@ public class EagerLoadingTests(BloggingFixture fixture) : IAsyncLifetime
     [Fact(Skip = "Requires a derived-type model (e.g. Student : Person with School navigation). Deferred to Phase 6.")]
     public Task Include_OnDerivedType_PopulatesDerivedNavigation()
         => Task.CompletedTask;
+
+    // -----------------------------------------------------------------------
+    // 9 — Explicit join-entity many-to-many (Post → PostTag → Tag)
+    // Verifies that the existing FK-navigation Include chain works for the
+    // explicit join-entity pattern before tackling true skip navigation.
+    // -----------------------------------------------------------------------
+
+    [Fact]
+    public async Task Include_Post_Tags_ViaExplicitJoinEntity_PopulatesPostTags()
+    {
+        // Post 1 has two PostTags (general, informative).
+        await using var context = fixture.GetDbContext();
+
+        var post = await context.Posts
+            .Include(p => p.Tags)
+            .FirstAsync(p => p.PostId == 1);
+
+        Assert.NotNull(post.Tags);
+        Assert.Equal(2, post.Tags.Count);
+        Assert.Contains(post.Tags, pt => pt.TagId == "general");
+        Assert.Contains(post.Tags, pt => pt.TagId == "informative");
+    }
+
+    [Fact]
+    public async Task Include_Post_Tags_ThenInclude_Tag_PopulatesTagEntities()
+    {
+        // Include the join entity then ThenInclude the Tag itself — both hops
+        // must resolve correctly through two FK JOINs.
+        await using var context = fixture.GetDbContext();
+
+        var post = await context.Posts
+            .Include(p => p.Tags)
+                .ThenInclude(pt => pt.Tag)
+            .FirstAsync(p => p.PostId == 1);
+
+        Assert.NotNull(post.Tags);
+        Assert.Equal(2, post.Tags.Count);
+        Assert.All(post.Tags, pt => Assert.NotNull(pt.Tag));
+        Assert.Contains(post.Tags, pt => pt.Tag.TagId == "general");
+        Assert.Contains(post.Tags, pt => pt.Tag.TagId == "informative");
+    }
+
+    // -----------------------------------------------------------------------
+    // 10 — True skip navigation many-to-many (Post.DirectTags ↔ Tag.DirectPosts)
+    // Verifies that EF Core's HasMany/WithMany transparent join-table pattern
+    // works with the Couchbase provider without any custom population code.
+    // -----------------------------------------------------------------------
+
+    [Fact]
+    public async Task SkipNav_Include_DirectTags_PopulatesTags()
+    {
+        // Post 1 has two DirectTags (general, informative) via skip navigation.
+        await using var context = fixture.GetDbContext();
+
+        var post = await context.Posts
+            .Include(p => p.DirectTags)
+            .FirstAsync(p => p.PostId == 1);
+
+        Assert.NotNull(post.DirectTags);
+        Assert.Equal(2, post.DirectTags.Count);
+        Assert.Contains(post.DirectTags, t => t.TagId == "general");
+        Assert.Contains(post.DirectTags, t => t.TagId == "informative");
+    }
+
+    [Fact]
+    public async Task SkipNav_Include_DirectTags_EmptyCollection_IsEmpty()
+    {
+        // Posts without DirectTags should have an empty collection, not null.
+        await using var context = fixture.GetDbContext();
+
+        var post = await context.Posts
+            .Include(p => p.DirectTags)
+            .FirstAsync(p => p.PostId == 2);
+
+        Assert.NotNull(post.DirectTags);
+        Assert.Empty(post.DirectTags);
+    }
+
+    [Fact]
+    public async Task SkipNav_Include_DirectTags_MultiplePostsCorrectlyGrouped()
+    {
+        // Each post gets only its own tags — no cross-contamination.
+        await using var context = fixture.GetDbContext();
+
+        var posts = await context.Posts
+            .Include(p => p.DirectTags)
+            .OrderBy(p => p.PostId)
+            .ToListAsync();
+
+        var post1 = posts.First(p => p.PostId == 1);
+        Assert.Equal(2, post1.DirectTags.Count);
+        Assert.Contains(post1.DirectTags, t => t.TagId == "general");
+        Assert.Contains(post1.DirectTags, t => t.TagId == "informative");
+
+        var post4 = posts.First(p => p.PostId == 4);
+        Assert.Equal(2, post4.DirectTags.Count);
+        Assert.Contains(post4.DirectTags, t => t.TagId == "opinion");
+        Assert.Contains(post4.DirectTags, t => t.TagId == "informative");
+    }
+
+    [Fact]
+    public async Task SkipNav_Inverse_Include_DirectPosts_PopulatesPosts()
+    {
+        // Query from the Tag side — Tag.DirectPosts should be populated.
+        await using var context = fixture.GetDbContext();
+
+        var tag = await context.Set<BloggingFixture.Tag>()
+            .Include(t => t.DirectPosts)
+            .FirstAsync(t => t.TagId == "general");
+
+        Assert.NotNull(tag.DirectPosts);
+        Assert.Single(tag.DirectPosts);
+        Assert.Equal(1, tag.DirectPosts.First().PostId);
+    }
+
+    [Fact]
+    public async Task Include_Post_Tags_ThenInclude_Tag_MultiplePostsCorrectlyGrouped()
+    {
+        // Blog 2 has three posts with different tag sets — verify each post
+        // gets only its own PostTags, not tags from other posts.
+        await using var context = fixture.GetDbContext();
+
+        var posts = await context.Posts
+            .Include(p => p.Tags)
+                .ThenInclude(pt => pt.Tag)
+            .Where(p => p.BlogId == 2)
+            .OrderBy(p => p.PostId)
+            .ToListAsync();
+
+        Assert.Equal(3, posts.Count);
+
+        // Post 2: one tag (classic)
+        var post2 = posts.First(p => p.PostId == 2);
+        Assert.Single(post2.Tags);
+        Assert.Equal("classic", post2.Tags[0].TagId);
+
+        // Post 3: one tag (opinion)
+        var post3 = posts.First(p => p.PostId == 3);
+        Assert.Single(post3.Tags);
+        Assert.Equal("opinion", post3.Tags[0].TagId);
+
+        // Post 4: two tags (opinion, informative)
+        var post4 = posts.First(p => p.PostId == 4);
+        Assert.Equal(2, post4.Tags.Count);
+        Assert.Contains(post4.Tags, pt => pt.TagId == "opinion");
+        Assert.Contains(post4.Tags, pt => pt.TagId == "informative");
+    }
+
+    // -----------------------------------------------------------------------
+    // GetPrimaryKey integration — verifies correct document key generation
+    // for shared entity types (skip navigation join table) against the live DB.
+    // These tests exercise both overloads indirectly via write/read round-trips.
+    // -----------------------------------------------------------------------
+
+    [Fact]
+    public async Task SkipNav_AddRelationship_WritesJoinDocumentWithCorrectKey()
+    {
+        // Add a new skip-navigation relationship and read it back — confirms
+        // the join document was written with a non-empty composite key.
+        await using var context = fixture.GetDbContext();
+
+        var post = await context.Posts
+            .Include(p => p.DirectTags)
+            .FirstAsync(p => p.PostId == 3);
+        var tag = await context.Set<BloggingFixture.Tag>().FindAsync("classic");
+
+        Assert.DoesNotContain(post.DirectTags, t => t.TagId == "classic");
+        post.DirectTags.Add(tag!);
+        await context.SaveChangesAsync();
+
+        await using var verify = fixture.GetDbContext();
+        var reloaded = await verify.Posts
+            .Include(p => p.DirectTags)
+            .FirstAsync(p => p.PostId == 3);
+
+        Assert.Contains(reloaded.DirectTags, t => t.TagId == "classic");
+    }
+
+    [Fact]
+    public async Task SkipNav_RemoveRelationship_DeletesJoinDocument()
+    {
+        // Remove a skip-navigation relationship — confirms the join document
+        // is deleted (the relationship is no longer present after reload).
+        await using var context = fixture.GetDbContext();
+
+        var post = await context.Posts
+            .Include(p => p.DirectTags)
+            .FirstAsync(p => p.PostId == 1);
+
+        Assert.Contains(post.DirectTags, t => t.TagId == "general");
+        var tagToRemove = post.DirectTags.First(t => t.TagId == "general");
+        post.DirectTags.Remove(tagToRemove);
+        await context.SaveChangesAsync();
+
+        await using var verify = fixture.GetDbContext();
+        var reloaded = await verify.Posts
+            .Include(p => p.DirectTags)
+            .FirstAsync(p => p.PostId == 1);
+
+        Assert.DoesNotContain(reloaded.DirectTags, t => t.TagId == "general");
+    }
+
+    [Fact]
+    public async Task SkipNav_ReplaceAllRelationships_RoundTrips()
+    {
+        // Clear all DirectTags on a post and replace with a new set —
+        // verifies both delete (Clear) and insert (Add) paths generate valid keys.
+        await using var context = fixture.GetDbContext();
+
+        var post = await context.Posts
+            .Include(p => p.DirectTags)
+            .FirstAsync(p => p.PostId == 4);
+        var tagClassic = await context.Set<BloggingFixture.Tag>().FindAsync("classic");
+
+        post.DirectTags.Clear();
+        post.DirectTags.Add(tagClassic!);
+        await context.SaveChangesAsync();
+
+        await using var verify = fixture.GetDbContext();
+        var reloaded = await verify.Posts
+            .Include(p => p.DirectTags)
+            .FirstAsync(p => p.PostId == 4);
+
+        Assert.Single(reloaded.DirectTags);
+        Assert.Equal("classic", reloaded.DirectTags.First().TagId);
+    }
 }

--- a/tests/Couchbase.EntityFrameworkCore.IntegrationTests/Tests/EagerLoadingTests.cs
+++ b/tests/Couchbase.EntityFrameworkCore.IntegrationTests/Tests/EagerLoadingTests.cs
@@ -42,7 +42,8 @@ public class EagerLoadingTests(BloggingFixture fixture) : IAsyncLifetime
         ctx.Update(new BloggingFixture.PostTag { PostTagId = 6, PostId = 4, TagId = "informative" });
         await ctx.SaveChangesAsync();
 
-        // Seed skip-navigation join table data (mirrors the explicit PostTag data).
+        // Seed skip-navigation join table data for Posts 1 and 4 only.
+        // Posts 2 and 3 intentionally have no DirectTags (exercises the empty-collection path).
         // Load with Include so Clear() can remove existing join entries (idempotent reseed).
         var post1 = await ctx.Posts.Include(p => p.DirectTags).FirstAsync(p => p.PostId == 1);
         var post4 = await ctx.Posts.Include(p => p.DirectTags).FirstAsync(p => p.PostId == 4);

--- a/tests/Couchbase.EntityFrameworkCore.UnitTests/Couchbase/EntityFrameworkCore/Extensions/EntityTypeExtensionsTests.cs
+++ b/tests/Couchbase.EntityFrameworkCore.UnitTests/Couchbase/EntityFrameworkCore/Extensions/EntityTypeExtensionsTests.cs
@@ -270,6 +270,23 @@ public class EntityTypeExtensionsTests
     }
 
     [Fact]
+    public void GetPrimaryKey_UpdateEntry_KeylessEntity_ThrowsInvalidOperationException()
+    {
+        var entityType = new Moq.Mock<Microsoft.EntityFrameworkCore.Metadata.IEntityType>();
+        entityType.Setup(e => e.FindPrimaryKey()).Returns((Microsoft.EntityFrameworkCore.Metadata.IKey?)null);
+        entityType.Setup(e => e.DisplayName()).Returns("KeylessEntity");
+
+        var entry = new Moq.Mock<IUpdateEntry>();
+        entry.Setup(e => e.EntityType).Returns(entityType.Object);
+
+        var ex = Assert.Throws<InvalidOperationException>(
+            () => entityType.Object.GetPrimaryKey(entry.Object));
+
+        Assert.Contains("KeylessEntity", ex.Message);
+        Assert.Contains("primary key", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
     public void GetPrimaryKey_UpdateEntry_SharedEntityType_DifferentValues_ProduceDifferentKeys()
     {
         var entityType = BuildSharedEntityType();

--- a/tests/Couchbase.EntityFrameworkCore.UnitTests/Couchbase/EntityFrameworkCore/Extensions/EntityTypeExtensionsTests.cs
+++ b/tests/Couchbase.EntityFrameworkCore.UnitTests/Couchbase/EntityFrameworkCore/Extensions/EntityTypeExtensionsTests.cs
@@ -1,0 +1,287 @@
+using Couchbase.EntityFrameworkCore.Extensions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Update;
+using Moq;
+using Xunit;
+
+namespace Couchbase.EntityFrameworkCore.UnitTests.Couchbase.EntityFrameworkCore.Extensions;
+
+/// <summary>
+/// Unit tests for <see cref="EntityTypeExtensions.GetPrimaryKey(Microsoft.EntityFrameworkCore.Metadata.IEntityType,object)"/>
+/// and <see cref="EntityTypeExtensions.GetPrimaryKey(Microsoft.EntityFrameworkCore.Metadata.IEntityType,IUpdateEntry)"/>.
+/// </summary>
+public class EntityTypeExtensionsTests
+{
+    // -----------------------------------------------------------------------
+    // CLR-instance overload — GetPrimaryKey(IEntityType, object)
+    // -----------------------------------------------------------------------
+
+    private class SingleKeyEntity
+    {
+        public int Id { get; set; }
+        public string Name { get; set; } = "";
+    }
+
+    private class CompositeKeyEntity
+    {
+        public int TenantId { get; set; }
+        public int UserId { get; set; }
+        public string Value { get; set; } = "";
+    }
+
+    private class StringKeyEntity
+    {
+        public string Code { get; set; } = "";
+        public string Description { get; set; } = "";
+    }
+
+    private static Microsoft.EntityFrameworkCore.Metadata.IEntityType BuildEntityType<T>(
+        Action<Microsoft.EntityFrameworkCore.ModelBuilder> configure)
+        where T : class
+    {
+        var opts = new global::Couchbase.ClusterOptions()
+            .WithConnectionString("couchbase://localhost")
+            .WithPasswordAuthentication("Administrator", "password");
+        var builder = new DbContextOptionsBuilder<TestContext<T>>();
+        builder.UseCouchbaseProvider(opts);
+
+        using var ctx = new TestContext<T>(builder.Options, configure);
+        return ctx.Model.FindEntityType(typeof(T))!;
+    }
+
+    private class TestContext<T>(
+        DbContextOptions options,
+        Action<ModelBuilder> configure) : DbContext(options)
+        where T : class
+    {
+        public DbSet<T> Entities { get; set; } = null!;
+        protected override void OnModelCreating(ModelBuilder modelBuilder) => configure(modelBuilder);
+    }
+
+    [Fact]
+    public void GetPrimaryKey_SingleIntKey_ReturnsId()
+    {
+        var entityType = BuildEntityType<SingleKeyEntity>(mb =>
+        {
+            mb.Entity<SingleKeyEntity>(b =>
+            {
+                b.ToCouchbaseCollection("bucket", "scope", "entity");
+                b.HasKey(e => e.Id);
+            });
+        });
+
+        var entity = new SingleKeyEntity { Id = 42, Name = "test" };
+        Assert.Equal("42", entityType.GetPrimaryKey(entity));
+    }
+
+    [Fact]
+    public void GetPrimaryKey_StringKey_ReturnsCode()
+    {
+        var entityType = BuildEntityType<StringKeyEntity>(mb =>
+        {
+            mb.Entity<StringKeyEntity>(b =>
+            {
+                b.ToCouchbaseCollection("bucket", "scope", "entity");
+                b.HasKey(e => e.Code);
+            });
+        });
+
+        var entity = new StringKeyEntity { Code = "ABC", Description = "desc" };
+        Assert.Equal("ABC", entityType.GetPrimaryKey(entity));
+    }
+
+    [Fact]
+    public void GetPrimaryKey_CompositeKey_ReturnsConcatenatedWithUnderscore()
+    {
+        var entityType = BuildEntityType<CompositeKeyEntity>(mb =>
+        {
+            mb.Entity<CompositeKeyEntity>(b =>
+            {
+                b.ToCouchbaseCollection("bucket", "scope", "entity");
+                b.HasKey(e => new { e.TenantId, e.UserId });
+            });
+        });
+
+        var entity = new CompositeKeyEntity { TenantId = 1, UserId = 7, Value = "x" };
+        var key = entityType.GetPrimaryKey(entity);
+
+        // Composite key joins with underscore; order follows key property declaration.
+        Assert.Contains("1", key);
+        Assert.Contains("7", key);
+        Assert.Contains("_", key);
+    }
+
+    [Fact]
+    public void GetPrimaryKey_DifferentInstances_ProduceDifferentKeys()
+    {
+        var entityType = BuildEntityType<SingleKeyEntity>(mb =>
+        {
+            mb.Entity<SingleKeyEntity>(b =>
+            {
+                b.ToCouchbaseCollection("bucket", "scope", "entity");
+                b.HasKey(e => e.Id);
+            });
+        });
+
+        var key1 = entityType.GetPrimaryKey(new SingleKeyEntity { Id = 1 });
+        var key2 = entityType.GetPrimaryKey(new SingleKeyEntity { Id = 2 });
+        Assert.NotEqual(key1, key2);
+    }
+
+    [Fact]
+    public void GetPrimaryKey_ZeroValue_ReturnsZeroString()
+    {
+        var entityType = BuildEntityType<SingleKeyEntity>(mb =>
+        {
+            mb.Entity<SingleKeyEntity>(b =>
+            {
+                b.ToCouchbaseCollection("bucket", "scope", "entity");
+                b.HasKey(e => e.Id);
+            });
+        });
+
+        var key = entityType.GetPrimaryKey(new SingleKeyEntity { Id = 0 });
+        Assert.Equal("0", key);
+    }
+
+    // -----------------------------------------------------------------------
+    // IUpdateEntry overload — GetPrimaryKey(IEntityType, IUpdateEntry)
+    // Used for shared entity types (HasMany/WithMany hidden join tables)
+    // whose PK columns are shadow properties.
+    // -----------------------------------------------------------------------
+
+    private static Microsoft.EntityFrameworkCore.Metadata.IEntityType BuildSharedEntityType()
+    {
+        // Simulate the hidden join entity created by HasMany/WithMany.
+        // Its PK is composite (PostsPostId + TagsTagId), both shadow properties.
+        var opts = new global::Couchbase.ClusterOptions()
+            .WithConnectionString("couchbase://localhost")
+            .WithPasswordAuthentication("Administrator", "password");
+        var builder = new DbContextOptionsBuilder<SkipNavContext>();
+        builder.UseCouchbaseProvider(opts);
+        using var ctx = new SkipNavContext(builder.Options);
+        return ctx.Model.GetEntityTypes()
+            .First(e => e.HasSharedClrType);
+    }
+
+    private class Post
+    {
+        public int PostId { get; set; }
+        public ICollection<Tag> Tags { get; set; } = [];
+    }
+
+    private class Tag
+    {
+        public string TagId { get; set; } = "";
+        public ICollection<Post> Posts { get; set; } = [];
+    }
+
+    private class SkipNavContext(DbContextOptions options) : DbContext(options)
+    {
+        public DbSet<Post> Posts { get; set; } = null!;
+        public DbSet<Tag> Tags  { get; set; } = null!;
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            modelBuilder.Entity<Post>(b =>
+            {
+                b.ToCouchbaseCollection("bucket", "scope", "post");
+                b.HasKey(p => p.PostId);
+                b.HasMany(p => p.Tags).WithMany(t => t.Posts).UsingEntity("PostTag");
+            });
+            modelBuilder.Entity<Tag>(b =>
+            {
+                b.ToCouchbaseCollection("bucket", "scope", "tag");
+                b.HasKey(t => t.TagId);
+            });
+        }
+    }
+
+    private static IUpdateEntry MockUpdateEntry(
+        Microsoft.EntityFrameworkCore.Metadata.IEntityType entityType,
+        params (string propertyName, object value)[] values)
+    {
+        var mock = new Mock<IUpdateEntry>();
+        mock.Setup(e => e.EntityType).Returns(entityType);
+        foreach (var (name, value) in values)
+        {
+            var prop = entityType.FindProperty(name)!;
+            mock.Setup(e => e.GetCurrentValue(prop)).Returns(value);
+        }
+        return mock.Object;
+    }
+
+    [Fact]
+    public void GetPrimaryKey_UpdateEntry_SingleValue_ReturnsValue()
+    {
+        var entityType = BuildEntityType<SingleKeyEntity>(mb =>
+        {
+            mb.Entity<SingleKeyEntity>(b =>
+            {
+                b.ToCouchbaseCollection("bucket", "scope", "entity");
+                b.HasKey(e => e.Id);
+            });
+        });
+
+        var entry = MockUpdateEntry(entityType, ("Id", 99));
+        Assert.Equal("99", entityType.GetPrimaryKey(entry));
+    }
+
+    [Fact]
+    public void GetPrimaryKey_UpdateEntry_CompositeKey_ReturnsConcatenated()
+    {
+        var entityType = BuildEntityType<CompositeKeyEntity>(mb =>
+        {
+            mb.Entity<CompositeKeyEntity>(b =>
+            {
+                b.ToCouchbaseCollection("bucket", "scope", "entity");
+                b.HasKey(e => new { e.TenantId, e.UserId });
+            });
+        });
+
+        var entry = MockUpdateEntry(entityType, ("TenantId", 3), ("UserId", 7));
+        var key = entityType.GetPrimaryKey(entry);
+
+        Assert.Contains("3", key);
+        Assert.Contains("7", key);
+        Assert.Contains("_", key);
+    }
+
+    [Fact]
+    public void GetPrimaryKey_UpdateEntry_SharedEntityType_ReadsShadowProperties()
+    {
+        // This is the critical case: the hidden join entity for HasMany/WithMany
+        // has shadow-only PK properties. The IUpdateEntry overload must read them
+        // via GetCurrentValue rather than CLR PropertyInfo (which would return empty).
+        var entityType = BuildSharedEntityType();
+        Assert.True(entityType.HasSharedClrType,
+            "Expected a shared entity type (hidden join table).");
+
+        // PK property names follow EF Core's convention: {NavName}{EntityPk}
+        var pkProps = entityType.FindPrimaryKey()!.Properties;
+        var entries = pkProps.Select(p => (p.Name, (object)(p.ClrType == typeof(int) ? 1 : "general")))
+                             .ToArray();
+
+        var entry = MockUpdateEntry(entityType, entries);
+        var key = entityType.GetPrimaryKey(entry);
+
+        Assert.NotEmpty(key);
+        // Key must contain values from both shadow FK columns.
+        Assert.All(entries, e => Assert.Contains(e.Item2.ToString()!, key));
+    }
+
+    [Fact]
+    public void GetPrimaryKey_UpdateEntry_SharedEntityType_DifferentValues_ProduceDifferentKeys()
+    {
+        var entityType = BuildSharedEntityType();
+        var pkProps = entityType.FindPrimaryKey()!.Properties;
+
+        // Two join rows: (1, "general") and (1, "informative")
+        var entries1 = pkProps.Select(p => (p.Name, (object)(p.ClrType == typeof(int) ? 1 : "general"))).ToArray();
+        var entries2 = pkProps.Select(p => (p.Name, (object)(p.ClrType == typeof(int) ? 1 : "informative"))).ToArray();
+
+        var key1 = entityType.GetPrimaryKey(MockUpdateEntry(entityType, entries1));
+        var key2 = entityType.GetPrimaryKey(MockUpdateEntry(entityType, entries2));
+
+        Assert.NotEqual(key1, key2);
+    }
+}

--- a/tests/Couchbase.EntityFrameworkCore.UnitTests/Couchbase/EntityFrameworkCore/Query/NavigationIncludeTests.cs
+++ b/tests/Couchbase.EntityFrameworkCore.UnitTests/Couchbase/EntityFrameworkCore/Query/NavigationIncludeTests.cs
@@ -186,8 +186,11 @@ public class NavigationIncludeTests
     }
 
     [Fact]
-    public void ExtractNavigationIncludes_SkipNavigation_IsExcluded()
+    public void ExtractNavigationIncludes_SkipNavigation_IsIncluded()
     {
+        // Skip navigations (HasMany/WithMany) are now recorded alongside FK navigations
+        // because the EF Core shaper handles their collection accumulation via the
+        // standard SingleQueryResultCoordinator path — no separate population needed.
         var postsNav = MockNavigation("Posts");
         var skipNav = new Mock<ISkipNavigation>();
         skipNav.Setup(n => n.Name).Returns("Tags");
@@ -199,8 +202,9 @@ public class NavigationIncludeTests
         var result = CouchbaseShapedQueryCompilingExpressionVisitor
             .ExtractNavigationIncludes(outer);
 
-        Assert.Single(result);
+        Assert.Equal(2, result.Count);
         Assert.Equal("Posts", result[0].Navigation.Name);
+        Assert.Equal("Tags",  result[1].Navigation.Name);
     }
 
     // ---------------------------------------------------------------

--- a/tests/Couchbase.EntityFrameworkCore.UnitTests/Couchbase/EntityFrameworkCore/Query/SkipNavigationSqlGenerationTests.cs
+++ b/tests/Couchbase.EntityFrameworkCore.UnitTests/Couchbase/EntityFrameworkCore/Query/SkipNavigationSqlGenerationTests.cs
@@ -8,7 +8,7 @@ namespace Couchbase.EntityFrameworkCore.UnitTests.Couchbase.EntityFrameworkCore.
 /// <summary>
 /// Verifies that EF Core's skip-navigation (HasMany/WithMany) queries generate
 /// valid N1QL — no dangling aliases, balanced parentheses, no empty FROM, and
-/// no owned-table JOIN leakage — before implementing Pattern B many-to-many support.
+/// no owned-table JOIN leakage — as a regression test for many-to-many support.
 /// </summary>
 public class SkipNavigationSqlGenerationTests
 {

--- a/tests/Couchbase.EntityFrameworkCore.UnitTests/Couchbase/EntityFrameworkCore/Query/SkipNavigationSqlGenerationTests.cs
+++ b/tests/Couchbase.EntityFrameworkCore.UnitTests/Couchbase/EntityFrameworkCore/Query/SkipNavigationSqlGenerationTests.cs
@@ -1,0 +1,124 @@
+using Couchbase.EntityFrameworkCore.Extensions;
+using Microsoft.EntityFrameworkCore;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Couchbase.EntityFrameworkCore.UnitTests.Couchbase.EntityFrameworkCore.Query;
+
+/// <summary>
+/// Verifies that EF Core's skip-navigation (HasMany/WithMany) queries generate
+/// valid N1QL — no dangling aliases, balanced parentheses, no empty FROM, and
+/// no owned-table JOIN leakage — before implementing Pattern B many-to-many support.
+/// </summary>
+public class SkipNavigationSqlGenerationTests
+{
+    private readonly ITestOutputHelper _output;
+    public SkipNavigationSqlGenerationTests(ITestOutputHelper output) => _output = output;
+
+    // -----------------------------------------------------------------------
+    // Model — Post ↔ Tag via EF Core skip navigation (.HasMany().WithMany())
+    // -----------------------------------------------------------------------
+
+    private class Post
+    {
+        public int PostId { get; set; }
+        public string Title { get; set; } = "";
+        public ICollection<Tag> Tags { get; set; } = [];
+    }
+
+    private class Tag
+    {
+        public string TagId { get; set; } = "";
+        public string Name { get; set; } = "";
+        public ICollection<Post> Posts { get; set; } = [];
+    }
+
+    private class BlogContext(DbContextOptions<BlogContext> options) : DbContext(options)
+    {
+        public DbSet<Post> Posts { get; set; } = null!;
+        public DbSet<Tag> Tags { get; set; } = null!;
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            modelBuilder.Entity<Post>(b =>
+            {
+                b.ToCouchbaseCollection("bucket", "scope", "post");
+                b.HasKey(p => p.PostId);
+                b.HasMany(p => p.Tags)
+                 .WithMany(t => t.Posts)
+                 .UsingEntity(j => j.ToTable("bucket.scope.posttag"));
+            });
+
+            modelBuilder.Entity<Tag>(b =>
+            {
+                b.ToCouchbaseCollection("bucket", "scope", "tag");
+                b.HasKey(t => t.TagId);
+            });
+        }
+    }
+
+    private static BlogContext CreateContext()
+    {
+        var opts = new global::Couchbase.ClusterOptions()
+            .WithConnectionString("couchbase://localhost")
+            .WithPasswordAuthentication("Administrator", "password");
+        var builder = new DbContextOptionsBuilder<BlogContext>();
+        builder.UseCouchbaseProvider(opts);
+        return new BlogContext(builder.Options);
+    }
+
+    // -----------------------------------------------------------------------
+    // SQL shape tests
+    // -----------------------------------------------------------------------
+
+    [Fact]
+    public void SkipNav_Include_ToList_EmitsSQL()
+    {
+        using var ctx = CreateContext();
+        var sql = ctx.Posts.Include(p => p.Tags).ToQueryString();
+        _output.WriteLine(sql);
+        Assert.NotEmpty(sql);
+    }
+
+    [Fact]
+    public void SkipNav_Include_ToList_ContainsJoins()
+    {
+        using var ctx = CreateContext();
+        var sql = ctx.Posts.Include(p => p.Tags).ToQueryString();
+        // Skip navigation requires two JOINs: post→posttag and posttag→tag
+        Assert.Contains("JOIN", sql, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void SkipNav_Include_ToList_ParenthesesBalanced()
+    {
+        using var ctx = CreateContext();
+        var sql = ctx.Posts.Include(p => p.Tags).ToQueryString();
+        Assert.Equal(sql.Count(c => c == '('), sql.Count(c => c == ')'));
+    }
+
+    [Fact]
+    public void SkipNav_Include_First_ParenthesesBalanced()
+    {
+        using var ctx = CreateContext();
+        var sql = ctx.Posts.Include(p => p.Tags).Where(p => p.PostId == 1).Take(1).ToQueryString();
+        Assert.Equal(sql.Count(c => c == '('), sql.Count(c => c == ')'));
+    }
+
+    [Fact]
+    public void SkipNav_Include_ToList_NoEmptyFromClause()
+    {
+        using var ctx = CreateContext();
+        var sql = ctx.Posts.Include(p => p.Tags).ToQueryString();
+        Assert.DoesNotContain("FROM\n",   sql, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("FROM\r\n", sql, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void SkipNav_NoInclude_ToList_NoJoin()
+    {
+        using var ctx = CreateContext();
+        var sql = ctx.Posts.ToQueryString();
+        Assert.DoesNotContain("JOIN", sql, StringComparison.OrdinalIgnoreCase);
+    }
+}

--- a/tests/Couchbase.EntityFrameworkCore.UnitTests/Couchbase/EntityFrameworkCore/Storage/Internal/CouchbaseDatabaseWrapperHydrateTests.cs
+++ b/tests/Couchbase.EntityFrameworkCore.UnitTests/Couchbase/EntityFrameworkCore/Storage/Internal/CouchbaseDatabaseWrapperHydrateTests.cs
@@ -304,7 +304,13 @@ public class CouchbaseDatabaseWrapperHydrateTests
         prop.Setup(p => p.PropertyInfo).Returns((PropertyInfo?)null);
         prop.Setup(p => p.FieldInfo).Returns((FieldInfo?)null);
         prop.Setup(p => p.IsShadowProperty()).Returns(true);
-        prop.Setup(p => p.GetColumnName()).Returns(columnName);
+        // GetColumnName() is an EF Core extension method — Moq cannot mock it directly.
+        // Wire the column name via the relational annotation it reads internally,
+        // matching the pattern used by BuildOwnedProperty above.
+        var annotation = new Mock<IAnnotation>();
+        annotation.Setup(a => a.Value).Returns(columnName);
+        prop.Setup(p => p.FindAnnotation("Relational:ColumnName")).Returns(annotation.Object);
+        prop.Setup(p => p["Relational:ColumnName"]).Returns(columnName);
         entryMock.Setup(e => e.GetCurrentValue(prop.Object)).Returns(value);
         return prop;
     }

--- a/tests/Couchbase.EntityFrameworkCore.UnitTests/Couchbase/EntityFrameworkCore/Storage/Internal/CouchbaseDatabaseWrapperHydrateTests.cs
+++ b/tests/Couchbase.EntityFrameworkCore.UnitTests/Couchbase/EntityFrameworkCore/Storage/Internal/CouchbaseDatabaseWrapperHydrateTests.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using System.Reflection;
+using System.Text.Json;
 using Couchbase.EntityFrameworkCore.Storage.Internal;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
@@ -10,20 +11,15 @@ using Xunit;
 namespace Couchbase.EntityFrameworkCore.UnitTests.Couchbase.EntityFrameworkCore.Storage.Internal;
 
 /// <summary>
-/// Tests for CouchbaseDatabaseWrapper.HydrateObjectFromEntity via reflection.
+/// Tests for <see cref="CouchbaseDatabaseWrapper.HydrateObjectFromEntity"/>.
 ///
-/// The method is private static, so we invoke it directly rather than going through
-/// the full SaveChangesAsync stack (which requires live EF Core model infrastructure
-/// for GetPrimaryKey, GetCollectionName, IsOwned, etc.).
+/// The method is <c>internal static</c> and called directly to avoid requiring
+/// the full <c>SaveChangesAsync</c> stack (GetPrimaryKey, GetCollectionName, IsOwned, …).
 /// </summary>
 public class CouchbaseDatabaseWrapperHydrateTests
 {
-    private static readonly MethodInfo HydrateMethod =
-        typeof(CouchbaseDatabaseWrapper)
-            .GetMethod("HydrateObjectFromEntity", BindingFlags.NonPublic | BindingFlags.Static)!;
-
-    private static object Hydrate(IUpdateEntry entry)
-        => HydrateMethod.Invoke(null, [entry, null])!;
+    private static object Hydrate(IUpdateEntry entry, System.Text.Json.JsonNamingPolicy? policy = null)
+        => CouchbaseDatabaseWrapper.HydrateObjectFromEntity(entry, policy)!;
 
     // -----------------------------------------------------------------------
     // Helpers
@@ -293,6 +289,105 @@ public class CouchbaseDatabaseWrapperHydrateTests
         var result = (EntityWithSetter)Hydrate(entry.Object);
 
         Assert.Equal("real", result.Name);
+    }
+
+    // -----------------------------------------------------------------------
+    // Shared entity type (HasMany/WithMany hidden join table)
+    // -----------------------------------------------------------------------
+
+    private static Mock<IProperty> MakeSharedProperty(
+        string columnName,
+        object? value,
+        Mock<IUpdateEntry> entryMock)
+    {
+        var prop = new Mock<IProperty>();
+        prop.Setup(p => p.PropertyInfo).Returns((PropertyInfo?)null);
+        prop.Setup(p => p.FieldInfo).Returns((FieldInfo?)null);
+        prop.Setup(p => p.IsShadowProperty()).Returns(true);
+        prop.Setup(p => p.GetColumnName()).Returns(columnName);
+        entryMock.Setup(e => e.GetCurrentValue(prop.Object)).Returns(value);
+        return prop;
+    }
+
+    private static Mock<IEntityType> MakeSharedEntityType(params Mock<IProperty>[] props)
+    {
+        var entityType = new Mock<IEntityType>();
+        entityType.Setup(t => t.HasSharedClrType).Returns(true);
+        entityType.Setup(t => t.ClrType).Returns(typeof(Dictionary<string, object>));
+        entityType.Setup(t => t.GetProperties()).Returns(props.Select(p => p.Object).ToArray());
+        entityType.Setup(t => t.GetNavigations()).Returns([]);
+        return entityType;
+    }
+
+    [Fact]
+    public void Hydrate_SharedEntityType_UseColumnNameVerbatim()
+    {
+        // The join document keys must be GetColumnName() verbatim — not policy-transformed.
+        // If camelCase were applied, "PostsPostId" → "postsPostId" which would diverge
+        // from the SQL projection alias and make the document unreadable on the query path.
+        var entry = new Mock<IUpdateEntry>();
+        var postsPostId = MakeSharedProperty("PostsPostId", 1,    entry);
+        var tagsTagId   = MakeSharedProperty("TagsTagId",   "abc", entry);
+        var entityType  = MakeSharedEntityType(postsPostId, tagsTagId);
+        entry.Setup(e => e.EntityType).Returns(entityType.Object);
+
+        // Pass camelCase policy — must NOT be applied to column names.
+        var result = (Dictionary<string, object?>)Hydrate(entry.Object, JsonNamingPolicy.CamelCase);
+
+        Assert.True(result.ContainsKey("PostsPostId"),
+            "Expected verbatim column name 'PostsPostId' — naming policy must not be applied.");
+        Assert.True(result.ContainsKey("TagsTagId"),
+            "Expected verbatim column name 'TagsTagId' — naming policy must not be applied.");
+        Assert.Equal(1,     result["PostsPostId"]);
+        Assert.Equal("abc", result["TagsTagId"]);
+    }
+
+    [Fact]
+    public void Hydrate_SharedEntityType_DoesNotContainPolicyTransformedKeys()
+    {
+        // Negative assertion: camelCased variants of the column names must NOT appear.
+        var entry = new Mock<IUpdateEntry>();
+        var postsPostId = MakeSharedProperty("PostsPostId", 1,    entry);
+        var tagsTagId   = MakeSharedProperty("TagsTagId",   "abc", entry);
+        var entityType  = MakeSharedEntityType(postsPostId, tagsTagId);
+        entry.Setup(e => e.EntityType).Returns(entityType.Object);
+
+        var result = (Dictionary<string, object?>)Hydrate(entry.Object, JsonNamingPolicy.CamelCase);
+
+        Assert.False(result.ContainsKey("postsPostId"),
+            "camelCase-transformed key 'postsPostId' must not appear — naming policy must not be applied.");
+        Assert.False(result.ContainsKey("tagsTagId"),
+            "camelCase-transformed key 'tagsTagId' must not appear — naming policy must not be applied.");
+    }
+
+    [Fact]
+    public void Hydrate_SharedEntityType_NullPolicyAlso_UsesColumnNameVerbatim()
+    {
+        // Sanity check: null policy also uses GetColumnName() verbatim.
+        var entry = new Mock<IUpdateEntry>();
+        var prop = MakeSharedProperty("PostsPostId", 42, entry);
+        var entityType = MakeSharedEntityType(prop);
+        entry.Setup(e => e.EntityType).Returns(entityType.Object);
+
+        var result = (Dictionary<string, object?>)Hydrate(entry.Object, policy: null);
+
+        Assert.True(result.ContainsKey("PostsPostId"));
+        Assert.Equal(42, result["PostsPostId"]);
+    }
+
+    [Fact]
+    public void Hydrate_SharedEntityType_IncludesAllProperties()
+    {
+        // All properties (shadow or not) must appear in the join document.
+        var entry = new Mock<IUpdateEntry>();
+        var p1 = MakeSharedProperty("PostsPostId", 5,       entry);
+        var p2 = MakeSharedProperty("TagsTagId",   "tag1",  entry);
+        var entityType = MakeSharedEntityType(p1, p2);
+        entry.Setup(e => e.EntityType).Returns(entityType.Object);
+
+        var result = (Dictionary<string, object?>)Hydrate(entry.Object);
+
+        Assert.Equal(2, result.Count);
     }
 }
 


### PR DESCRIPTION

EF Core's shaper already handles skip navigation collection accumulation via
the standard `SingleQueryResultCoordinator` path so no custom read-path code
is needed. Three gaps required fixing:

### Write path (`CouchbaseDatabaseWrapper` / `EntityTypeExtensions`)
- Shared entity types (`HasSharedClrType` — the hidden join table created by
  `HasMany/WithMany`) use `Dictionary<string,object>` as their CLR type; all FK
  columns are shadow properties. Add a `HasSharedClrType` branch that builds
  the document as a plain dictionary from all properties via `GetCurrentValue`,
  bypassing the CLR `PropertyInfo` path that fails for `Dictionary<string,object>`.
- Add an `IUpdateEntry` overload of `GetPrimaryKey` that reads PK values from
  the update entry; the existing `GetType().GetProperties()` loop returns no
  matching properties for shadow-only shared types, producing an empty key.

### Include extraction (`CouchbaseShapedQueryCompilingExpressionVisitor`)
- Remove the `ISkipNavigation` exclusion filter so skip navigations are recorded
  in `NavigationIncludes` alongside FK navigations.
- Update `NavigationInclude` record to use `INavigationBase` (common base for
  both `INavigation` and `ISkipNavigation`) instead of `INavigation`.

### Model / tests
- Add `Post.DirectTags` / `Tag.DirectPosts` skip navigation to `BloggingFixture`
  with a distinct `"PostDirectTag"` join entity to avoid collision with the
  existing explicit `PostTag` entity.
- Add `EnsureCreatedAsync` to `BloggingFixture.InitializeAsync` so the new
  `postdirecttag` collection is created on first run.
- Add `SkipNavigationSqlGenerationTests` (6 unit tests) verifying valid N1QL
  is generated for skip navigation queries.
- Add 4 integration tests: basic `Include`, empty collection, multi-post
  grouping correctness, and inverse navigation from the `Tag` side.
- Add 3 integration tests for the explicit join-entity pattern (Pattern A)
  confirming it works via chained FK includes.