### PR TITLE
Apply HasConversion converters across the entire write path

### DIFF
--- a/src/Couchbase.EntityFrameworkCore/Storage/Internal/CouchbaseDatabaseWrapper.cs
+++ b/src/Couchbase.EntityFrameworkCore/Storage/Internal/CouchbaseDatabaseWrapper.cs
@@ -220,10 +220,10 @@ public class CouchbaseDatabaseWrapper : Database
         foreach (var p in nav.TargetEntityType.GetProperties().Where(p => !p.IsShadowProperty()))
         {
             // Read via PropertyInfo when available; fall back to FieldInfo for field-access properties.
-            var value = navValue == null ? null
+            var rawValue = navValue == null ? null
                 : p.PropertyInfo != null ? p.PropertyInfo.GetValue(navValue)
                 : p.FieldInfo?.GetValue(navValue);
-            doc[p.GetColumnName()] = value;
+            doc[p.GetColumnName()] = ApplyConverter(p, rawValue);
         }
     }
 
@@ -244,16 +244,15 @@ public class CouchbaseDatabaseWrapper : Database
             .Where(n => n.TargetEntityType.IsOwned() && n.PropertyInfo != null)
             .ToList();
 
-        // No owned navigations: use CLR instance so the SDK's camelCase serializer produces
-        // the same field names that already work for all existing entity types.
+        // No owned navigations: build a dictionary keyed by GetColumnName() so that
+        // (a) value converters (HasConversion) can be applied before storage and
+        // (b) the stored keys match what the N1QL SELECT projection aliases expect.
         //
         // Exception: shared entity types (HasSharedClrType == true, e.g. the hidden join
         // entity for skip navigations / HasMany().WithMany()) use Dictionary<string,object>
         // as their CLR type.  All their FK properties are shadow properties — the standard
-        // IsShadowProperty filter would produce an empty document.  Additionally, Dictionary's
-        // indexer throws TargetParameterCountException when PropertyInfo.SetValue is called
-        // without index arguments.  For shared types we therefore build a plain dictionary
-        // keyed by column name from ALL (including shadow) properties.
+        // IsShadowProperty filter would produce an empty document.  For shared types we
+        // therefore write every property value (including shadow) by column name.
         if (ownedNavs.Count == 0)
         {
             if (entityType.HasSharedClrType)
@@ -268,22 +267,22 @@ public class CouchbaseDatabaseWrapper : Database
                     // name (e.g. "PostsPostId", "TagsTagId"), so the written document keys
                     // must match. Applying a naming policy would silently diverge from the
                     // SQL projection and make join documents unreadable on the query path.
-                    joinDoc[property.GetColumnName()] = updateEntry.GetCurrentValue(property);
+                    var rawJoinValue = updateEntry.GetCurrentValue(property);
+                    joinDoc[property.GetColumnName()] = ApplyConverter(property, rawJoinValue);
                 }
                 return joinDoc;
             }
 
-            var obj = Activator.CreateInstance(entityType.ClrType)!;
+            // Regular entity type: build a dictionary with converter-applied values so that
+            // types with HasConversion (e.g. enum → string) store the provider representation.
+            var regularDoc = new Dictionary<string, object?>();
             foreach (var property in entityType.GetProperties())
             {
                 if (property.IsShadowProperty()) continue;
-                var value = updateEntry.GetCurrentValue(property);
-                if (property.PropertyInfo?.GetSetMethod(nonPublic: true) != null)
-                    property.PropertyInfo.SetValue(obj, value);
-                else if (property.FieldInfo != null)
-                    property.FieldInfo.SetValue(obj, value);
+                var rawValue = updateEntry.GetCurrentValue(property);
+                regularDoc[property.GetColumnName()] = ApplyConverter(property, rawValue);
             }
-            return obj;
+            return regularDoc;
         }
 
         // With owned navigations, build a flat dictionary so that:
@@ -298,23 +297,16 @@ public class CouchbaseDatabaseWrapper : Database
         // Dictionary keys are serialized verbatim by System.Text.Json — no camelCase
         // transformation — so GetColumnName() keys match what N1QL SELECT returns.
         //
-        // Known limitations (apply equally to the CLR-instance path above):
-        //   1. EF Core value converters (HasConversion) are not applied. GetCurrentValue
-        //      returns the model-side CLR value; property.GetValueConverter()?.ConvertToProvider
-        //      is never called. This affects all entity writes and should be fixed in a
-        //      dedicated write-path correctness pass.
-        //   2. Properties with no PropertyInfo and no FieldInfo are silently dropped.
-        //
-        // Additional limitation specific to the OwnsMany item dictionary (built below):
-        //   3. A custom JsonConverter<TOwnedItem> registered in the SDK's serializer options
-        //      will not fire for owned-item dictionaries, because the item-type boundary is
-        //      erased. The SDK sees Dictionary<string,object?> rather than TOwnedItem and
-        //      dispatches on the runtime type of each property value instead.
+        // Note: a custom JsonConverter<TOwnedItem> registered in the SDK's serializer options
+        // will not fire for owned-item dictionaries, because the item-type boundary is erased.
+        // The SDK sees Dictionary<string,object?> rather than TOwnedItem and dispatches on
+        // the runtime type of each property value instead.
         var doc = new Dictionary<string, object?>();
         foreach (var property in entityType.GetProperties())
         {
             if (property.IsShadowProperty()) continue;
-            doc[property.GetColumnName()] = updateEntry.GetCurrentValue(property);
+            var rawDocValue = updateEntry.GetCurrentValue(property);
+            doc[property.GetColumnName()] = ApplyConverter(property, rawDocValue);
         }
 
         var entity = updateEntry.ToEntityEntry().Entity;
@@ -354,6 +346,21 @@ public class CouchbaseDatabaseWrapper : Database
     }
 
     /// <summary>
+    /// Applies the EF Core value converter (<c>HasConversion</c>) for a property to produce
+    /// the provider/storage representation before writing to Couchbase.  When no converter
+    /// is configured the raw model-side value is returned unchanged.
+    /// </summary>
+    private static object? ApplyConverter(IProperty property, object? rawValue)
+    {
+        var converter = property.GetValueConverter() ?? property.FindTypeMapping()?.Converter;
+        // Always call the converter if one is present, even for null rawValue, because a
+        // converter with ConvertsNulls=true may map null to a non-null provider value.
+        return converter is not null && (rawValue is not null || converter.ConvertsNulls)
+            ? converter.ConvertToProvider(rawValue)
+            : rawValue;
+    }
+
+    /// <summary>
     /// Recursively serializes a single owned-item CLR instance to a dictionary,
     /// including any nested OwnsOne / OwnsMany navigations at arbitrary depth.
     /// </summary>
@@ -371,19 +378,7 @@ public class CouchbaseDatabaseWrapper : Database
             var rawValue = p.PropertyInfo != null
                 ? p.PropertyInfo.GetValue(item)
                 : p.FieldInfo?.GetValue(item);
-            // Apply value converter (HasConversion) so the stored value is the
-            // provider/storage representation, not the raw CLR model value.
-            // GetValueConverter() delegates to FindTypeMapping()?.Converter in EF Core 10;
-            // check FindTypeMapping().Converter directly as a fallback for owned-entity
-            // properties where the two may diverge.
-            var converter   = p.GetValueConverter() ?? p.FindTypeMapping()?.Converter;
-            // Apply the converter when present — even if rawValue is null, because a
-            // converter with ConvertsNulls=true may map null to a non-null provider value.
-            // Only bypass the converter when none is configured.
-            var storedValue = converter is not null && (rawValue is not null || converter.ConvertsNulls)
-                ? converter.ConvertToProvider(rawValue)
-                : rawValue;
-            doc[fieldNamingPolicy?.ConvertName(p.Name) ?? p.Name] = storedValue;
+            doc[fieldNamingPolicy?.ConvertName(p.Name) ?? p.Name] = ApplyConverter(p, rawValue);
         }
 
         foreach (var nav in entityType.GetNavigations())

--- a/src/Couchbase.EntityFrameworkCore/Storage/Internal/CouchbaseDatabaseWrapper.cs
+++ b/src/Couchbase.EntityFrameworkCore/Storage/Internal/CouchbaseDatabaseWrapper.cs
@@ -373,8 +373,9 @@ public class CouchbaseDatabaseWrapper : Database
     /// <summary>
     /// Recursively serializes a single owned-item CLR instance to a dictionary,
     /// including any nested OwnsOne / OwnsMany navigations at arbitrary depth.
+    /// Internal so the field-access fallback can be verified without a live DbContext.
     /// </summary>
-    private static Dictionary<string, object?> SerializeOwnedItem(
+    internal static Dictionary<string, object?> SerializeOwnedItem(
         object item,
         IEntityType entityType,
         JsonNamingPolicy? fieldNamingPolicy)
@@ -393,8 +394,13 @@ public class CouchbaseDatabaseWrapper : Database
 
         foreach (var nav in entityType.GetNavigations())
         {
-            if (!nav.TargetEntityType.IsOwned() || nav.PropertyInfo == null) continue;
-            var navValue = nav.PropertyInfo.GetValue(item);
+            // Skip only when the navigation is not owned or cannot be read at all.
+            // Read via PropertyInfo when available; fall back to FieldInfo for field-access
+            // navigations (backing-field or [BackingField]-annotated) where PropertyInfo is null.
+            if (!nav.TargetEntityType.IsOwned() || (nav.PropertyInfo == null && nav.FieldInfo == null)) continue;
+            var navValue = nav.PropertyInfo != null
+                ? nav.PropertyInfo.GetValue(item)
+                : nav.FieldInfo?.GetValue(item);
             var fieldName = fieldNamingPolicy?.ConvertName(nav.Name) ?? nav.Name;
 
             if (nav.IsCollection)

--- a/src/Couchbase.EntityFrameworkCore/Storage/Internal/CouchbaseDatabaseWrapper.cs
+++ b/src/Couchbase.EntityFrameworkCore/Storage/Internal/CouchbaseDatabaseWrapper.cs
@@ -219,9 +219,19 @@ public class CouchbaseDatabaseWrapper : Database
     {
         foreach (var p in nav.TargetEntityType.GetProperties().Where(p => !p.IsShadowProperty()))
         {
+            // When the entire navigation is null every flattened column must be written as
+            // null unconditionally — do NOT call ApplyConverter here.  A converter with
+            // ConvertsNulls=true would map null to a non-null sentinel value; EF would then
+            // see that non-null value on the read path and incorrectly treat the navigation
+            // as present, causing materialisation to fail or return a phantom owned object.
+            if (navValue == null)
+            {
+                doc[p.GetColumnName()] = null;
+                continue;
+            }
+
             // Read via PropertyInfo when available; fall back to FieldInfo for field-access properties.
-            var rawValue = navValue == null ? null
-                : p.PropertyInfo != null ? p.PropertyInfo.GetValue(navValue)
+            var rawValue = p.PropertyInfo != null ? p.PropertyInfo.GetValue(navValue)
                 : p.FieldInfo?.GetValue(navValue);
             doc[p.GetColumnName()] = ApplyConverter(p, rawValue);
         }

--- a/tests/Couchbase.EntityFrameworkCore.UnitTests/Couchbase/EntityFrameworkCore/Storage/Internal/CouchbaseDatabaseWrapperHydrateTests.cs
+++ b/tests/Couchbase.EntityFrameworkCore.UnitTests/Couchbase/EntityFrameworkCore/Storage/Internal/CouchbaseDatabaseWrapperHydrateTests.cs
@@ -1,7 +1,10 @@
 using System.Collections.Generic;
 using System.Reflection;
 using System.Text.Json;
+using Couchbase.EntityFrameworkCore.Extensions;
+using Couchbase.EntityFrameworkCore.Infrastructure;
 using Couchbase.EntityFrameworkCore.Storage.Internal;
+using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Update;
@@ -34,6 +37,18 @@ public class CouchbaseDatabaseWrapperHydrateTests
         var prop = new Mock<IProperty>();
         prop.Setup(p => p.PropertyInfo).Returns(propertyInfo);
         prop.Setup(p => p.FieldInfo).Returns(fieldInfo);
+        // IsShadowProperty() is on the IPropertyBase interface; Moq returns false by default
+        // which would cause GetColumnName() to be called on a property with no annotation,
+        // throwing NullReferenceException.  Set it explicitly from the CLR members.
+        var isShadow = propertyInfo == null && fieldInfo == null;
+        prop.Setup(p => p.IsShadowProperty()).Returns(isShadow);
+        // Wire GetColumnName() via the relational annotation so it short-circuits before
+        // reaching GetDefaultColumnName(), which requires a real entity-type table mapping.
+        var name = propertyInfo?.Name ?? fieldInfo?.Name ?? "Prop";
+        prop.Setup(p => p.Name).Returns(name);
+        var annotation = new Mock<IAnnotation>();
+        annotation.Setup(a => a.Value).Returns(name);
+        prop.Setup(p => p.FindAnnotation("Relational:ColumnName")).Returns(annotation.Object);
         entryMock.Setup(e => e.GetCurrentValue(prop.Object)).Returns(value);
         return prop;
     }
@@ -85,9 +100,12 @@ public class CouchbaseDatabaseWrapperHydrateTests
         entityType.Setup(t => t.GetProperties()).Returns([nameProp.Object]);
         entry.Setup(e => e.EntityType).Returns(entityType.Object);
 
-        var result = (EntityWithSetter)Hydrate(entry.Object);
+        // HydrateObjectFromEntity now always returns Dictionary<string,object?> so that
+        // value converters (HasConversion) can be applied before storage.
+        var result = (Dictionary<string, object?>)Hydrate(entry.Object);
 
-        Assert.Equal("hello", result.Name);
+        Assert.True(result.ContainsKey("Name"));
+        Assert.Equal("hello", result["Name"]);
     }
 
     [Fact]
@@ -106,9 +124,10 @@ public class CouchbaseDatabaseWrapperHydrateTests
         entityType.Setup(t => t.GetProperties()).Returns([nameProp.Object]);
         entry.Setup(e => e.EntityType).Returns(entityType.Object);
 
-        var result = (EntityWithSetter)Hydrate(entry.Object);
+        var result = (Dictionary<string, object?>)Hydrate(entry.Object);
 
-        Assert.Null(result.Name);
+        Assert.True(result.ContainsKey("Name"));
+        Assert.Null(result["Name"]);
     }
 
     // -----------------------------------------------------------------------
@@ -116,8 +135,11 @@ public class CouchbaseDatabaseWrapperHydrateTests
     // -----------------------------------------------------------------------
 
     [Fact]
-    public void Hydrate_FieldBackedProperty_SetsValueViaFieldInfo()
+    public void Hydrate_FieldBackedProperty_SetsValueViaPropertyInfo()
     {
+        // Field-backed properties are still accessible by EF Core via GetCurrentValue(),
+        // which reads from the change-tracker entry regardless of backing-field strategy.
+        // The stored value should appear in the document dictionary.
         var entry = new Mock<IUpdateEntry>();
         var entityType = new Mock<IEntityType>();
         entityType.Setup(t => t.ClrType).Returns(typeof(EntityWithFieldBackedProperty));
@@ -135,9 +157,10 @@ public class CouchbaseDatabaseWrapperHydrateTests
         entityType.Setup(t => t.GetProperties()).Returns([nameProp.Object]);
         entry.Setup(e => e.EntityType).Returns(entityType.Object);
 
-        var result = (EntityWithFieldBackedProperty)Hydrate(entry.Object);
+        var result = (Dictionary<string, object?>)Hydrate(entry.Object);
 
-        Assert.Equal("field-set", result.Name);
+        Assert.True(result.ContainsKey("Name"));
+        Assert.Equal("field-set", result["Name"]);
     }
 
     // -----------------------------------------------------------------------
@@ -152,7 +175,8 @@ public class CouchbaseDatabaseWrapperHydrateTests
         var entityType = new Mock<IEntityType>();
         entityType.Setup(t => t.ClrType).Returns(typeof(EntityWithSetter));
 
-        // Shadow property: both PropertyInfo and FieldInfo are null.
+        // Shadow property: both PropertyInfo and FieldInfo are null →
+        // IsShadowProperty() returns true → the property must be omitted from the document.
         var shadowProp = MakeProperty(
             propertyInfo: null,
             fieldInfo: null,
@@ -162,10 +186,10 @@ public class CouchbaseDatabaseWrapperHydrateTests
         entityType.Setup(t => t.GetProperties()).Returns([shadowProp.Object]);
         entry.Setup(e => e.EntityType).Returns(entityType.Object);
 
-        // Must not throw and the Name property must remain at its default.
-        var result = (EntityWithSetter)Hydrate(entry.Object);
+        // Must not throw and the shadow value must not appear in the document.
+        var result = (Dictionary<string, object?>)Hydrate(entry.Object);
 
-        Assert.Null(result.Name);
+        Assert.Empty(result);
     }
 
     // -----------------------------------------------------------------------
@@ -174,26 +198,30 @@ public class CouchbaseDatabaseWrapperHydrateTests
     // -----------------------------------------------------------------------
 
     [Fact]
-    public void Hydrate_NoSetterNoField_IsSkipped_NoNullReferenceException()
+    public void Hydrate_PropertyWithNoSetterNoField_StillStoresValueInDocument()
     {
+        // With the dictionary path, GetCurrentValue() supplies the value from the
+        // change-tracker regardless of whether the CLR property has a setter.  The
+        // value is stored in the document dictionary so it round-trips to Couchbase.
         var entry = new Mock<IUpdateEntry>();
         var entityType = new Mock<IEntityType>();
         entityType.Setup(t => t.ClrType).Returns(typeof(EntityWithComputedProperty));
 
         // PropertyInfo exists (so IsShadowProperty() == false) but has no setter.
-        // FieldInfo is null.
         var computedProp = MakeProperty(
             typeof(EntityWithComputedProperty).GetProperty(nameof(EntityWithComputedProperty.Name)),
             fieldInfo: null,
-            value: "should-be-ignored",
+            value: "ef-tracked-value",
             entry);
 
         entityType.Setup(t => t.GetProperties()).Returns([computedProp.Object]);
         entry.Setup(e => e.EntityType).Returns(entityType.Object);
 
-        var ex = Record.Exception(() => Hydrate(entry.Object));
+        var result = (Dictionary<string, object?>)Hydrate(entry.Object);
 
-        Assert.Null(ex);
+        // The dictionary path stores all non-shadow properties regardless of CLR setters.
+        Assert.True(result.ContainsKey("Name"));
+        Assert.Equal("ef-tracked-value", result["Name"]);
     }
 
     // -----------------------------------------------------------------------
@@ -286,9 +314,12 @@ public class CouchbaseDatabaseWrapperHydrateTests
         entityType.Setup(t => t.GetProperties()).Returns([nameProp.Object, shadowProp.Object]);
         entry.Setup(e => e.EntityType).Returns(entityType.Object);
 
-        var result = (EntityWithSetter)Hydrate(entry.Object);
+        var result = (Dictionary<string, object?>)Hydrate(entry.Object);
 
-        Assert.Equal("real", result.Name);
+        Assert.True(result.ContainsKey("Name"));
+        Assert.Equal("real", result["Name"]);
+        // Shadow property (PropertyInfo == null && FieldInfo == null) must be omitted.
+        Assert.Single(result);
     }
 
     // -----------------------------------------------------------------------
@@ -394,6 +425,287 @@ public class CouchbaseDatabaseWrapperHydrateTests
         var result = (Dictionary<string, object?>)Hydrate(entry.Object);
 
         Assert.Equal(2, result.Count);
+    }
+
+    // -----------------------------------------------------------------------
+    // Value converters (HasConversion) — regular entity write path
+    //
+    // Uses a real DbContext + real IEntityType / IProperty so that EF Core's
+    // type-mapping pipeline populates the converter metadata correctly.
+    // -----------------------------------------------------------------------
+
+    private enum ConverterStatusEnum { Active, Inactive }
+
+    private class RegularEntityWithConverter
+    {
+        public int Id { get; set; }
+        public ConverterStatusEnum Status { get; set; }
+        public string? Name { get; set; }
+    }
+
+    private class RegularConverterContext(DbContextOptions<RegularConverterContext> options)
+        : DbContext(options)
+    {
+        public DbSet<RegularEntityWithConverter> Entities { get; set; } = null!;
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            modelBuilder.Entity<RegularEntityWithConverter>(b =>
+            {
+                b.ToCouchbaseCollection("bucket", "scope", "entities");
+                b.HasKey(e => e.Id);
+                b.Property(e => e.Status).HasConversion<string>();
+            });
+        }
+    }
+
+    private static RegularConverterContext CreateRegularConverterContext()
+    {
+        var opts = new global::Couchbase.ClusterOptions()
+            .WithConnectionString("couchbase://localhost")
+            .WithPasswordAuthentication("Administrator", "password");
+        var builder = new DbContextOptionsBuilder<RegularConverterContext>();
+        builder.UseCouchbaseProvider(opts);
+        return new RegularConverterContext(builder.Options);
+    }
+
+    [Fact]
+    public void Hydrate_PropertyWithConverter_StoresProviderValue()
+    {
+        // HasConversion<string> on a ConverterStatusEnum property: the stored document
+        // must contain the provider type ("Active") rather than the model CLR value
+        // (ConverterStatusEnum.Active / integer 0).
+        using var ctx = CreateRegularConverterContext();
+        var entityType = ctx.Model.FindEntityType(typeof(RegularEntityWithConverter))!;
+        var idProp     = entityType.FindProperty(nameof(RegularEntityWithConverter.Id))!;
+        var statusProp = entityType.FindProperty(nameof(RegularEntityWithConverter.Status))!;
+        var nameProp   = entityType.FindProperty(nameof(RegularEntityWithConverter.Name))!;
+
+        var entry = new Mock<IUpdateEntry>();
+        entry.Setup(e => e.EntityType).Returns(entityType);
+        entry.Setup(e => e.GetCurrentValue(idProp)).Returns(1);
+        entry.Setup(e => e.GetCurrentValue(statusProp)).Returns(ConverterStatusEnum.Active);
+        entry.Setup(e => e.GetCurrentValue(nameProp)).Returns("Alice");
+
+        var result = (Dictionary<string, object?>)Hydrate(entry.Object);
+
+        // Converter must produce the provider string, not the raw enum.
+        Assert.Equal("Active", result[statusProp.GetColumnName()]);
+        Assert.Equal("Alice",  result[nameProp.GetColumnName()]);
+        Assert.Equal(1,        result[idProp.GetColumnName()]);
+    }
+
+    [Fact]
+    public void Hydrate_PropertyWithConverter_InactiveVariant()
+    {
+        using var ctx = CreateRegularConverterContext();
+        var entityType = ctx.Model.FindEntityType(typeof(RegularEntityWithConverter))!;
+        var statusProp = entityType.FindProperty(nameof(RegularEntityWithConverter.Status))!;
+        var idProp     = entityType.FindProperty(nameof(RegularEntityWithConverter.Id))!;
+        var nameProp   = entityType.FindProperty(nameof(RegularEntityWithConverter.Name))!;
+
+        var entry = new Mock<IUpdateEntry>();
+        entry.Setup(e => e.EntityType).Returns(entityType);
+        entry.Setup(e => e.GetCurrentValue(statusProp)).Returns(ConverterStatusEnum.Inactive);
+        entry.Setup(e => e.GetCurrentValue(idProp)).Returns(2);
+        entry.Setup(e => e.GetCurrentValue(nameProp)).Returns((object?)null);
+
+        var result = (Dictionary<string, object?>)Hydrate(entry.Object);
+
+        Assert.Equal("Inactive", result[statusProp.GetColumnName()]);
+    }
+
+    [Fact]
+    public void Hydrate_PropertyWithConverter_NullValue_NoConverter_StoredAsNull()
+    {
+        // A nullable property WITHOUT a converter: null must be stored verbatim.
+        using var ctx = CreateRegularConverterContext();
+        var entityType = ctx.Model.FindEntityType(typeof(RegularEntityWithConverter))!;
+        var nameProp   = entityType.FindProperty(nameof(RegularEntityWithConverter.Name))!;
+        var idProp     = entityType.FindProperty(nameof(RegularEntityWithConverter.Id))!;
+        var statusProp = entityType.FindProperty(nameof(RegularEntityWithConverter.Status))!;
+
+        var entry = new Mock<IUpdateEntry>();
+        entry.Setup(e => e.EntityType).Returns(entityType);
+        entry.Setup(e => e.GetCurrentValue(nameProp)).Returns((object?)null);
+        entry.Setup(e => e.GetCurrentValue(idProp)).Returns(1);
+        entry.Setup(e => e.GetCurrentValue(statusProp)).Returns(ConverterStatusEnum.Active);
+
+        var result = (Dictionary<string, object?>)Hydrate(entry.Object);
+
+        Assert.Null(result[nameProp.GetColumnName()]);
+    }
+
+    // -----------------------------------------------------------------------
+    // ConvertsNulls=true — null model value must reach the converter
+    // -----------------------------------------------------------------------
+
+    private sealed class NullSentinelConverter
+        : Microsoft.EntityFrameworkCore.Storage.ValueConversion.ValueConverter<string?, string>
+    {
+        public NullSentinelConverter()
+            : base(v => v ?? "NULL_SENTINEL", v => v == "NULL_SENTINEL" ? null : v) { }
+
+        public override bool ConvertsNulls => true;
+    }
+
+    private class NullSentinelEntity
+    {
+        public int     Id   { get; set; }
+        public string? Note { get; set; }
+    }
+
+    private class NullSentinelEntityContext(DbContextOptions<NullSentinelEntityContext> options)
+        : DbContext(options)
+    {
+        public DbSet<NullSentinelEntity> Entities { get; set; } = null!;
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            modelBuilder.Entity<NullSentinelEntity>(b =>
+            {
+                b.ToCouchbaseCollection("bucket", "scope", "entities");
+                b.HasKey(e => e.Id);
+                b.Property(e => e.Note).HasConversion(new NullSentinelConverter());
+            });
+        }
+    }
+
+    private static NullSentinelEntityContext CreateNullSentinelEntityContext()
+    {
+        var opts = new global::Couchbase.ClusterOptions()
+            .WithConnectionString("couchbase://localhost")
+            .WithPasswordAuthentication("Administrator", "password");
+        var builder = new DbContextOptionsBuilder<NullSentinelEntityContext>();
+        builder.UseCouchbaseProvider(opts);
+        return new NullSentinelEntityContext(builder.Options);
+    }
+
+    [Fact]
+    public void Hydrate_ConvertsNulls_True_NullModelValue_StoresSentinel()
+    {
+        // A converter with ConvertsNulls=true must be invoked even when the model value
+        // is null, so that null → "NULL_SENTINEL" is written to Couchbase.
+        using var ctx = CreateNullSentinelEntityContext();
+        var entityType = ctx.Model.FindEntityType(typeof(NullSentinelEntity))!;
+        var noteProp   = entityType.FindProperty(nameof(NullSentinelEntity.Note))!;
+        var idProp     = entityType.FindProperty(nameof(NullSentinelEntity.Id))!;
+
+        var entry = new Mock<IUpdateEntry>();
+        entry.Setup(e => e.EntityType).Returns(entityType);
+        entry.Setup(e => e.GetCurrentValue(noteProp)).Returns((object?)null);
+        entry.Setup(e => e.GetCurrentValue(idProp)).Returns(1);
+
+        var result = (Dictionary<string, object?>)Hydrate(entry.Object);
+
+        Assert.Equal("NULL_SENTINEL", result[noteProp.GetColumnName()]);
+    }
+
+    [Fact]
+    public void Hydrate_ConvertsNulls_True_NonNullModelValue_StoresConverted()
+    {
+        using var ctx = CreateNullSentinelEntityContext();
+        var entityType = ctx.Model.FindEntityType(typeof(NullSentinelEntity))!;
+        var noteProp   = entityType.FindProperty(nameof(NullSentinelEntity.Note))!;
+        var idProp     = entityType.FindProperty(nameof(NullSentinelEntity.Id))!;
+
+        var entry = new Mock<IUpdateEntry>();
+        entry.Setup(e => e.EntityType).Returns(entityType);
+        entry.Setup(e => e.GetCurrentValue(noteProp)).Returns("hello");
+        entry.Setup(e => e.GetCurrentValue(idProp)).Returns(1);
+
+        var result = (Dictionary<string, object?>)Hydrate(entry.Object);
+
+        // Non-null value passes through unchanged (v => v ?? "NULL_SENTINEL" keeps "hello").
+        Assert.Equal("hello", result[noteProp.GetColumnName()]);
+    }
+
+    // -----------------------------------------------------------------------
+    // FillOwnsOneIntoDoc — value converter on an OwnsOne scalar
+    // -----------------------------------------------------------------------
+
+    private class OwnedDetails
+    {
+        public ConverterStatusEnum Status { get; set; }
+        public string?              Label  { get; set; }
+    }
+
+    private class OwnerWithOwnsOne
+    {
+        public int         Id      { get; set; }
+        public OwnedDetails Details { get; set; } = null!;
+    }
+
+    private class OwnsOneConverterContext(DbContextOptions<OwnsOneConverterContext> options)
+        : DbContext(options)
+    {
+        public DbSet<OwnerWithOwnsOne> Owners { get; set; } = null!;
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            modelBuilder.Entity<OwnerWithOwnsOne>(b =>
+            {
+                b.ToCouchbaseCollection("bucket", "scope", "owners");
+                b.HasKey(o => o.Id);
+                b.OwnsOne(o => o.Details, d =>
+                {
+                    d.Property(x => x.Status).HasConversion<string>();
+                });
+            });
+        }
+    }
+
+    private static OwnsOneConverterContext CreateOwnsOneConverterContext()
+    {
+        var opts = new global::Couchbase.ClusterOptions()
+            .WithConnectionString("couchbase://localhost")
+            .WithPasswordAuthentication("Administrator", "password");
+        var builder = new DbContextOptionsBuilder<OwnsOneConverterContext>();
+        builder.UseCouchbaseProvider(opts);
+        return new OwnsOneConverterContext(builder.Options);
+    }
+
+    [Fact]
+    public void FillOwnsOneIntoDoc_PropertyWithConverter_StoresProviderValue()
+    {
+        // HasConversion<string> on an OwnsOne scalar: FillOwnsOneIntoDoc must apply
+        // ConvertToProvider so the document stores "Active" not the enum integer.
+        using var ctx = CreateOwnsOneConverterContext();
+        var ownerEntityType = ctx.Model.FindEntityType(typeof(OwnerWithOwnsOne))!;
+        var detailsNav      = ownerEntityType.GetNavigations()
+            .First(n => n.Name == nameof(OwnerWithOwnsOne.Details));
+
+        var navValue = new OwnedDetails { Status = ConverterStatusEnum.Active, Label = "primary" };
+        var doc      = new Dictionary<string, object?>();
+
+        CouchbaseDatabaseWrapper.FillOwnsOneIntoDoc(doc, detailsNav, navValue);
+
+        // Status must be stored as the provider string, not the enum / integer.
+        var statusKey = detailsNav.TargetEntityType
+            .FindProperty(nameof(OwnedDetails.Status))!.GetColumnName();
+        Assert.Equal("Active", doc[statusKey]);
+
+        var labelKey = detailsNav.TargetEntityType
+            .FindProperty(nameof(OwnedDetails.Label))!.GetColumnName();
+        Assert.Equal("primary", doc[labelKey]);
+    }
+
+    [Fact]
+    public void FillOwnsOneIntoDoc_NullNavigation_WithConverter_WritesNullForEachColumn()
+    {
+        // When the entire OwnsOne navigation is null every column must be written as null
+        // regardless of whether a converter is present.
+        using var ctx = CreateOwnsOneConverterContext();
+        var ownerEntityType = ctx.Model.FindEntityType(typeof(OwnerWithOwnsOne))!;
+        var detailsNav      = ownerEntityType.GetNavigations()
+            .First(n => n.Name == nameof(OwnerWithOwnsOne.Details));
+
+        var doc = new Dictionary<string, object?>();
+        CouchbaseDatabaseWrapper.FillOwnsOneIntoDoc(doc, detailsNav, navValue: null);
+
+        var statusKey = detailsNav.TargetEntityType
+            .FindProperty(nameof(OwnedDetails.Status))!.GetColumnName();
+        Assert.Null(doc[statusKey]);
     }
 }
 

--- a/tests/Couchbase.EntityFrameworkCore.UnitTests/Couchbase/EntityFrameworkCore/Storage/Internal/CouchbaseDatabaseWrapperHydrateTests.cs
+++ b/tests/Couchbase.EntityFrameworkCore.UnitTests/Couchbase/EntityFrameworkCore/Storage/Internal/CouchbaseDatabaseWrapperHydrateTests.cs
@@ -707,6 +707,77 @@ public class CouchbaseDatabaseWrapperHydrateTests
             .FindProperty(nameof(OwnedDetails.Status))!.GetColumnName();
         Assert.Null(doc[statusKey]);
     }
+
+    // FillOwnsOneIntoDoc — ConvertsNulls=true converter on an OwnsOne scalar
+    // -----------------------------------------------------------------------
+    // Regression: when navValue is null, ApplyConverter must NOT be called even
+    // when the property's converter has ConvertsNulls=true.  Calling it would write
+    // a non-null sentinel and EF would materialise a phantom owned object on read.
+
+    private class OwnedDetailsWithSentinel
+    {
+        public string? Note { get; set; }
+    }
+
+    private class OwnerWithSentinelOwnsOne
+    {
+        public int                    Id      { get; set; }
+        public OwnedDetailsWithSentinel? Details { get; set; }
+    }
+
+    private class OwnsOneWithSentinelConverterContext(DbContextOptions<OwnsOneWithSentinelConverterContext> options)
+        : DbContext(options)
+    {
+        public DbSet<OwnerWithSentinelOwnsOne> Owners { get; set; } = null!;
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            modelBuilder.Entity<OwnerWithSentinelOwnsOne>(b =>
+            {
+                b.ToCouchbaseCollection("bucket", "scope", "owners");
+                b.HasKey(o => o.Id);
+                b.OwnsOne(o => o.Details, d =>
+                {
+                    // NullSentinelConverter has ConvertsNulls=true and maps null → "NULL_SENTINEL".
+                    // When the navigation itself is null FillOwnsOneIntoDoc must still write null,
+                    // not the sentinel, for every owned column.
+                    d.Property(x => x.Note).HasConversion(new NullSentinelConverter());
+                });
+            });
+        }
+    }
+
+    private static OwnsOneWithSentinelConverterContext CreateOwnsOneWithSentinelConverterContext()
+    {
+        var opts = new global::Couchbase.ClusterOptions()
+            .WithConnectionString("couchbase://localhost")
+            .WithPasswordAuthentication("Administrator", "password");
+        var builder = new DbContextOptionsBuilder<OwnsOneWithSentinelConverterContext>();
+        builder.UseCouchbaseProvider(opts);
+        return new OwnsOneWithSentinelConverterContext(builder.Options);
+    }
+
+    [Fact]
+    public void FillOwnsOneIntoDoc_NullNavigation_ConvertsNullsConverter_WritesNullNotSentinel()
+    {
+        // Regression: a ConvertsNulls=true converter on an OwnsOne property must NOT be
+        // invoked when the navigation itself is null.  Before the fix, ApplyConverter was
+        // called with rawValue=null and ConvertsNulls=true, causing "NULL_SENTINEL" to be
+        // written — EF would then materialise a phantom owned object on the read path.
+        using var ctx = CreateOwnsOneWithSentinelConverterContext();
+        var ownerEntityType = ctx.Model.FindEntityType(typeof(OwnerWithSentinelOwnsOne))!;
+        var detailsNav      = ownerEntityType.GetNavigations()
+            .First(n => n.Name == nameof(OwnerWithSentinelOwnsOne.Details));
+
+        var doc = new Dictionary<string, object?>();
+        CouchbaseDatabaseWrapper.FillOwnsOneIntoDoc(doc, detailsNav, navValue: null);
+
+        var noteKey = detailsNav.TargetEntityType
+            .FindProperty(nameof(OwnedDetailsWithSentinel.Note))!.GetColumnName();
+
+        // Must be null — not "NULL_SENTINEL" — because the navigation is absent.
+        Assert.Null(doc[noteKey]);
+    }
 }
 
 /* ************************************************************

--- a/tests/Couchbase.EntityFrameworkCore.UnitTests/Couchbase/EntityFrameworkCore/Storage/Internal/CouchbaseDatabaseWrapperHydrateTests.cs
+++ b/tests/Couchbase.EntityFrameworkCore.UnitTests/Couchbase/EntityFrameworkCore/Storage/Internal/CouchbaseDatabaseWrapperHydrateTests.cs
@@ -49,6 +49,10 @@ public class CouchbaseDatabaseWrapperHydrateTests
         var annotation = new Mock<IAnnotation>();
         annotation.Setup(a => a.Value).Returns(name);
         prop.Setup(p => p.FindAnnotation("Relational:ColumnName")).Returns(annotation.Object);
+        // GetColumnName() reads the column name through the indexer (property["Relational:ColumnName"]),
+        // which Moq will not delegate to FindAnnotation unless set up explicitly — without this the
+        // call falls back to GetDefaultColumnName() and throws.  Mirror the other helpers below.
+        prop.Setup(p => p["Relational:ColumnName"]).Returns(name);
         entryMock.Setup(e => e.GetCurrentValue(prop.Object)).Returns(value);
         return prop;
     }
@@ -85,7 +89,7 @@ public class CouchbaseDatabaseWrapperHydrateTests
     // -----------------------------------------------------------------------
 
     [Fact]
-    public void Hydrate_StandardProperty_SetsValueViaPropertyInfo()
+    public void Hydrate_StandardProperty_StoresValueInDocument()
     {
         var entry = new Mock<IUpdateEntry>();
         var entityType = new Mock<IEntityType>();
@@ -109,7 +113,7 @@ public class CouchbaseDatabaseWrapperHydrateTests
     }
 
     [Fact]
-    public void Hydrate_StandardProperty_NullValue_SetsNull()
+    public void Hydrate_StandardProperty_NullValue_StoresNullInDocument()
     {
         var entry = new Mock<IUpdateEntry>();
         var entityType = new Mock<IEntityType>();
@@ -135,7 +139,7 @@ public class CouchbaseDatabaseWrapperHydrateTests
     // -----------------------------------------------------------------------
 
     [Fact]
-    public void Hydrate_FieldBackedProperty_SetsValueViaPropertyInfo()
+    public void Hydrate_FieldBackedProperty_StoresValueInDocument()
     {
         // Field-backed properties are still accessible by EF Core via GetCurrentValue(),
         // which reads from the change-tracker entry regardless of backing-field strategy.
@@ -193,8 +197,9 @@ public class CouchbaseDatabaseWrapperHydrateTests
     }
 
     // -----------------------------------------------------------------------
-    // Computed property (no setter, no FieldInfo) — must be skipped silently.
-    // Before the fix this would NullReferenceException on propertyInfo.SetValue.
+    // Computed property (no setter, no FieldInfo) — its EF-tracked value is still
+    // written to the document via GetCurrentValue(), regardless of CLR setters.
+    // (The old CLR-mutation path would NullReferenceException on PropertyInfo.SetValue.)
     // -----------------------------------------------------------------------
 
     [Fact]
@@ -293,7 +298,7 @@ public class CouchbaseDatabaseWrapperHydrateTests
     }
 
     [Fact]
-    public void Hydrate_MixedProperties_SetsSettableSkipsShadow()
+    public void Hydrate_MixedProperties_StoresNonShadowOmitsShadow()
     {
         var entry = new Mock<IUpdateEntry>();
         var entityType = new Mock<IEntityType>();
@@ -777,6 +782,79 @@ public class CouchbaseDatabaseWrapperHydrateTests
 
         // Must be null — not "NULL_SENTINEL" — because the navigation is absent.
         Assert.Null(doc[noteKey]);
+    }
+
+    // -----------------------------------------------------------------------
+    // SerializeOwnedItem — nested owned navigation via field access
+    //
+    // A nested OwnsOne/OwnsMany whose PropertyInfo is null (field-access, e.g.
+    // a backing field or [BackingField] navigation) must still be serialized by
+    // reading through FieldInfo, not silently dropped.
+    // -----------------------------------------------------------------------
+
+    private class OwnedLabel
+    {
+        public string? Text { get; set; }
+    }
+
+    private class OwnedContact
+    {
+        // Nested owned navigation accessed via this backing field (no CLR property
+        // exposed to EF), so the mocked INavigation.PropertyInfo is null.
+        private OwnedLabel? _label;
+
+        public OwnedLabel? GetLabel() => _label;
+        public void SetLabel(OwnedLabel? label) => _label = label;
+    }
+
+    private static INavigation BuildNestedOwnsOneNavViaField(string propName)
+    {
+        // SerializeOwnedItem keys owned scalars by p.Name, so wire Name (not just the
+        // column annotation) and a PropertyInfo to read the value through.
+        var textProp = new Mock<IProperty>();
+        textProp.Setup(p => p.PropertyInfo).Returns(typeof(OwnedLabel).GetProperty(nameof(OwnedLabel.Text)));
+        textProp.Setup(p => p.FieldInfo).Returns((FieldInfo?)null);
+        textProp.Setup(p => p.IsShadowProperty()).Returns(false);
+        textProp.Setup(p => p.Name).Returns(propName);
+
+        var targetType = new Mock<IEntityType>();
+        targetType.Setup(t => t.GetProperties()).Returns([textProp.Object]);
+        targetType.Setup(t => t.GetNavigations()).Returns([]);
+        targetType.Setup(t => t.IsOwned()).Returns(true);
+
+        var nav = new Mock<INavigation>();
+        nav.Setup(n => n.IsCollection).Returns(false);
+        nav.Setup(n => n.Name).Returns("label");
+        nav.Setup(n => n.TargetEntityType).Returns(targetType.Object);
+        // PropertyInfo is null (field-access); the FieldInfo points at the backing field.
+        nav.Setup(n => n.PropertyInfo).Returns((PropertyInfo?)null);
+        nav.Setup(n => n.FieldInfo).Returns(
+            typeof(OwnedContact).GetField("_label", BindingFlags.NonPublic | BindingFlags.Instance));
+
+        return nav.Object;
+    }
+
+    [Fact]
+    public void SerializeOwnedItem_NestedNavViaFieldAccess_IsSerialized()
+    {
+        // Regression: before the FieldInfo fallback, a nested owned navigation with
+        // PropertyInfo == null was skipped entirely, dropping its data from the document.
+        var contact = new OwnedContact();
+        contact.SetLabel(new OwnedLabel { Text = "primary" });
+
+        var nestedNav = BuildNestedOwnsOneNavViaField("text");
+
+        var contactType = new Mock<IEntityType>();
+        contactType.Setup(t => t.GetProperties()).Returns([]);
+        contactType.Setup(t => t.GetNavigations()).Returns([nestedNav]);
+
+        var result = CouchbaseDatabaseWrapper.SerializeOwnedItem(
+            contact, contactType.Object, fieldNamingPolicy: null);
+
+        // The nested navigation must be present and read via FieldInfo.
+        Assert.True(result.ContainsKey("label"), "nested nav 'label' must be serialized");
+        var nested = Assert.IsType<Dictionary<string, object?>>(result["label"]);
+        Assert.Equal("primary", nested["text"]);
     }
 }
 


### PR DESCRIPTION
Value converters (`HasConversion`) were only applied for some entity
shapes on write. This branch routes every write-path location through a
shared `ApplyConverter` helper so the provider representation is stored
consistently.

## What changed

- `HydrateObjectFromEntity` now builds a document dictionary (keyed by
  column name) and applies the configured converter for regular
  entities, shared/join-table entities, owned-nav scalars, and
  `FillOwnsOneIntoDoc`.
- Reads fall back from `PropertyInfo` to `FieldInfo`, so field-access
  (backing-field / `[BackingField]`) properties and nested owned
  navigations are no longer silently dropped.
- `ConvertsNulls=true` converters are honored, while a null owned
  navigation still writes `null` for every flattened column.

## Tests

Added/updated unit coverage for converter application, `ConvertsNulls`,
and field-access nested owned navs. Full unit suite green (794/794).