### PR TITLE
Fix filtered Include returning wrong rows via duplicate projection al…

### DIFF
--- a/src/Couchbase.EntityFrameworkCore/Query/Internal/CouchbaseProjectionAliases.cs
+++ b/src/Couchbase.EntityFrameworkCore/Query/Internal/CouchbaseProjectionAliases.cs
@@ -42,11 +42,25 @@ internal static class CouchbaseProjectionAliases
     /// </summary>
     public static string[] ComputeUnique(IReadOnlyList<ProjectionExpression> projections)
     {
-        var result = new string[projections.Count];
-        var seen = new Dictionary<string, int>();
+        var names = new string[projections.Count];
         for (var i = 0; i < projections.Count; i++)
+            names[i] = EffectiveAlias(projections[i]);
+        return MakeUnique(names);
+    }
+
+    /// <summary>
+    /// Makes a list of alias names collision-free, preserving order: the first occurrence of
+    /// each name is kept verbatim and later duplicates receive an incrementing numeric suffix.
+    /// The suffix search skips any candidate that already exists so a literal collision with an
+    /// already-used "&lt;name&gt;&lt;n&gt;" cannot produce a second duplicate.
+    /// </summary>
+    public static string[] MakeUnique(IReadOnlyList<string> names)
+    {
+        var result = new string[names.Count];
+        var seen = new Dictionary<string, int>();
+        for (var i = 0; i < names.Count; i++)
         {
-            var name = EffectiveAlias(projections[i]);
+            var name = names[i];
             if (seen.TryGetValue(name, out var count))
             {
                 // Find the next free suffixed name (guard against a literal collision with

--- a/src/Couchbase.EntityFrameworkCore/Query/Internal/CouchbaseProjectionAliases.cs
+++ b/src/Couchbase.EntityFrameworkCore/Query/Internal/CouchbaseProjectionAliases.cs
@@ -50,37 +50,38 @@ internal static class CouchbaseProjectionAliases
 
     /// <summary>
     /// Makes a list of alias names collision-free, preserving order: the first occurrence of
-    /// each name is kept verbatim and later duplicates receive an incrementing numeric suffix.
-    /// The suffix search skips any candidate that already exists so a literal collision with an
-    /// already-used "&lt;name&gt;&lt;n&gt;" cannot produce a second duplicate.
+    /// each name is kept verbatim and later duplicates receive the smallest numeric suffix that
+    /// is neither already emitted nor an original (reserved) literal.  Reserving every input name
+    /// up front ensures a generated suffix never steals a distinct literal alias that appears
+    /// later in the list (e.g. <c>["rating", "rating", "rating0"]</c> →
+    /// <c>["rating", "rating1", "rating0"]</c>, not <c>["rating", "rating0", "rating00"]</c>).
     /// </summary>
     public static string[] MakeUnique(IReadOnlyList<string> names)
     {
         var result = new string[names.Count];
-        var seen = new Dictionary<string, int>();
+        var reserved = new HashSet<string>(names);   // every original literal alias
+        var used = new HashSet<string>();            // names already emitted into result
         for (var i = 0; i < names.Count; i++)
         {
             var name = names[i];
-            if (seen.TryGetValue(name, out var count))
+            if (used.Add(name))
             {
-                // Find the next free suffixed name (guard against a literal collision with
-                // an already-used "<name><n>").
-                string candidate;
-                do
-                {
-                    candidate = name + count;
-                    count++;
-                } while (seen.ContainsKey(candidate));
-
-                seen[name] = count;
-                seen[candidate] = 0;
-                result[i] = candidate;
-            }
-            else
-            {
-                seen[name] = 0;
+                // First time this exact literal is emitted — always keep it verbatim.
                 result[i] = name;
+                continue;
             }
+
+            // Duplicate: pick the smallest "<name><n>" that is not already emitted and is not an
+            // original literal (so a later distinct literal keeps its own slot).
+            var n = 0;
+            string candidate;
+            do
+            {
+                candidate = name + n++;
+            } while (used.Contains(candidate) || reserved.Contains(candidate));
+
+            used.Add(candidate);
+            result[i] = candidate;
         }
 
         return result;

--- a/src/Couchbase.EntityFrameworkCore/Query/Internal/CouchbaseProjectionAliases.cs
+++ b/src/Couchbase.EntityFrameworkCore/Query/Internal/CouchbaseProjectionAliases.cs
@@ -1,0 +1,74 @@
+using System.Collections.Generic;
+using Microsoft.EntityFrameworkCore.Query.SqlExpressions;
+
+namespace Couchbase.EntityFrameworkCore.Query.Internal;
+
+/// <summary>
+/// Helpers for computing the result-key (alias) names used by N1QL projections.
+/// <para>
+/// Unlike a relational tabular result set — where columns are addressed positionally and
+/// duplicate column names are harmless — a N1QL query returns each row as a JSON object keyed
+/// by the projection alias.  When two projected columns share the same effective alias (for
+/// example a collection <c>Include</c> where the principal and dependent both expose a
+/// <c>rating</c> / <c>blogId</c> property) their values would collide on a single JSON key,
+/// and <see cref="Storage.Internal.CouchbaseDbDataReader{T}"/> — which maps each shaper ordinal
+/// to its alias — would read the same value into both ordinals.
+/// </para>
+/// <para>
+/// To keep a one-to-one mapping between shaper ordinals and JSON keys, the alias of each
+/// projection is made unique by appending an incrementing numeric suffix on collision.  The
+/// SQL generator and the shaped-query compiler both derive their aliases from this method over
+/// the same <see cref="SelectExpression.Projection"/> list (in the same order), so the emitted
+/// <c>AS</c> clauses and the alias array handed to the reader stay aligned.
+/// </para>
+/// </summary>
+internal static class CouchbaseProjectionAliases
+{
+    /// <summary>
+    /// The N1QL response key for a single projection when no uniquification is applied:
+    /// the explicit <c>AS</c> alias if present, otherwise the underlying column name.
+    /// </summary>
+    public static string EffectiveAlias(ProjectionExpression projection)
+        => projection.Alias != string.Empty
+            ? projection.Alias
+            : projection.Expression is ColumnExpression c
+                ? c.Name
+                : string.Empty;
+
+    /// <summary>
+    /// Computes a collision-free alias for every projection, in projection order.  The first
+    /// occurrence of an effective alias is kept verbatim; subsequent duplicates get an
+    /// incrementing numeric suffix (e.g. <c>rating</c>, <c>rating0</c>, <c>rating1</c>).
+    /// </summary>
+    public static string[] ComputeUnique(IReadOnlyList<ProjectionExpression> projections)
+    {
+        var result = new string[projections.Count];
+        var seen = new Dictionary<string, int>();
+        for (var i = 0; i < projections.Count; i++)
+        {
+            var name = EffectiveAlias(projections[i]);
+            if (seen.TryGetValue(name, out var count))
+            {
+                // Find the next free suffixed name (guard against a literal collision with
+                // an already-used "<name><n>").
+                string candidate;
+                do
+                {
+                    candidate = name + count;
+                    count++;
+                } while (seen.ContainsKey(candidate));
+
+                seen[name] = count;
+                seen[candidate] = 0;
+                result[i] = candidate;
+            }
+            else
+            {
+                seen[name] = 0;
+                result[i] = name;
+            }
+        }
+
+        return result;
+    }
+}

--- a/src/Couchbase.EntityFrameworkCore/Query/Internal/CouchbaseProjectionAliases.cs
+++ b/src/Couchbase.EntityFrameworkCore/Query/Internal/CouchbaseProjectionAliases.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using Microsoft.EntityFrameworkCore.Query.SqlExpressions;
 
@@ -55,12 +56,21 @@ internal static class CouchbaseProjectionAliases
     /// up front ensures a generated suffix never steals a distinct literal alias that appears
     /// later in the list (e.g. <c>["rating", "rating", "rating0"]</c> →
     /// <c>["rating", "rating1", "rating0"]</c>, not <c>["rating", "rating0", "rating00"]</c>).
+    /// <para>
+    /// Collisions are detected case-insensitively to match
+    /// <see cref="Storage.Internal.CouchbaseDbDataReader{T}"/>, which keys its alias→ordinal map
+    /// with <see cref="StringComparer.OrdinalIgnoreCase"/>.  Aliases differing only by case
+    /// (e.g. <c>rating</c> / <c>Rating</c>) would otherwise collide at read time even though this
+    /// method left them untouched.  The base name's original casing is preserved in the suffixed
+    /// result (<c>Rating</c> → <c>Rating0</c>).
+    /// </para>
     /// </summary>
     public static string[] MakeUnique(IReadOnlyList<string> names)
     {
         var result = new string[names.Count];
-        var reserved = new HashSet<string>(names);   // every original literal alias
-        var used = new HashSet<string>();            // names already emitted into result
+        // Case-insensitive to match CouchbaseDbDataReader's alias lookup.
+        var reserved = new HashSet<string>(names, StringComparer.OrdinalIgnoreCase);  // every original literal alias
+        var used = new HashSet<string>(StringComparer.OrdinalIgnoreCase);             // names already emitted into result
         for (var i = 0; i < names.Count; i++)
         {
             var name = names[i];

--- a/src/Couchbase.EntityFrameworkCore/Query/Internal/CouchbaseQuerySqlGenerator.cs
+++ b/src/Couchbase.EntityFrameworkCore/Query/Internal/CouchbaseQuerySqlGenerator.cs
@@ -498,8 +498,43 @@ public class CouchbaseQuerySqlGenerator : QuerySqlGenerator
                     }
                     GenerateList(selectExpression.Projection, e => Visit(e));
                 }
+                else if (selectExpression.Alias == null)
+                {
+                    // Top-level SELECT: each row becomes a JSON object keyed by alias, so two
+                    // projections sharing an effective alias (e.g. a collection Include where the
+                    // principal and dependent both expose `rating` / `blogId`) would collide on a
+                    // single key. Emit a unique alias for every colliding projection, aligned with
+                    // the alias array built in CouchbaseShapedQueryCompilingExpressionVisitor.
+                    var uniqueAliases = CouchbaseProjectionAliases.ComputeUnique(selectExpression.Projection);
+                    var emitted = new List<(ProjectionExpression Projection, string Alias)>();
+                    for (var i = 0; i < selectExpression.Projection.Count; i++)
+                    {
+                        var projection = selectExpression.Projection[i];
+                        if (!IsFromSkippedJoin(projection))
+                            emitted.Add((projection, uniqueAliases[i]));
+                    }
+
+                    GenerateList(emitted, e =>
+                    {
+                        // Only append AS when the unique alias differs from what the projection
+                        // would emit on its own — keeps non-colliding queries byte-identical.
+                        if (e.Alias != CouchbaseProjectionAliases.EffectiveAlias(e.Projection))
+                        {
+                            Visit(e.Projection.Expression);
+                            Sql.Append(AliasSeparator)
+                                .Append(Dependencies.SqlGenerationHelper.DelimitIdentifier(e.Alias));
+                        }
+                        else
+                        {
+                            Visit(e.Projection);
+                        }
+                    });
+                }
                 else
                 {
+                    // Sub-query SELECT: its projected column names are referenced by the enclosing
+                    // query's join/column expressions, so they must not be renamed. Dedupe by
+                    // alias to avoid emitting an identical column twice.
                     var dedupedProjections = new Dictionary<string, ProjectionExpression>();
                     foreach (var expression in selectExpression.Projection)
                     {

--- a/src/Couchbase.EntityFrameworkCore/Query/Internal/CouchbaseShapedQueryCompilingExpressionVisitor.cs
+++ b/src/Couchbase.EntityFrameworkCore/Query/Internal/CouchbaseShapedQueryCompilingExpressionVisitor.cs
@@ -230,26 +230,27 @@ public class CouchbaseShapedQueryCompilingExpressionVisitor : RelationalShapedQu
             // included in the alias array that CouchbaseDbDataReader uses for column lookup).
             AddOwnedCollectionColumnsToProjection(selectExpression, shaper.ReturnType);
 
-            // ProjectionExpression.Alias is "" when no explicit AS clause is emitted — in that case
-            // the N1QL response key is the underlying ColumnExpression.Name.
-            static string EffectiveAlias(ProjectionExpression pe) =>
-                pe.Alias != string.Empty ? pe.Alias
-                    : pe.Expression is ColumnExpression c ? c.Name
-                    : string.Empty;
-
-            // Keep the FULL unfiltered projection alias array so the EF Core shaper's baked-in
-            // ordinals remain correct. Columns from skipped owned-type JOINs (e.g. cm0.id) are
-            // absent from the N1QL result and return DBNull via CouchbaseDbDataReader, which is
-            // the expected signal for "no collection rows" — PopulateCollectionNavigations then
-            // fills the actual collection from the embedded JSON array.
+            // Build the per-ordinal N1QL response keys.  Aliases are made unique (see
+            // CouchbaseProjectionAliases) so that a collection Include where the principal and
+            // dependent share a property name (e.g. blogId / rating) maps each shaper ordinal to
+            // a distinct JSON key instead of both reading the same colliding key.  The SQL
+            // generator derives the same array from the same projection list, so the emitted
+            // AS clauses and this array stay aligned.
+            //
+            // The FULL unfiltered projection is kept so the EF Core shaper's baked-in ordinals
+            // remain correct. Columns from skipped owned-type JOINs (e.g. cm0.id) are absent from
+            // the N1QL result and return DBNull via CouchbaseDbDataReader, which is the expected
+            // signal for "no collection rows" — PopulateCollectionNavigations then fills the
+            // actual collection from the embedded JSON array.
+            var uniqueAliases = CouchbaseProjectionAliases.ComputeUnique(selectExpression.Projection);
             var projectionAliasesExpression = Dependencies.LiftableConstantFactory.CreateLiftableConstant(
-                selectExpression.Projection.Select(EffectiveAlias).ToArray(),
+                uniqueAliases,
 #pragma warning disable EF9100
                 Expression.Lambda<Func<MaterializerLiftableConstantContext, object>>(
 #pragma warning restore EF9100
                     Expression.NewArrayInit(
                         typeof(string),
-                        selectExpression.Projection.Select(pe => Expression.Constant(EffectiveAlias(pe), typeof(string)))),
+                        uniqueAliases.Select(a => (Expression)Expression.Constant(a, typeof(string)))),
 #pragma warning disable EF9100
                     Expression.Parameter(typeof(MaterializerLiftableConstantContext), "_")),
 #pragma warning restore EF9100

--- a/tests/Couchbase.EntityFrameworkCore.IntegrationTests/Tests/EagerLoadingTests.cs
+++ b/tests/Couchbase.EntityFrameworkCore.IntegrationTests/Tests/EagerLoadingTests.cs
@@ -177,6 +177,48 @@ public class EagerLoadingTests(BloggingFixture fixture) : IAsyncLifetime
         Assert.Equal(5, blog2.Posts[0].Rating);
     }
 
+    [Fact]
+    public async Task Include_Posts_WithFilter_MultipleMatches_ReturnsAllMatching()
+    {
+        // Regression guard for the projection-alias collision fix: the predicate must keep
+        // MORE THAN ONE dependent row per principal (the original failing case returned a
+        // single row per blog, which masked mis-aligned multi-row materialization).
+        await using var context = fixture.GetDbContext();
+
+        var blogs = await context.Blogs
+            .Include(b => b.Posts.Where(p => p.Rating >= 4))
+            .OrderBy(b => b.BlogId)
+            .ToListAsync();
+
+        // Blog 2 has posts rated 5, 4, 3 → ratings 5 and 4 match.
+        var blog2 = blogs.First(b => b.BlogId == 2);
+        Assert.Equal(2, blog2.Posts.Count);
+        Assert.Equal([4, 5], blog2.Posts.Select(p => p.Rating).OrderBy(r => r));
+        // The dependent's own FK column must be the post's, not the principal's leaking through.
+        Assert.All(blog2.Posts, p => Assert.Equal(2, p.BlogId));
+    }
+
+    [Fact]
+    public async Task Include_Posts_Unfiltered_DependentCollidingColumnsAreCorrect()
+    {
+        // Blog and Post both expose `rating` and `blogId`. This asserts the dependent's values
+        // for those colliding columns — before the alias-uniquification fix the post read the
+        // blog's `rating` (and `blogId`) instead of its own, even without a filter.
+        await using var context = fixture.GetDbContext();
+
+        var blogs = await context.Blogs
+            .Include(b => b.Posts)
+            .OrderBy(b => b.BlogId)
+            .ToListAsync();
+
+        var blog2 = blogs.First(b => b.BlogId == 2);   // blog2.Rating == 4
+        var post2 = blog2.Posts.First(p => p.PostId == 2);
+
+        // Post 2's own rating is 5 — distinct from blog2's rating (4), so a leak is detectable.
+        Assert.Equal(5, post2.Rating);
+        Assert.Equal(2, post2.BlogId);
+    }
+
     // -----------------------------------------------------------------------
     // 6 — Auto-include (Person.Photo configured with AutoInclude in model)
     // -----------------------------------------------------------------------

--- a/tests/Couchbase.EntityFrameworkCore.IntegrationTests/Tests/EagerLoadingTests.cs
+++ b/tests/Couchbase.EntityFrameworkCore.IntegrationTests/Tests/EagerLoadingTests.cs
@@ -155,7 +155,7 @@ public class EagerLoadingTests(BloggingFixture fixture) : IAsyncLifetime
     // 5 — Filtered include
     // -----------------------------------------------------------------------
 
-    [Fact(Skip = "Filtered include returns incorrect posts — the WHERE predicate is not applied correctly in the generated N1QL. Needs investigation in CouchbaseQuerySqlGenerator.")]
+    [Fact]
     public async Task Include_Posts_WithFilter_ReturnsOnlyMatchingPosts()
     {
         await using var context = fixture.GetDbContext();

--- a/tests/Couchbase.EntityFrameworkCore.UnitTests/Couchbase/EntityFrameworkCore/Query/CouchbaseProjectionAliasesTests.cs
+++ b/tests/Couchbase.EntityFrameworkCore.UnitTests/Couchbase/EntityFrameworkCore/Query/CouchbaseProjectionAliasesTests.cs
@@ -49,6 +49,16 @@ public class CouchbaseProjectionAliasesTests
     }
 
     [Fact]
+    public void MakeUnique_LaterDistinctLiteral_IsNotConsumedByEarlierDuplicate()
+    {
+        // The duplicate "rating" at index 1 must NOT take "rating0" — that literal appears later
+        // (index 2) as a distinct alias and must keep its own slot. The duplicate skips to
+        // "rating1" instead.
+        var result = CouchbaseProjectionAliases.MakeUnique(["rating", "rating", "rating0"]);
+        Assert.Equal(["rating", "rating1", "rating0"], result);
+    }
+
+    [Fact]
     public void MakeUnique_FirstOccurrenceAlwaysVerbatim()
     {
         // Order is preserved and only later occurrences are renamed — never the first.

--- a/tests/Couchbase.EntityFrameworkCore.UnitTests/Couchbase/EntityFrameworkCore/Query/CouchbaseProjectionAliasesTests.cs
+++ b/tests/Couchbase.EntityFrameworkCore.UnitTests/Couchbase/EntityFrameworkCore/Query/CouchbaseProjectionAliasesTests.cs
@@ -59,6 +59,25 @@ public class CouchbaseProjectionAliasesTests
     }
 
     [Fact]
+    public void MakeUnique_CaseOnlyDuplicate_IsSuffixed()
+    {
+        // CouchbaseDbDataReader keys its alias->ordinal map with OrdinalIgnoreCase, so aliases
+        // differing only by case collide at read time. MakeUnique must treat them as duplicates;
+        // the base name's original casing is preserved in the suffix.
+        var result = CouchbaseProjectionAliases.MakeUnique(["rating", "Rating"]);
+        Assert.Equal(["rating", "Rating0"], result);
+    }
+
+    [Fact]
+    public void MakeUnique_CaseInsensitiveReservation_SkipsCaseOnlyLiteral()
+    {
+        // The duplicate "rating" must not take "RATING0" (a distinct literal that appears later but
+        // differs only by case) — it skips to "rating1".
+        var result = CouchbaseProjectionAliases.MakeUnique(["rating", "rating", "RATING0"]);
+        Assert.Equal(["rating", "rating1", "RATING0"], result);
+    }
+
+    [Fact]
     public void MakeUnique_FirstOccurrenceAlwaysVerbatim()
     {
         // Order is preserved and only later occurrences are renamed — never the first.

--- a/tests/Couchbase.EntityFrameworkCore.UnitTests/Couchbase/EntityFrameworkCore/Query/CouchbaseProjectionAliasesTests.cs
+++ b/tests/Couchbase.EntityFrameworkCore.UnitTests/Couchbase/EntityFrameworkCore/Query/CouchbaseProjectionAliasesTests.cs
@@ -96,9 +96,12 @@ public class CouchbaseProjectionAliasesTests
     public void MakeUnique_AllElementsDistinct()
     {
         // Whatever the input, the output must contain no duplicates (the core invariant the
-        // reader relies on for a 1:1 ordinal->key mapping).
+        // reader relies on for a 1:1 ordinal->key mapping). The input includes a case-only
+        // duplicate ("A") so the distinctness check must use the same OrdinalIgnoreCase
+        // semantics as CouchbaseDbDataReader's alias map — otherwise a case-only collision in
+        // the output would slip past a case-sensitive comparer.
         var result = CouchbaseProjectionAliases.MakeUnique(
-            ["a", "a", "b", "a", "b", "c", "a0"]);
-        Assert.Equal(result.Length, new HashSet<string>(result).Count);
+            ["a", "a", "b", "A", "b", "c", "a0"]);
+        Assert.Equal(result.Length, new HashSet<string>(result, StringComparer.OrdinalIgnoreCase).Count);
     }
 }

--- a/tests/Couchbase.EntityFrameworkCore.UnitTests/Couchbase/EntityFrameworkCore/Query/CouchbaseProjectionAliasesTests.cs
+++ b/tests/Couchbase.EntityFrameworkCore.UnitTests/Couchbase/EntityFrameworkCore/Query/CouchbaseProjectionAliasesTests.cs
@@ -1,0 +1,75 @@
+using Couchbase.EntityFrameworkCore.Query.Internal;
+using Xunit;
+
+namespace Couchbase.EntityFrameworkCore.UnitTests.Couchbase.EntityFrameworkCore.Query;
+
+/// <summary>
+/// Tests for <see cref="CouchbaseProjectionAliases.MakeUnique"/>, the alias-uniquification used
+/// to give each N1QL projection a distinct result-object key. Distinct keys are required because
+/// a N1QL row is a JSON object keyed by alias — two projections sharing a name (e.g. a collection
+/// Include where principal and dependent both expose <c>rating</c> / <c>blogId</c>) would collide
+/// on a single key and the reader would map two shaper ordinals to the same value.
+/// </summary>
+public class CouchbaseProjectionAliasesTests
+{
+    [Fact]
+    public void MakeUnique_NoDuplicates_ReturnsInputUnchanged()
+    {
+        var result = CouchbaseProjectionAliases.MakeUnique(["blogId", "ownerId", "rating", "url"]);
+        Assert.Equal(["blogId", "ownerId", "rating", "url"], result);
+    }
+
+    [Fact]
+    public void MakeUnique_SingleDuplicate_SuffixesSecondOccurrence()
+    {
+        // The collision case from the filtered-Include bug: Blog and Post both project
+        // blogId and rating. First occurrence kept; second suffixed.
+        var result = CouchbaseProjectionAliases.MakeUnique(
+            ["blogId", "ownerId", "rating", "url", "postId", "authorId", "blogId", "content", "rating", "title"]);
+
+        Assert.Equal(
+            ["blogId", "ownerId", "rating", "url", "postId", "authorId", "blogId0", "content", "rating0", "title"],
+            result);
+    }
+
+    [Fact]
+    public void MakeUnique_RepeatedDuplicates_IncrementSuffix()
+    {
+        var result = CouchbaseProjectionAliases.MakeUnique(["rating", "rating", "rating", "rating"]);
+        Assert.Equal(["rating", "rating0", "rating1", "rating2"], result);
+    }
+
+    [Fact]
+    public void MakeUnique_PreExistingSuffixedName_DoesNotCollide()
+    {
+        // "rating0" already present, so the suffixed form of the duplicate "rating" must skip it
+        // and pick the next free candidate.
+        var result = CouchbaseProjectionAliases.MakeUnique(["rating", "rating0", "rating"]);
+        Assert.Equal(["rating", "rating0", "rating1"], result);
+    }
+
+    [Fact]
+    public void MakeUnique_FirstOccurrenceAlwaysVerbatim()
+    {
+        // Order is preserved and only later occurrences are renamed — never the first.
+        var result = CouchbaseProjectionAliases.MakeUnique(["id", "name", "id"]);
+        Assert.Equal("id", result[0]);
+        Assert.Equal("id0", result[2]);
+    }
+
+    [Fact]
+    public void MakeUnique_EmptyInput_ReturnsEmpty()
+    {
+        Assert.Empty(CouchbaseProjectionAliases.MakeUnique([]));
+    }
+
+    [Fact]
+    public void MakeUnique_AllElementsDistinct()
+    {
+        // Whatever the input, the output must contain no duplicates (the core invariant the
+        // reader relies on for a 1:1 ordinal->key mapping).
+        var result = CouchbaseProjectionAliases.MakeUnique(
+            ["a", "a", "b", "a", "b", "c", "a0"]);
+        Assert.Equal(result.Length, new HashSet<string>(result).Count);
+    }
+}


### PR DESCRIPTION
…iases

A collection Include whose principal and dependent share property names (e.g. Blog and Post both expose blogId and rating) produced a top-level N1QL SELECT with two projections sharing the same alias. Because N1QL returns each row as a JSON object keyed by alias, the colliding keys made the dependent's column read the principal's value (a filtered post came back with the blog's rating), and VisitSelect's alias-dedup silently dropped the dependent's columns from the emitted SQL.

Make top-level projection aliases unique. Add CouchbaseProjectionAliases with EffectiveAlias() and ComputeUnique() (numeric suffix on collision), build projectionAliases from it in the shaped-query compiler, and emit AS <uniqueAlias> for colliding projections in the generator's top-level SELECT (only when the unique alias differs, so non-colliding queries stay byte-identical). Sub-query selects keep the old dedup since their column names are referenced by enclosing join/column expressions.

The N1QL WHERE predicate was already generated correctly — the original skip reason blaming predicate generation was a misdiagnosis. Un-skip Include_Posts_WithFilter_ReturnsOnlyMatchingPosts.