### PR TITLE
## Add RequestPlus scan-consistency option; stabilize eager-loading tests

### DIFF
--- a/src/Couchbase.EntityFrameworkCore/Infrastructure/CouchbaseDbContextOptionsBuilder.cs
+++ b/src/Couchbase.EntityFrameworkCore/Infrastructure/CouchbaseDbContextOptionsBuilder.cs
@@ -1,5 +1,6 @@
 using System.Text.Json;
 using Couchbase.EntityFrameworkCore.Extensions;
+using Couchbase.Query;
 using Microsoft.EntityFrameworkCore;
 
 namespace Couchbase.EntityFrameworkCore.Infrastructure;
@@ -37,6 +38,8 @@ public class CouchbaseDbContextOptionsBuilder : ICouchbaseDbContextOptionsBuilde
     public JsonNamingPolicy? FieldNamingPolicy { get; set; } = JsonNamingPolicy.CamelCase;
 
     public JsonSerializerOptions? SerializerOptions { get; set; }
+
+    public QueryScanConsistency ScanConsistency { get; set; } = QueryScanConsistency.NotBounded;
 
     DbContextOptionsBuilder ICouchbaseDbContextOptionsBuilder.OptionsBuilder => OptionsBuilder;
 }
@@ -81,6 +84,15 @@ public interface ICouchbaseDbContextOptionsBuilder
     /// (e.g. custom converters, different enum handling, or a different naming policy).
     /// </summary>
     public JsonSerializerOptions? SerializerOptions { get; set; }
+
+    /// <summary>
+    /// The N1QL scan consistency applied to generated queries. Defaults to
+    /// <see cref="QueryScanConsistency.NotBounded"/> (the SDK default — fastest, but may read a
+    /// not-yet-indexed mutation). Set to <see cref="QueryScanConsistency.RequestPlus"/> to make a
+    /// query wait until the index reflects all prior mutations — i.e. read-after-write
+    /// consistency — at the cost of higher latency.
+    /// </summary>
+    public QueryScanConsistency ScanConsistency { get; set; }
 }
 
 /* ************************************************************

--- a/src/Couchbase.EntityFrameworkCore/Infrastructure/CouchbaseDbContextOptionsBuilder.cs
+++ b/src/Couchbase.EntityFrameworkCore/Infrastructure/CouchbaseDbContextOptionsBuilder.cs
@@ -86,10 +86,12 @@ public interface ICouchbaseDbContextOptionsBuilder
     public JsonSerializerOptions? SerializerOptions { get; set; }
 
     /// <summary>
-    /// The N1QL scan consistency applied to generated queries. Defaults to
-    /// <see cref="QueryScanConsistency.NotBounded"/> (the SDK default — fastest, but may read a
-    /// not-yet-indexed mutation). Set to <see cref="QueryScanConsistency.RequestPlus"/> to make a
-    /// query wait until the index reflects all prior mutations — i.e. read-after-write
+    /// The N1QL scan consistency applied to the N1QL queries the provider executes — LINQ
+    /// queries, <c>FromSql</c> queries, and ADO.NET <see cref="System.Data.Common.DbCommand"/>
+    /// queries (does not affect schema/DDL operations such as scope/collection creation).
+    /// Defaults to <see cref="QueryScanConsistency.NotBounded"/> (the SDK default — fastest, but
+    /// may read a not-yet-indexed mutation). Set to <see cref="QueryScanConsistency.RequestPlus"/>
+    /// to make a query wait until the index reflects all prior mutations — i.e. read-after-write
     /// consistency — at the cost of higher latency.
     /// </summary>
     public QueryScanConsistency ScanConsistency { get; set; }

--- a/src/Couchbase.EntityFrameworkCore/Query/Internal/CouchbaseFromSqlQueryingEnumerable.cs
+++ b/src/Couchbase.EntityFrameworkCore/Query/Internal/CouchbaseFromSqlQueryingEnumerable.cs
@@ -114,6 +114,7 @@ public class CouchbaseFromSqlQueryingEnumerable<T> : IEnumerable<T>, IAsyncEnume
         logger.LogStatement(dbCommand, TimeSpan.Zero);
 #endif
         var queryOptions = GetParameters(dbCommand);
+        queryOptions.CancellationToken(cancellationToken);
 
         var bucket = await _bucketProvider.
             GetBucketAsync(_couchbaseDbContextOptionsBuilder.Bucket).
@@ -126,7 +127,7 @@ public class CouchbaseFromSqlQueryingEnumerable<T> : IEnumerable<T>, IAsyncEnume
         var model = _dbContext.Model;
         var entityType = model.FindEntityType(typeof(T));
 
-        await foreach (var doc in result)
+        await foreach (var doc in result.WithCancellation(cancellationToken).ConfigureAwait(false))
         {
             try
             {

--- a/src/Couchbase.EntityFrameworkCore/Query/Internal/CouchbaseFromSqlQueryingEnumerable.cs
+++ b/src/Couchbase.EntityFrameworkCore/Query/Internal/CouchbaseFromSqlQueryingEnumerable.cs
@@ -149,6 +149,7 @@ public class CouchbaseFromSqlQueryingEnumerable<T> : IEnumerable<T>, IAsyncEnume
     private QueryOptions GetParameters(DbCommand command)
     {
         var queryOptions = new QueryOptions();
+        queryOptions.ScanConsistency(_couchbaseDbContextOptionsBuilder.ScanConsistency);
         foreach (CouchbaseParameter parameter in command.Parameters)
         {
             queryOptions.Parameter(parameter.ParameterName, parameter.Value);

--- a/src/Couchbase.EntityFrameworkCore/Query/Internal/CouchbaseQueryEnumerable.cs
+++ b/src/Couchbase.EntityFrameworkCore/Query/Internal/CouchbaseQueryEnumerable.cs
@@ -280,6 +280,7 @@ public class CouchbaseQueryEnumerable<T> : IEnumerable<T>, IAsyncEnumerable<T>, 
     private QueryOptions GetParameters(DbCommand command)
     {
         var queryOptions = new QueryOptions();
+        queryOptions.ScanConsistency(_couchbaseDbContextOptionsBuilder.ScanConsistency);
         foreach (CouchbaseParameter parameter in command.Parameters)
         {
             queryOptions.Parameter(parameter.ParameterName, parameter.Value);

--- a/src/Couchbase.EntityFrameworkCore/Storage/Internal/CouchbaseCommand.cs
+++ b/src/Couchbase.EntityFrameworkCore/Storage/Internal/CouchbaseCommand.cs
@@ -16,6 +16,11 @@ public class CouchbaseCommand : DbCommand
 
     internal ICluster? Cluster { get; set; }
 
+    // N1QL scan consistency for queries executed through this command (ExecuteReader/Scalar/
+    // NonQuery). Set from the configured option by CouchbaseConnection.CreateDbCommand;
+    // defaults to NotBounded to match the SDK default.
+    internal QueryScanConsistency ScanConsistency { get; set; } = QueryScanConsistency.NotBounded;
+
     public override string CommandText
     {
         get => _commandText;
@@ -247,6 +252,7 @@ public class CouchbaseCommand : DbCommand
     private QueryOptions BuildQueryOptions(CancellationToken cancellationToken)
     {
         var options = new QueryOptions().CancellationToken(cancellationToken);
+        options.ScanConsistency(ScanConsistency);
 
         if (CommandTimeout > 0)
         {

--- a/src/Couchbase.EntityFrameworkCore/Storage/Internal/CouchbaseConnection.cs
+++ b/src/Couchbase.EntityFrameworkCore/Storage/Internal/CouchbaseConnection.cs
@@ -187,7 +187,8 @@ public class CouchbaseConnection : DbConnection
         return new CouchbaseCommand
         {
             Connection = this,
-            Cluster = _cluster!
+            Cluster = _cluster!,
+            ScanConsistency = _couchbaseDbContextOptionsBuilder.ScanConsistency
         };
     }
 

--- a/tests/Couchbase.EntityFrameworkCore.IntegrationTests/Fixtures/CouchbaseFixture.cs
+++ b/tests/Couchbase.EntityFrameworkCore.IntegrationTests/Fixtures/CouchbaseFixture.cs
@@ -45,6 +45,10 @@ public abstract class CouchbaseFixture<T> : IDisposable, IAsyncDisposable, IAsyn
             {
                 couchbaseDbContextOptions.Bucket = BucketName;
                 couchbaseDbContextOptions.Scope = ScopeName;
+                // Read-after-write consistency: tests seed via KV then immediately query through
+                // the N1QL index, so wait for the index to reflect prior mutations. Avoids
+                // intermittent stale reads under the default NotBounded scan consistency.
+                couchbaseDbContextOptions.ScanConsistency = global::Couchbase.Query.QueryScanConsistency.RequestPlus;
             });
         optionsBuilder.UseCamelCaseNamingConvention();
 

--- a/tests/Couchbase.EntityFrameworkCore.IntegrationTests/Tests/CouchbaseCommandTests.cs
+++ b/tests/Couchbase.EntityFrameworkCore.IntegrationTests/Tests/CouchbaseCommandTests.cs
@@ -2,6 +2,7 @@ using System.Data;
 using System.Text.Json;
 using Couchbase.EntityFrameworkCode.IntegrationTests.Fixtures;
 using Couchbase.EntityFrameworkCore.Storage.Internal;
+using Couchbase.Query;
 using Microsoft.EntityFrameworkCore;
 using Xunit.Abstractions;
 
@@ -23,6 +24,21 @@ public class CouchbaseCommandTests(
 
         Assert.NotNull(command);
         Assert.IsType<CouchbaseCommand>(command);
+    }
+
+    [Fact]
+    public async Task CreateCommand_AppliesConfiguredScanConsistency()
+    {
+        // The integration fixture configures RequestPlus. Proves the option is threaded from
+        // CouchbaseDbContextOptionsBuilder through CouchbaseConnection.CreateDbCommand onto the
+        // ADO.NET command, so DbCommand-based queries (ExecuteReader/Scalar/NonQuery) honor it.
+        await using var context = bloggingFixture.GetDbContext();
+        var connection = context.Database.GetDbConnection();
+        await connection.OpenAsync();
+
+        using var command = (CouchbaseCommand)connection.CreateCommand();
+
+        Assert.Equal(QueryScanConsistency.RequestPlus, command.ScanConsistency);
     }
 
     [Fact]

--- a/tests/Couchbase.EntityFrameworkCore.IntegrationTests/Tests/EagerLoadingTests.cs
+++ b/tests/Couchbase.EntityFrameworkCore.IntegrationTests/Tests/EagerLoadingTests.cs
@@ -70,16 +70,30 @@ public class EagerLoadingTests(BloggingFixture fixture) : IAsyncLifetime
 
     // Poll the index a few times until Post 1's two DirectTags are visible. No-op in practice
     // when scan consistency is RequestPlus; protects the read tests if it is ever relaxed.
+    // Throws if the seed never becomes visible so the failure is reported here — with an
+    // actionable message — rather than as an opaque assertion failure inside a later test.
     private async Task WaitForSeedAsync()
     {
-        for (var attempt = 0; attempt < 10; attempt++)
+        const int maxAttempts = 10;
+        const int delayMs = 100;
+        for (var attempt = 0; attempt < maxAttempts; attempt++)
         {
-            await using var ctx = fixture.GetDbContext();
-            var post1 = await ctx.Posts.Include(p => p.DirectTags).FirstOrDefaultAsync(p => p.PostId == 1);
-            if (post1 is { DirectTags.Count: 2 })
+            // Dispose the context before delaying so we don't hold a connection open while waiting.
+            int directTagCount;
+            await using (var ctx = fixture.GetDbContext())
+            {
+                var post1 = await ctx.Posts.Include(p => p.DirectTags).FirstOrDefaultAsync(p => p.PostId == 1);
+                directTagCount = post1?.DirectTags.Count ?? -1;
+            }
+            if (directTagCount == 2)
                 return;
-            await Task.Delay(100);
+            await Task.Delay(delayMs);
         }
+
+        throw new TimeoutException(
+            $"EagerLoadingTests seed did not become visible after {maxAttempts} attempts " +
+            $"({maxAttempts * delayMs}ms): Post 1 was expected to have 2 DirectTags. " +
+            "The N1QL index may be lagging behind the seed writes, or the seed failed.");
     }
 
     public Task DisposeAsync() => Task.CompletedTask;

--- a/tests/Couchbase.EntityFrameworkCore.IntegrationTests/Tests/EagerLoadingTests.cs
+++ b/tests/Couchbase.EntityFrameworkCore.IntegrationTests/Tests/EagerLoadingTests.cs
@@ -17,54 +17,58 @@ public class EagerLoadingTests(BloggingFixture fixture) : IAsyncLifetime
     // cause these read-only queries to return empty result sets.
     public async Task InitializeAsync()
     {
-        await using var ctx = fixture.GetDbContext();
-        ctx.Update(new BloggingFixture.Blog { BlogId = 1, Url = "https://devblogs.microsoft.com/dotnet", Rating = 5, OwnerId = 1 });
-        ctx.Update(new BloggingFixture.Blog { BlogId = 2, Url = "https://mytravelblog.com/", Rating = 4, OwnerId = 3 });
-        ctx.Update(new BloggingFixture.Post { PostId = 1, BlogId = 1, Title = "What's new", Content = "Lorem ipsum dolor sit amet", Rating = 5, AuthorId = 1 });
-        ctx.Update(new BloggingFixture.Post { PostId = 2, BlogId = 2, Title = "Around the World in Eighty Days", Content = "consectetur adipiscing elit", Rating = 5, AuthorId = 2 });
-        ctx.Update(new BloggingFixture.Post { PostId = 3, BlogId = 2, Title = "Glamping *is* the way", Content = "sed do eiusmod tempor incididunt", Rating = 4, AuthorId = 3 });
-        ctx.Update(new BloggingFixture.Post { PostId = 4, BlogId = 2, Title = "Travel in the time of pandemic", Content = "ut labore et dolore magna aliqua", Rating = 3, AuthorId = 3 });
-        ctx.Update(new BloggingFixture.Person { PersonId = 1, Name = "Dotnet Blog Admin", PhotoId = 1 });
-        ctx.Update(new BloggingFixture.Person { PersonId = 2, Name = "Phileas Fogg", PhotoId = 2 });
-        ctx.Update(new BloggingFixture.Person { PersonId = 3, Name = "Jane Doe", PhotoId = 3 });
-        ctx.Update(new BloggingFixture.PersonPhoto { PersonPhotoId = 1, Caption = "SN", Photo = [0x00, 0x01] });
-        ctx.Update(new BloggingFixture.PersonPhoto { PersonPhotoId = 2, Caption = "PF", Photo = [0x01, 0x02, 0x03] });
-        ctx.Update(new BloggingFixture.PersonPhoto { PersonPhotoId = 3, Caption = "JD", Photo = [0x01, 0x01, 0x01] });
-        ctx.Update(new BloggingFixture.Tag { TagId = "general" });
-        ctx.Update(new BloggingFixture.Tag { TagId = "classic" });
-        ctx.Update(new BloggingFixture.Tag { TagId = "opinion" });
-        ctx.Update(new BloggingFixture.Tag { TagId = "informative" });
-        ctx.Update(new BloggingFixture.PostTag { PostTagId = 1, PostId = 1, TagId = "general" });
-        ctx.Update(new BloggingFixture.PostTag { PostTagId = 2, PostId = 1, TagId = "informative" });
-        ctx.Update(new BloggingFixture.PostTag { PostTagId = 3, PostId = 2, TagId = "classic" });
-        ctx.Update(new BloggingFixture.PostTag { PostTagId = 4, PostId = 3, TagId = "opinion" });
-        ctx.Update(new BloggingFixture.PostTag { PostTagId = 5, PostId = 4, TagId = "opinion" });
-        ctx.Update(new BloggingFixture.PostTag { PostTagId = 6, PostId = 4, TagId = "informative" });
-        await ctx.SaveChangesAsync();
+        // Scope the seeding context so it is disposed before the warm-up poll below — otherwise
+        // it would stay open (holding a cluster connection) while WaitForSeedAsync opens its own.
+        await using (var ctx = fixture.GetDbContext())
+        {
+            ctx.Update(new BloggingFixture.Blog { BlogId = 1, Url = "https://devblogs.microsoft.com/dotnet", Rating = 5, OwnerId = 1 });
+            ctx.Update(new BloggingFixture.Blog { BlogId = 2, Url = "https://mytravelblog.com/", Rating = 4, OwnerId = 3 });
+            ctx.Update(new BloggingFixture.Post { PostId = 1, BlogId = 1, Title = "What's new", Content = "Lorem ipsum dolor sit amet", Rating = 5, AuthorId = 1 });
+            ctx.Update(new BloggingFixture.Post { PostId = 2, BlogId = 2, Title = "Around the World in Eighty Days", Content = "consectetur adipiscing elit", Rating = 5, AuthorId = 2 });
+            ctx.Update(new BloggingFixture.Post { PostId = 3, BlogId = 2, Title = "Glamping *is* the way", Content = "sed do eiusmod tempor incididunt", Rating = 4, AuthorId = 3 });
+            ctx.Update(new BloggingFixture.Post { PostId = 4, BlogId = 2, Title = "Travel in the time of pandemic", Content = "ut labore et dolore magna aliqua", Rating = 3, AuthorId = 3 });
+            ctx.Update(new BloggingFixture.Person { PersonId = 1, Name = "Dotnet Blog Admin", PhotoId = 1 });
+            ctx.Update(new BloggingFixture.Person { PersonId = 2, Name = "Phileas Fogg", PhotoId = 2 });
+            ctx.Update(new BloggingFixture.Person { PersonId = 3, Name = "Jane Doe", PhotoId = 3 });
+            ctx.Update(new BloggingFixture.PersonPhoto { PersonPhotoId = 1, Caption = "SN", Photo = [0x00, 0x01] });
+            ctx.Update(new BloggingFixture.PersonPhoto { PersonPhotoId = 2, Caption = "PF", Photo = [0x01, 0x02, 0x03] });
+            ctx.Update(new BloggingFixture.PersonPhoto { PersonPhotoId = 3, Caption = "JD", Photo = [0x01, 0x01, 0x01] });
+            ctx.Update(new BloggingFixture.Tag { TagId = "general" });
+            ctx.Update(new BloggingFixture.Tag { TagId = "classic" });
+            ctx.Update(new BloggingFixture.Tag { TagId = "opinion" });
+            ctx.Update(new BloggingFixture.Tag { TagId = "informative" });
+            ctx.Update(new BloggingFixture.PostTag { PostTagId = 1, PostId = 1, TagId = "general" });
+            ctx.Update(new BloggingFixture.PostTag { PostTagId = 2, PostId = 1, TagId = "informative" });
+            ctx.Update(new BloggingFixture.PostTag { PostTagId = 3, PostId = 2, TagId = "classic" });
+            ctx.Update(new BloggingFixture.PostTag { PostTagId = 4, PostId = 3, TagId = "opinion" });
+            ctx.Update(new BloggingFixture.PostTag { PostTagId = 5, PostId = 4, TagId = "opinion" });
+            ctx.Update(new BloggingFixture.PostTag { PostTagId = 6, PostId = 4, TagId = "informative" });
+            await ctx.SaveChangesAsync();
 
-        // Seed skip-navigation join table data for Posts 1 and 4 only.
-        // Posts 2 and 3 intentionally have no DirectTags (exercises the empty-collection path).
-        // Load with Include so Clear() can remove existing join entries (idempotent reseed).
-        // Post 3 is reset to empty too: SkipNav_AddRelationship_WritesJoinDocumentWithCorrectKey
-        // adds a tag to it, so without this reset its precondition would fail on the next run.
-        var post1 = await ctx.Posts.Include(p => p.DirectTags).FirstAsync(p => p.PostId == 1);
-        var post3 = await ctx.Posts.Include(p => p.DirectTags).FirstAsync(p => p.PostId == 3);
-        var post4 = await ctx.Posts.Include(p => p.DirectTags).FirstAsync(p => p.PostId == 4);
-        var tagGeneral     = await ctx.Set<BloggingFixture.Tag>().FindAsync("general");
-        var tagInformative = await ctx.Set<BloggingFixture.Tag>().FindAsync("informative");
-        var tagOpinion     = await ctx.Set<BloggingFixture.Tag>().FindAsync("opinion");
-        post1.DirectTags.Clear();
-        post1.DirectTags.Add(tagGeneral!);
-        post1.DirectTags.Add(tagInformative!);
-        post3.DirectTags.Clear();
-        post4.DirectTags.Clear();
-        post4.DirectTags.Add(tagOpinion!);
-        post4.DirectTags.Add(tagInformative!);
-        await ctx.SaveChangesAsync();
+            // Seed skip-navigation join table data for Posts 1 and 4 only.
+            // Posts 2 and 3 intentionally have no DirectTags (exercises the empty-collection path).
+            // Load with Include so Clear() can remove existing join entries (idempotent reseed).
+            // Post 3 is reset to empty too: SkipNav_AddRelationship_WritesJoinDocumentWithCorrectKey
+            // adds a tag to it, so without this reset its precondition would fail on the next run.
+            var post1 = await ctx.Posts.Include(p => p.DirectTags).FirstAsync(p => p.PostId == 1);
+            var post3 = await ctx.Posts.Include(p => p.DirectTags).FirstAsync(p => p.PostId == 3);
+            var post4 = await ctx.Posts.Include(p => p.DirectTags).FirstAsync(p => p.PostId == 4);
+            var tagGeneral     = await ctx.Set<BloggingFixture.Tag>().FindAsync("general");
+            var tagInformative = await ctx.Set<BloggingFixture.Tag>().FindAsync("informative");
+            var tagOpinion     = await ctx.Set<BloggingFixture.Tag>().FindAsync("opinion");
+            post1.DirectTags.Clear();
+            post1.DirectTags.Add(tagGeneral!);
+            post1.DirectTags.Add(tagInformative!);
+            post3.DirectTags.Clear();
+            post4.DirectTags.Clear();
+            post4.DirectTags.Add(tagOpinion!);
+            post4.DirectTags.Add(tagInformative!);
+            await ctx.SaveChangesAsync();
+        }
 
         // Warm-up: with RequestPlus this is already consistent, but as a belt-and-suspenders
         // guard against index lag, poll until the canonical seed for Post 1 is observable before
-        // the test body runs.
+        // the test body runs. The seeding context above is disposed before we get here.
         await WaitForSeedAsync();
     }
 

--- a/tests/Couchbase.EntityFrameworkCore.IntegrationTests/Tests/EagerLoadingTests.cs
+++ b/tests/Couchbase.EntityFrameworkCore.IntegrationTests/Tests/EagerLoadingTests.cs
@@ -45,7 +45,10 @@ public class EagerLoadingTests(BloggingFixture fixture) : IAsyncLifetime
         // Seed skip-navigation join table data for Posts 1 and 4 only.
         // Posts 2 and 3 intentionally have no DirectTags (exercises the empty-collection path).
         // Load with Include so Clear() can remove existing join entries (idempotent reseed).
+        // Post 3 is reset to empty too: SkipNav_AddRelationship_WritesJoinDocumentWithCorrectKey
+        // adds a tag to it, so without this reset its precondition would fail on the next run.
         var post1 = await ctx.Posts.Include(p => p.DirectTags).FirstAsync(p => p.PostId == 1);
+        var post3 = await ctx.Posts.Include(p => p.DirectTags).FirstAsync(p => p.PostId == 3);
         var post4 = await ctx.Posts.Include(p => p.DirectTags).FirstAsync(p => p.PostId == 4);
         var tagGeneral     = await ctx.Set<BloggingFixture.Tag>().FindAsync("general");
         var tagInformative = await ctx.Set<BloggingFixture.Tag>().FindAsync("informative");
@@ -53,10 +56,30 @@ public class EagerLoadingTests(BloggingFixture fixture) : IAsyncLifetime
         post1.DirectTags.Clear();
         post1.DirectTags.Add(tagGeneral!);
         post1.DirectTags.Add(tagInformative!);
+        post3.DirectTags.Clear();
         post4.DirectTags.Clear();
         post4.DirectTags.Add(tagOpinion!);
         post4.DirectTags.Add(tagInformative!);
         await ctx.SaveChangesAsync();
+
+        // Warm-up: with RequestPlus this is already consistent, but as a belt-and-suspenders
+        // guard against index lag, poll until the canonical seed for Post 1 is observable before
+        // the test body runs.
+        await WaitForSeedAsync();
+    }
+
+    // Poll the index a few times until Post 1's two DirectTags are visible. No-op in practice
+    // when scan consistency is RequestPlus; protects the read tests if it is ever relaxed.
+    private async Task WaitForSeedAsync()
+    {
+        for (var attempt = 0; attempt < 10; attempt++)
+        {
+            await using var ctx = fixture.GetDbContext();
+            var post1 = await ctx.Posts.Include(p => p.DirectTags).FirstOrDefaultAsync(p => p.PostId == 1);
+            if (post1 is { DirectTags.Count: 2 })
+                return;
+            await Task.Delay(100);
+        }
     }
 
     public Task DisposeAsync() => Task.CompletedTask;

--- a/tests/Couchbase.EntityFrameworkCore.UnitTests/Couchbase/EntityFrameworkCore/Infrastructure/CouchbaseDbContextOptionsBuilderTests.cs
+++ b/tests/Couchbase.EntityFrameworkCore.UnitTests/Couchbase/EntityFrameworkCore/Infrastructure/CouchbaseDbContextOptionsBuilderTests.cs
@@ -1,4 +1,5 @@
 using Couchbase.EntityFrameworkCore.Infrastructure;
+using Couchbase.Query;
 using Microsoft.EntityFrameworkCore;
 using Xunit;
 
@@ -48,6 +49,50 @@ public class CouchbaseDbContextOptionsBuilderTests
 
         // Assert
         Assert.True(builder.AutoCreateScopes);
+    }
+
+    [Fact]
+    public void ScanConsistency_DefaultsToNotBounded()
+    {
+        // Arrange
+        var dbContextOptionsBuilder = new DbContextOptionsBuilder();
+        var clusterOptions = new ClusterOptions().WithConnectionString("couchbase://localhost");
+
+        // Act
+        var builder = new CouchbaseDbContextOptionsBuilder(dbContextOptionsBuilder, clusterOptions);
+
+        // Assert — preserves the SDK default; opt-in to RequestPlus only when needed.
+        Assert.Equal(QueryScanConsistency.NotBounded, builder.ScanConsistency);
+    }
+
+    [Fact]
+    public void ScanConsistency_CanBeSetToRequestPlus()
+    {
+        // Arrange
+        var dbContextOptionsBuilder = new DbContextOptionsBuilder();
+        var clusterOptions = new ClusterOptions().WithConnectionString("couchbase://localhost");
+        var builder = new CouchbaseDbContextOptionsBuilder(dbContextOptionsBuilder, clusterOptions);
+
+        // Act
+        builder.ScanConsistency = QueryScanConsistency.RequestPlus;
+
+        // Assert
+        Assert.Equal(QueryScanConsistency.RequestPlus, builder.ScanConsistency);
+    }
+
+    [Fact]
+    public void ScanConsistency_CanBeSetViaInterface()
+    {
+        // Arrange
+        var dbContextOptionsBuilder = new DbContextOptionsBuilder();
+        var clusterOptions = new ClusterOptions().WithConnectionString("couchbase://localhost");
+        ICouchbaseDbContextOptionsBuilder builder = new CouchbaseDbContextOptionsBuilder(dbContextOptionsBuilder, clusterOptions);
+
+        // Act
+        builder.ScanConsistency = QueryScanConsistency.RequestPlus;
+
+        // Assert
+        Assert.Equal(QueryScanConsistency.RequestPlus, builder.ScanConsistency);
     }
 
     [Fact]

--- a/tests/Couchbase.EntityFrameworkCore.UnitTests/Couchbase/EntityFrameworkCore/Storage/Internal/CouchbaseCommandTests.cs
+++ b/tests/Couchbase.EntityFrameworkCore.UnitTests/Couchbase/EntityFrameworkCore/Storage/Internal/CouchbaseCommandTests.cs
@@ -49,6 +49,23 @@ public class CouchbaseCommandTests
     }
 
     [Fact]
+    public void ScanConsistency_DefaultsToNotBounded()
+    {
+        var command = new CouchbaseCommand();
+
+        // Preserves the SDK default so behavior is unchanged unless explicitly configured.
+        Assert.Equal(QueryScanConsistency.NotBounded, command.ScanConsistency);
+    }
+
+    [Fact]
+    public void ScanConsistency_CanBeSet()
+    {
+        var command = new CouchbaseCommand { ScanConsistency = QueryScanConsistency.RequestPlus };
+
+        Assert.Equal(QueryScanConsistency.RequestPlus, command.ScanConsistency);
+    }
+
+    [Fact]
     public void CommandText_SetNull_ReturnsEmptyString()
     {
         var command = new CouchbaseCommand();


### PR DESCRIPTION
Couchbase N1QL queries read an eventually-consistent index, but the
provider always used the SDK default `NotBounded` scan consistency — so a
query could miss a just-committed write. This caused intermittent
`EagerLoadingTests` failures and left users no way to opt into stronger
consistency.

### Changes

- **New option:** `CouchbaseDbContextOptionsBuilder.ScanConsistency`
  (and on `ICouchbaseDbContextOptionsBuilder`), defaulting to
  `NotBounded` so existing behavior is unchanged. Applied in both
  `CouchbaseQueryEnumerable` and `CouchbaseFromSqlQueryingEnumerable`.
  Set `RequestPlus` for read-after-write consistency.
- **Bug fix:** `CouchbaseFromSqlQueryingEnumerable` ignored its
  `CancellationToken`; now propagated to the query options and the
  result enumeration.
- **Tests:** fixture enables `RequestPlus`; `EagerLoadingTests` seed is
  made deterministic with a warm-up poll that throws on timeout and
  disposes its context between waits; new unit tests cover the option's
  default and that it is settable via the interface.

### Compatibility

Additive change to `ICouchbaseDbContextOptionsBuilder`. The interface is
only implemented by the provider's own type and this is `2.0.0-pre`, so
the addition is acceptable; the `NotBounded` default preserves runtime
behavior.

### Testing

Unit and live integration suites green; `EagerLoadingTests` now passes
across repeated runs.