### PR TITLE
Support Include/OfType and owned types on TPH derived types

### DIFF
--- a/src/Couchbase.EntityFrameworkCore/Query/Internal/CouchbaseQueryEnumerable.cs
+++ b/src/Couchbase.EntityFrameworkCore/Query/Internal/CouchbaseQueryEnumerable.cs
@@ -71,6 +71,7 @@ public class CouchbaseQueryEnumerable<T> : IEnumerable<T>, IAsyncEnumerable<T>, 
     private readonly IBucketProvider _bucketProvider;
     private readonly DbContext _dbContext;
     private readonly IReadOnlyList<INavigation> _ownedCollectionNavigations;
+    private readonly bool _ownedCollectionsSpanInheritance;
     private readonly CouchbaseOwnedCollectionMaterializer _materializer = new();
     private readonly CouchbaseCollectionSnapshot _snapshot = new();
 
@@ -106,10 +107,42 @@ public class CouchbaseQueryEnumerable<T> : IEnumerable<T>, IAsyncEnumerable<T>, 
         // Select(c => c.Name) where T = string, or anonymous projections such as Select(c => new { c.Name })).
         // In both cases _ownedCollectionNavigations is empty and OwnsMany population is skipped.
         var ownerEntityType = relationalQueryContext.Context.Model.FindEntityType(typeof(T));
+        // Include OwnsMany navigations declared on derived types (TPH): a base-type query
+        // (T = Person) must still populate owned collections on the Student rows it returns.
+        // GetNavigations() on the queried type covers inherited + own; GetDeclaredNavigations()
+        // on each strict descendant adds the navigations introduced lower in the hierarchy.
         _ownedCollectionNavigations = ownerEntityType == null ? [] :
             ownerEntityType.GetNavigations()
+                .Concat(ownerEntityType.GetDerivedTypes().SelectMany(t => t.GetDeclaredNavigations()))
                 .Where(n => n.IsCollection && n.TargetEntityType.IsOwned())
                 .ToArray();
+        // Per-row filtering is only needed when an owned collection is declared on a STRICT
+        // DESCENDANT of the queried type — those navigations apply to a subset of the rows.
+        // Navigations declared on the queried type or an ancestor (inherited via GetNavigations)
+        // apply to every row, so a derived-type query (T = Student) stays a zero-cost
+        // pass-through. Test with IsAssignableFrom against the queried type's CLR type.
+        _ownedCollectionsSpanInheritance = ownerEntityType != null &&
+            _ownedCollectionNavigations.Any(
+                n => !n.DeclaringEntityType.ClrType.IsAssignableFrom(ownerEntityType.ClrType));
+    }
+
+    /// <summary>
+    /// Returns the subset of <see cref="_ownedCollectionNavigations"/> whose declaring entity
+    /// type is assignable from <paramref name="entity"/>'s runtime type. For non-inheritance
+    /// queries this returns the full list unchanged.
+    /// </summary>
+    private IReadOnlyList<INavigation> ApplicableOwnedCollections(object? entity)
+    {
+        if (!_ownedCollectionsSpanInheritance || entity is null)
+            return _ownedCollectionNavigations;
+
+        var applicable = new List<INavigation>(_ownedCollectionNavigations.Count);
+        foreach (var nav in _ownedCollectionNavigations)
+        {
+            if (nav.DeclaringEntityType.ClrType.IsInstanceOfType(entity))
+                applicable.Add(nav);
+        }
+        return applicable;
     }
 
     /// <summary>Returns an enumerator that iterates through the collection.</summary>
@@ -192,8 +225,12 @@ public class CouchbaseQueryEnumerable<T> : IEnumerable<T>, IAsyncEnumerable<T>, 
                     && navRow is JsonElement rowElement
                     && rowElement.ValueKind == JsonValueKind.Object)
                 {
-                    _materializer.Populate(result, rowElement, _ownedCollectionNavigations, _couchbaseDbContextOptionsBuilder.FieldNamingPolicy, _couchbaseDbContextOptionsBuilder.SerializerOptions);
-                    _snapshot.Record(result, _ownedCollectionNavigations, _isTracking);
+                    var applicable = ApplicableOwnedCollections(result);
+                    if (applicable.Count > 0)
+                    {
+                        _materializer.Populate(result, rowElement, applicable, _couchbaseDbContextOptionsBuilder.FieldNamingPolicy, _couchbaseDbContextOptionsBuilder.SerializerOptions);
+                        _snapshot.Record(result, applicable, _isTracking);
+                    }
                 }
                 pendingEntityRow = null;
                 yield return result;
@@ -224,8 +261,12 @@ public class CouchbaseQueryEnumerable<T> : IEnumerable<T>, IAsyncEnumerable<T>, 
                         && pendingEntityRow is JsonElement lastRow
                         && lastRow.ValueKind == JsonValueKind.Object)
                     {
-                        _materializer.Populate(last, lastRow, _ownedCollectionNavigations, _couchbaseDbContextOptionsBuilder.FieldNamingPolicy, _couchbaseDbContextOptionsBuilder.SerializerOptions);
-                        _snapshot.Record(last, _ownedCollectionNavigations, _isTracking);
+                        var applicable = ApplicableOwnedCollections(last);
+                        if (applicable.Count > 0)
+                        {
+                            _materializer.Populate(last, lastRow, applicable, _couchbaseDbContextOptionsBuilder.FieldNamingPolicy, _couchbaseDbContextOptionsBuilder.SerializerOptions);
+                            _snapshot.Record(last, applicable, _isTracking);
+                        }
                     }
                     pendingEntityRow = null;
                     yield return last;

--- a/src/Couchbase.EntityFrameworkCore/Query/Internal/CouchbaseShapedQueryCompilingExpressionVisitor.cs
+++ b/src/Couchbase.EntityFrameworkCore/Query/Internal/CouchbaseShapedQueryCompilingExpressionVisitor.cs
@@ -328,7 +328,12 @@ public class CouchbaseShapedQueryCompilingExpressionVisitor : RelationalShapedQu
 
         if (ownerTable == null) return;
 
+        // Include OwnsMany navigations declared on derived types (TPH): when the base type is
+        // queried, the derived rows' owned-collection field must still be projected so it lands
+        // in the result JSON for CouchbaseQueryEnumerable to materialise. Derived types share the
+        // owner's table, so the column reference against ownerTable is valid (null for base rows).
         var ownedCollNavs = entityType.GetNavigations()
+            .Concat(entityType.GetDerivedTypes().SelectMany(t => t.GetDeclaredNavigations()))
             .Where(n => n.IsCollection && n.TargetEntityType.IsOwned())
             .ToList();
         if (ownedCollNavs.Count == 0) return;

--- a/src/Couchbase.EntityFrameworkCore/Storage/Internal/CouchbaseDatabaseWrapper.cs
+++ b/src/Couchbase.EntityFrameworkCore/Storage/Internal/CouchbaseDatabaseWrapper.cs
@@ -250,6 +250,11 @@ public class CouchbaseDatabaseWrapper : Database
     {
         var entityType = updateEntry.EntityType;
 
+        // For TPH inheritance the discriminator is a shadow property by default. It must
+        // still be persisted so the query path (e.g. OfType<TDerived>() / Include on a
+        // derived navigation) can filter documents to the correct CLR type.
+        var discriminator = entityType.FindDiscriminatorProperty();
+
         var ownedNavs = entityType.GetNavigations()
             .Where(n => n.TargetEntityType.IsOwned() && n.PropertyInfo != null)
             .ToList();
@@ -288,7 +293,7 @@ public class CouchbaseDatabaseWrapper : Database
             var regularDoc = new Dictionary<string, object?>();
             foreach (var property in entityType.GetProperties())
             {
-                if (property.IsShadowProperty()) continue;
+                if (property.IsShadowProperty() && property != discriminator) continue;
                 var rawValue = updateEntry.GetCurrentValue(property);
                 regularDoc[property.GetColumnName()] = ApplyConverter(property, rawValue);
             }
@@ -314,7 +319,7 @@ public class CouchbaseDatabaseWrapper : Database
         var doc = new Dictionary<string, object?>();
         foreach (var property in entityType.GetProperties())
         {
-            if (property.IsShadowProperty()) continue;
+            if (property.IsShadowProperty() && property != discriminator) continue;
             var rawDocValue = updateEntry.GetCurrentValue(property);
             doc[property.GetColumnName()] = ApplyConverter(property, rawDocValue);
         }

--- a/tests/Couchbase.EntityFrameworkCore.IntegrationTests/Fixtures/BloggingFixture.cs
+++ b/tests/Couchbase.EntityFrameworkCore.IntegrationTests/Fixtures/BloggingFixture.cs
@@ -100,7 +100,56 @@ public class BloggingFixture : CouchbaseFixture<BloggingDbContext>
                 {
                     PersonPhotoId = 3, Caption = "JD",
                     Photo = new byte[] { 0x01, 0x01, 0x01 }
+                },
+                new PersonPhoto
+                {
+                    PersonPhotoId = 4, Caption = "SS",
+                    Photo = new byte[] { 0x02, 0x02 }
+                },
+                new PersonPhoto
+                {
+                    PersonPhotoId = 5, Caption = "TT",
+                    Photo = new byte[] { 0x03, 0x03 }
                 }
+            };
+
+            var districts = new List<District>
+            {
+                new District { DistrictId = 1, Name = "Metro District" }
+            };
+
+            var schools = new List<School>
+            {
+                new School { SchoolId = 1, Name = "Couchbase University", DistrictId = 1 }
+            };
+
+            // Student and Teacher are derived types (TPH) stored in the "person" collection.
+            var students = new List<Student>
+            {
+                new Student
+                {
+                    PersonId = 4, Name = "Sam Student", PhotoId = 4, SchoolId = 1,
+                    Address = new StudentAddress { Street = "1 Database Way", City = "Mountain View" },
+                    Contacts =
+                    [
+                        new StudentContact { Id = 1, Kind = "email", Value = "sam@university.edu" },
+                        new StudentContact { Id = 2, Kind = "phone", Value = "555-0100" }
+                    ]
+                }
+            };
+
+            var teachers = new List<Teacher>
+            {
+                new Teacher
+                {
+                    PersonId = 5, Name = "Tina Teacher", PhotoId = 5, Subject = "Databases"
+                }
+            };
+
+            var enrollments = new List<Enrollment>
+            {
+                new Enrollment { EnrollmentId = 1, StudentId = 4, Title = "Distributed Systems" },
+                new Enrollment { EnrollmentId = 2, StudentId = 4, Title = "Query Optimization" }
             };
 
             var tags = new List<Tag>
@@ -126,6 +175,11 @@ public class BloggingFixture : CouchbaseFixture<BloggingDbContext>
             dbContext.UpdateRange(posts);
             dbContext.UpdateRange(persons);
             dbContext.UpdateRange(personPhotos);
+            dbContext.UpdateRange(districts);
+            dbContext.UpdateRange(schools);
+            dbContext.UpdateRange(students);
+            dbContext.UpdateRange(teachers);
+            dbContext.UpdateRange(enrollments);
             dbContext.UpdateRange(tags);
             dbContext.UpdateRange(postTags);
 
@@ -182,6 +236,77 @@ public class BloggingFixture : CouchbaseFixture<BloggingDbContext>
         public byte[] Photo { get; set; }
 
         public Person Person { get; set; }
+    }
+
+    /// <summary>Derived type for TPH inheritance — shares the "person" collection
+    /// with <see cref="Person"/>. Adds navigations (<see cref="School"/> reference,
+    /// <see cref="Enrollments"/> collection) that only exist on the derived type.</summary>
+    public class Student : Person
+    {
+        public int SchoolId { get; set; }
+        public School School { get; set; }
+
+        /// <summary>Collection navigation declared only on the derived type.</summary>
+        public ICollection<Enrollment> Enrollments { get; set; } = [];
+
+        /// <summary>Owned reference type embedded in the (shared) Student document.</summary>
+        public StudentAddress Address { get; set; }
+
+        /// <summary>Owned collection embedded in the (shared) Student document.</summary>
+        public List<StudentContact> Contacts { get; set; } = [];
+    }
+
+    /// <summary>Owned (OwnsOne) type on the derived <see cref="Student"/>.</summary>
+    public class StudentAddress
+    {
+        public string Street { get; set; }
+        public string City { get; set; }
+    }
+
+    /// <summary>Owned (OwnsMany) item on the derived <see cref="Student"/>.
+    /// Has an explicit <see cref="Id"/> so the owned collection uses a real key
+    /// (an implicit shadow key cannot be set when seeding a disconnected graph).</summary>
+    public class StudentContact
+    {
+        public int Id { get; set; }
+        public string Kind { get; set; }
+        public string Value { get; set; }
+    }
+
+    /// <summary>A second derived type, to verify discriminator filtering distinguishes
+    /// between multiple derived types sharing the "person" collection.</summary>
+    public class Teacher : Person
+    {
+        public string Subject { get; set; }
+    }
+
+    public class School
+    {
+        public int SchoolId { get; set; }
+        public string Name { get; set; }
+
+        /// <summary>Reference navigation used to verify ThenInclude off a derived navigation.</summary>
+        public int? DistrictId { get; set; }
+        public District District { get; set; }
+
+        public ICollection<Student> Students { get; set; } = [];
+    }
+
+    public class District
+    {
+        public int DistrictId { get; set; }
+        public string Name { get; set; }
+
+        public ICollection<School> Schools { get; set; } = [];
+    }
+
+    public class Enrollment
+    {
+        public int EnrollmentId { get; set; }
+        public string Title { get; set; }
+
+        public int StudentId { get; set; }
+        public Student Student { get; set; }
     }
 
     public class Tag

--- a/tests/Couchbase.EntityFrameworkCore.IntegrationTests/Fixtures/BloggingFixture.cs
+++ b/tests/Couchbase.EntityFrameworkCore.IntegrationTests/Fixtures/BloggingFixture.cs
@@ -152,6 +152,13 @@ public class BloggingFixture : CouchbaseFixture<BloggingDbContext>
                 new Enrollment { EnrollmentId = 2, StudentId = 4, Title = "Query Optimization" }
             };
 
+            // Abstract-base TPH hierarchy: seed concrete derived types only.
+            var animals = new List<Animal>
+            {
+                new Dog { AnimalId = 1, Name = "Rex", Breed = "Beagle" },
+                new Cat { AnimalId = 2, Name = "Whiskers", Indoor = true }
+            };
+
             var tags = new List<Tag>
             {
                 new Tag { TagId = "general" },
@@ -180,6 +187,7 @@ public class BloggingFixture : CouchbaseFixture<BloggingDbContext>
             dbContext.UpdateRange(students);
             dbContext.UpdateRange(teachers);
             dbContext.UpdateRange(enrollments);
+            dbContext.UpdateRange(animals);
             dbContext.UpdateRange(tags);
             dbContext.UpdateRange(postTags);
 
@@ -307,6 +315,24 @@ public class BloggingFixture : CouchbaseFixture<BloggingDbContext>
 
         public int StudentId { get; set; }
         public Student Student { get; set; }
+    }
+
+    /// <summary>Abstract TPH base — never instantiated. A base-set query must
+    /// materialise only the concrete derived types (<see cref="Dog"/>/<see cref="Cat"/>).</summary>
+    public abstract class Animal
+    {
+        public int AnimalId { get; set; }
+        public string Name { get; set; }
+    }
+
+    public class Dog : Animal
+    {
+        public string Breed { get; set; }
+    }
+
+    public class Cat : Animal
+    {
+        public bool Indoor { get; set; }
     }
 
     public class Tag

--- a/tests/Couchbase.EntityFrameworkCore.IntegrationTests/Models/BloggingDbContext.cs
+++ b/tests/Couchbase.EntityFrameworkCore.IntegrationTests/Models/BloggingDbContext.cs
@@ -10,6 +10,9 @@ public class BloggingDbContext(DbContextOptions<BloggingDbContext> options) : Db
     public DbSet<BloggingFixture.Post> Posts { get; set; }
     public DbSet<BloggingFixture.Person> People { get; set; }
     public DbSet<BloggingFixture.PersonPhoto> PersonPhotos { get; set; }
+    public DbSet<BloggingFixture.School> Schools { get; set; }
+    public DbSet<BloggingFixture.District> Districts { get; set; }
+    public DbSet<BloggingFixture.Enrollment> Enrollments { get; set; }
 
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
@@ -93,6 +96,61 @@ public class BloggingDbContext(DbContextOptions<BloggingDbContext> options) : Db
             .Navigation(p => p.Photo)
             .AutoInclude();
 
+        // TPH inheritance: Student and Teacher are derived types sharing the
+        // "person" collection. Mapping them to the same collection as Person
+        // signals TPH, so EF Core adds a "Discriminator" shadow property by default.
+        modelBuilder.Entity<BloggingFixture.Student>(b =>
+        {
+            b.ToCouchbaseCollection(this, "person");
+
+            b.HasOne(s => s.School)
+                .WithMany(sc => sc.Students)
+                .HasForeignKey(s => s.SchoolId);
+
+            // Collection navigation declared only on the derived Student type.
+            b.HasMany(s => s.Enrollments)
+                .WithOne(e => e.Student)
+                .HasForeignKey(e => e.StudentId);
+
+            // Owned types on a derived type: embedded in the Student's document
+            // within the shared "person" collection. Exercises the owned-nav write
+            // branch of HydrateObjectFromEntity alongside the TPH discriminator.
+            b.OwnsOne(s => s.Address);
+            b.OwnsMany(s => s.Contacts);
+        });
+        // Student rows are seeded via LoadDataAsync / the per-test warm-up rather than
+        // HasData: HasData on an owner with required owned navigations would also require
+        // seeding the owned data through the owned builders, which adds no coverage here.
+
+        modelBuilder.Entity<BloggingFixture.Teacher>()
+            .ToCouchbaseCollection(this, "person");
+
+        modelBuilder.Entity<BloggingFixture.Teacher>()
+            .HasData(new BloggingFixture.Teacher
+            {
+                PersonId = 5, Name = "Tina Teacher", PhotoId = 5, Subject = "Databases"
+            });
+
+        // School → District reference, used to verify ThenInclude off a derived nav.
+        modelBuilder.Entity<BloggingFixture.School>()
+            .HasOne(sc => sc.District)
+            .WithMany(d => d.Schools)
+            .HasForeignKey(sc => sc.DistrictId);
+
+        modelBuilder.Entity<BloggingFixture.School>()
+            .ToCouchbaseCollection(this, "school")
+            .HasData(new BloggingFixture.School { SchoolId = 1, Name = "Couchbase University", DistrictId = 1 });
+
+        modelBuilder.Entity<BloggingFixture.District>()
+            .ToCouchbaseCollection(this, "district")
+            .HasData(new BloggingFixture.District { DistrictId = 1, Name = "Metro District" });
+
+        modelBuilder.Entity<BloggingFixture.Enrollment>()
+            .ToCouchbaseCollection(this, "enrollment")
+            .HasData(
+                new BloggingFixture.Enrollment { EnrollmentId = 1, StudentId = 4, Title = "Distributed Systems" },
+                new BloggingFixture.Enrollment { EnrollmentId = 2, StudentId = 4, Title = "Query Optimization" });
+
         modelBuilder.Entity<BloggingFixture.PersonPhoto>()
             .ToCouchbaseCollection(this, "personphoto")
             .HasData(
@@ -110,6 +168,16 @@ public class BloggingDbContext(DbContextOptions<BloggingDbContext> options) : Db
                 {
                     PersonPhotoId = 3, Caption = "JD",
                     Photo = new byte[] { 0x01, 0x01, 0x01 }
+                },
+                new BloggingFixture.PersonPhoto
+                {
+                    PersonPhotoId = 4, Caption = "SS",
+                    Photo = new byte[] { 0x02, 0x02 }
+                },
+                new BloggingFixture.PersonPhoto
+                {
+                    PersonPhotoId = 5, Caption = "TT",
+                    Photo = new byte[] { 0x03, 0x03 }
                 });
 
         modelBuilder.Entity<BloggingFixture.Tag>()

--- a/tests/Couchbase.EntityFrameworkCore.IntegrationTests/Models/BloggingDbContext.cs
+++ b/tests/Couchbase.EntityFrameworkCore.IntegrationTests/Models/BloggingDbContext.cs
@@ -13,6 +13,7 @@ public class BloggingDbContext(DbContextOptions<BloggingDbContext> options) : Db
     public DbSet<BloggingFixture.School> Schools { get; set; }
     public DbSet<BloggingFixture.District> Districts { get; set; }
     public DbSet<BloggingFixture.Enrollment> Enrollments { get; set; }
+    public DbSet<BloggingFixture.Animal> Animals { get; set; }
 
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
@@ -150,6 +151,14 @@ public class BloggingDbContext(DbContextOptions<BloggingDbContext> options) : Db
             .HasData(
                 new BloggingFixture.Enrollment { EnrollmentId = 1, StudentId = 4, Title = "Distributed Systems" },
                 new BloggingFixture.Enrollment { EnrollmentId = 2, StudentId = 4, Title = "Query Optimization" });
+
+        // Abstract TPH base: Dog and Cat share the "animal" collection. The abstract
+        // Animal base is never instantiated; a base-set query must return concrete types.
+        modelBuilder.Entity<BloggingFixture.Animal>().ToCouchbaseCollection(this, "animal");
+        modelBuilder.Entity<BloggingFixture.Dog>()
+            .HasData(new BloggingFixture.Dog { AnimalId = 1, Name = "Rex", Breed = "Beagle" });
+        modelBuilder.Entity<BloggingFixture.Cat>()
+            .HasData(new BloggingFixture.Cat { AnimalId = 2, Name = "Whiskers", Indoor = true });
 
         modelBuilder.Entity<BloggingFixture.PersonPhoto>()
             .ToCouchbaseCollection(this, "personphoto")

--- a/tests/Couchbase.EntityFrameworkCore.IntegrationTests/Tests/EagerLoadingTests.cs
+++ b/tests/Couchbase.EntityFrameworkCore.IntegrationTests/Tests/EagerLoadingTests.cs
@@ -7,7 +7,9 @@ namespace Couchbase.EntityFrameworkCode.IntegrationTests.Tests;
 /// Phase 4 acceptance tests for eager loading via Include / ThenInclude.
 /// Tests 1–5 cover foreign-key navigations handled by the Phase 3 JOIN pipeline.
 /// Tests 6–7 cover auto-include and IgnoreAutoIncludes.
-/// Test 8 (include on derived type) is skipped — requires a derived-type model.
+/// Test 8 covers Include on a TPH derived type (Student/Teacher : Person):
+/// OfType + Include, cast-style Include without OfType, ThenInclude, collection
+/// navigations, multi-derived-type discriminator filtering, and filtered include.
 /// </summary>
 [Collection(CouchbaseTestingCollection.Name)]
 public class EagerLoadingTests(BloggingFixture fixture) : IAsyncLifetime
@@ -33,6 +35,23 @@ public class EagerLoadingTests(BloggingFixture fixture) : IAsyncLifetime
             ctx.Update(new BloggingFixture.PersonPhoto { PersonPhotoId = 1, Caption = "SN", Photo = [0x00, 0x01] });
             ctx.Update(new BloggingFixture.PersonPhoto { PersonPhotoId = 2, Caption = "PF", Photo = [0x01, 0x02, 0x03] });
             ctx.Update(new BloggingFixture.PersonPhoto { PersonPhotoId = 3, Caption = "JD", Photo = [0x01, 0x01, 0x01] });
+            ctx.Update(new BloggingFixture.PersonPhoto { PersonPhotoId = 4, Caption = "SS", Photo = [0x02, 0x02] });
+            ctx.Update(new BloggingFixture.PersonPhoto { PersonPhotoId = 5, Caption = "TT", Photo = [0x03, 0x03] });
+            ctx.Update(new BloggingFixture.District { DistrictId = 1, Name = "Metro District" });
+            ctx.Update(new BloggingFixture.School { SchoolId = 1, Name = "Couchbase University", DistrictId = 1 });
+            ctx.Update(new BloggingFixture.Student
+            {
+                PersonId = 4, Name = "Sam Student", PhotoId = 4, SchoolId = 1,
+                Address = new BloggingFixture.StudentAddress { Street = "1 Database Way", City = "Mountain View" },
+                Contacts =
+                [
+                    new BloggingFixture.StudentContact { Id = 1, Kind = "email", Value = "sam@university.edu" },
+                    new BloggingFixture.StudentContact { Id = 2, Kind = "phone", Value = "555-0100" }
+                ]
+            });
+            ctx.Update(new BloggingFixture.Teacher { PersonId = 5, Name = "Tina Teacher", PhotoId = 5, Subject = "Databases" });
+            ctx.Update(new BloggingFixture.Enrollment { EnrollmentId = 1, StudentId = 4, Title = "Distributed Systems" });
+            ctx.Update(new BloggingFixture.Enrollment { EnrollmentId = 2, StudentId = 4, Title = "Query Optimization" });
             ctx.Update(new BloggingFixture.Tag { TagId = "general" });
             ctx.Update(new BloggingFixture.Tag { TagId = "classic" });
             ctx.Update(new BloggingFixture.Tag { TagId = "opinion" });
@@ -296,12 +315,250 @@ public class EagerLoadingTests(BloggingFixture fixture) : IAsyncLifetime
     }
 
     // -----------------------------------------------------------------------
-    // 8 — Include on derived type (requires derived-type model — deferred)
+    // 8 — Include on a TPH derived type (Student : Person → School)
     // -----------------------------------------------------------------------
 
-    [Fact(Skip = "Requires a derived-type model (e.g. Student : Person with School navigation). Deferred to Phase 6.")]
-    public Task Include_OnDerivedType_PopulatesDerivedNavigation()
-        => Task.CompletedTask;
+    [Fact]
+    public async Task Include_OnDerivedType_PopulatesDerivedNavigation()
+    {
+        // Query the base set (People), narrow to the derived Student type, and
+        // Include the School navigation that only exists on Student. TPH stores
+        // both Person and Student in the "person" collection, discriminated by
+        // the "Discriminator" shadow property.
+        await using var context = fixture.GetDbContext();
+
+        var students = await context.People
+            .OfType<BloggingFixture.Student>()
+            .Include(s => s.School)
+            .OrderBy(s => s.PersonId)
+            .ToListAsync();
+
+        Assert.NotEmpty(students);
+        Assert.All(students, s => Assert.NotNull(s.School));
+        Assert.Contains(students, s => s.School.Name == "Couchbase University");
+    }
+
+    [Fact]
+    public async Task Include_OnDerivedType_CastStyle_WithoutOfType_PopulatesDerivedNavigation()
+    {
+        // Cast-style Include on the base set (no OfType filter). EF Core applies the
+        // derived navigation only to rows whose discriminator matches the cast type.
+        await using var context = fixture.GetDbContext();
+
+        var people = await context.People
+            .Include(p => ((BloggingFixture.Student)p).School)
+            .OrderBy(p => p.PersonId)
+            .ToListAsync();
+
+        var student = Assert.IsType<BloggingFixture.Student>(
+            Assert.Single(people, p => p is BloggingFixture.Student));
+        Assert.NotNull(student.School);
+        Assert.Equal("Couchbase University", student.School.Name);
+    }
+
+    [Fact]
+    public async Task Include_OnDerivedType_ThenInclude_PopulatesNestedNavigation()
+    {
+        // ThenInclude chained off a navigation declared on the derived type.
+        await using var context = fixture.GetDbContext();
+
+        var students = await context.People
+            .OfType<BloggingFixture.Student>()
+            .Include(s => s.School)
+                .ThenInclude(sc => sc.District)
+            .ToListAsync();
+
+        var student = Assert.Single(students);
+        Assert.NotNull(student.School);
+        Assert.NotNull(student.School.District);
+        Assert.Equal("Metro District", student.School.District.Name);
+    }
+
+    [Fact]
+    public async Task Include_OnDerivedType_CollectionNavigation_Populated()
+    {
+        // Collection navigation declared only on the derived type.
+        await using var context = fixture.GetDbContext();
+
+        var students = await context.People
+            .OfType<BloggingFixture.Student>()
+            .Include(s => s.Enrollments)
+            .ToListAsync();
+
+        var student = Assert.Single(students);
+        Assert.Equal(2, student.Enrollments.Count);
+        Assert.Contains(student.Enrollments, e => e.Title == "Distributed Systems");
+        Assert.Contains(student.Enrollments, e => e.Title == "Query Optimization");
+    }
+
+    [Fact]
+    public async Task OfType_WithMultipleDerivedTypes_FiltersByDiscriminator()
+    {
+        // Two derived types share the "person" collection; OfType must select exactly one.
+        await using var context = fixture.GetDbContext();
+
+        var students = await context.People.OfType<BloggingFixture.Student>().ToListAsync();
+        var teachers = await context.People.OfType<BloggingFixture.Teacher>().ToListAsync();
+
+        Assert.Single(students);
+        Assert.All(students, s => Assert.Equal("Sam Student", s.Name));
+
+        Assert.Single(teachers);
+        Assert.All(teachers, t => Assert.Equal("Databases", t.Subject));
+    }
+
+    [Fact]
+    public async Task Include_OnDerivedType_FilteredCollectionInclude_AppliesPredicate()
+    {
+        // Filtered include on a collection navigation declared on the derived type.
+        await using var context = fixture.GetDbContext();
+
+        var students = await context.People
+            .OfType<BloggingFixture.Student>()
+            .Include(s => s.Enrollments.Where(e => e.Title == "Query Optimization"))
+            .ToListAsync();
+
+        var student = Assert.Single(students);
+        var enrollment = Assert.Single(student.Enrollments);
+        Assert.Equal("Query Optimization", enrollment.Title);
+    }
+
+    // -----------------------------------------------------------------------
+    // 8b — Derived-type Find / write round-trip (non-query code paths that the
+    // discriminator persistence fix touches: Find type-resolution and the
+    // SaveChanges write path for derived entities).
+    // -----------------------------------------------------------------------
+
+    [Fact]
+    public async Task Find_OnBaseSet_ResolvesDerivedType()
+    {
+        // FindAsync against the base DbSet must resolve the discriminator and
+        // return the correct derived CLR type with its derived scalars populated.
+        await using var context = fixture.GetDbContext();
+
+        var person = await context.People.FindAsync(4);
+
+        var student = Assert.IsType<BloggingFixture.Student>(person);
+        Assert.Equal("Sam Student", student.Name);
+        Assert.Equal(1, student.SchoolId);
+    }
+
+    [Fact]
+    public async Task Find_OnDerivedSet_WrongDiscriminator_ReturnsNull()
+    {
+        // PersonId 1 is a base Person (not a Student); a derived-set Find must not
+        // return it — i.e. the discriminator filters the lookup.
+        await using var context = fixture.GetDbContext();
+
+        var student = await context.Set<BloggingFixture.Student>().FindAsync(1);
+
+        Assert.Null(student);
+    }
+
+    [Fact]
+    public async Task Update_DerivedEntity_PersistsChangeAndPreservesDiscriminator()
+    {
+        // Modify and save a derived entity, then reload in a fresh context. The
+        // change must persist AND the row must still resolve as the derived type
+        // (i.e. the discriminator survived the write path).
+        await using (var ctx = fixture.GetDbContext())
+        {
+            var student = await ctx.Set<BloggingFixture.Student>().FindAsync(4);
+            Assert.NotNull(student);
+            student!.Name = "Sam Updated";
+            await ctx.SaveChangesAsync();
+        }
+
+        await using (var ctx = fixture.GetDbContext())
+        {
+            var reloaded = await ctx.People.FindAsync(4);
+            var student = Assert.IsType<BloggingFixture.Student>(reloaded);
+            Assert.Equal("Sam Updated", student.Name);
+        }
+    }
+
+    [Fact]
+    public async Task Delete_DerivedEntity_RemovesDocument()
+    {
+        await using (var ctx = fixture.GetDbContext())
+        {
+            var student = await ctx.Set<BloggingFixture.Student>().FindAsync(4);
+            Assert.NotNull(student);
+            ctx.Remove(student!);
+            await ctx.SaveChangesAsync();
+        }
+
+        await using (var ctx = fixture.GetDbContext())
+        {
+            Assert.Null(await ctx.Set<BloggingFixture.Student>().FindAsync(4));
+            var ids = await ctx.People.Select(p => p.PersonId).ToListAsync();
+            Assert.DoesNotContain(4, ids);
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // 8c — Owned types (OwnsOne / OwnsMany) on a derived type. Owned data is
+    // embedded in the shared "person" document; these exercise the owned-nav
+    // read/write paths together with the TPH discriminator.
+    // -----------------------------------------------------------------------
+
+    [Fact]
+    public async Task OwnedTypes_OnDerivedType_MaterializeAlongsideDiscriminator()
+    {
+        await using var context = fixture.GetDbContext();
+
+        var student = await context.People
+            .OfType<BloggingFixture.Student>()
+            .Include(s => s.School)
+            .SingleAsync();
+
+        // Owned reference (OwnsOne) embedded in the Student document.
+        Assert.NotNull(student.Address);
+        Assert.Equal("1 Database Way", student.Address.Street);
+        Assert.Equal("Mountain View", student.Address.City);
+
+        // Owned collection (OwnsMany) embedded in the Student document.
+        Assert.Equal(2, student.Contacts.Count);
+        Assert.Contains(student.Contacts, c => c.Kind == "email" && c.Value == "sam@university.edu");
+        Assert.Contains(student.Contacts, c => c.Kind == "phone" && c.Value == "555-0100");
+
+        // FK navigation still resolves alongside owned types + discriminator.
+        Assert.NotNull(student.School);
+    }
+
+    [Fact]
+    public async Task OwnedTypes_OnDerivedType_BaseSetQuery_PopulatesForDerivedRows()
+    {
+        // Querying the base set materializes owned types for the derived rows.
+        await using var context = fixture.GetDbContext();
+
+        var people = await context.People.OrderBy(p => p.PersonId).ToListAsync();
+        var student = Assert.IsType<BloggingFixture.Student>(people.Single(p => p.PersonId == 4));
+
+        Assert.Equal("Mountain View", student.Address.City);
+        Assert.Equal(2, student.Contacts.Count);
+    }
+
+    [Fact]
+    public async Task OwnedTypes_OnDerivedType_WriteRoundTrip_PersistsChangesAndPreservesDiscriminator()
+    {
+        await using (var ctx = fixture.GetDbContext())
+        {
+            var student = await ctx.People.OfType<BloggingFixture.Student>().SingleAsync();
+            student.Address.City = "San Jose";
+            student.Contacts.Add(new BloggingFixture.StudentContact { Id = 3, Kind = "fax", Value = "555-0199" });
+            await ctx.SaveChangesAsync();
+        }
+
+        await using (var ctx = fixture.GetDbContext())
+        {
+            var reloaded = await ctx.People.FindAsync(4);
+            var student = Assert.IsType<BloggingFixture.Student>(reloaded);
+            Assert.Equal("San Jose", student.Address.City);
+            Assert.Equal(3, student.Contacts.Count);
+            Assert.Contains(student.Contacts, c => c.Kind == "fax" && c.Value == "555-0199");
+        }
+    }
 
     // -----------------------------------------------------------------------
     // 9 — Explicit join-entity many-to-many (Post → PostTag → Tag)

--- a/tests/Couchbase.EntityFrameworkCore.IntegrationTests/Tests/EagerLoadingTests.cs
+++ b/tests/Couchbase.EntityFrameworkCore.IntegrationTests/Tests/EagerLoadingTests.cs
@@ -52,6 +52,8 @@ public class EagerLoadingTests(BloggingFixture fixture) : IAsyncLifetime
             ctx.Update(new BloggingFixture.Teacher { PersonId = 5, Name = "Tina Teacher", PhotoId = 5, Subject = "Databases" });
             ctx.Update(new BloggingFixture.Enrollment { EnrollmentId = 1, StudentId = 4, Title = "Distributed Systems" });
             ctx.Update(new BloggingFixture.Enrollment { EnrollmentId = 2, StudentId = 4, Title = "Query Optimization" });
+            ctx.Update(new BloggingFixture.Dog { AnimalId = 1, Name = "Rex", Breed = "Beagle" });
+            ctx.Update(new BloggingFixture.Cat { AnimalId = 2, Name = "Whiskers", Indoor = true });
             ctx.Update(new BloggingFixture.Tag { TagId = "general" });
             ctx.Update(new BloggingFixture.Tag { TagId = "classic" });
             ctx.Update(new BloggingFixture.Tag { TagId = "opinion" });
@@ -558,6 +560,65 @@ public class EagerLoadingTests(BloggingFixture fixture) : IAsyncLifetime
             Assert.Equal(3, student.Contacts.Count);
             Assert.Contains(student.Contacts, c => c.Kind == "fax" && c.Value == "555-0199");
         }
+    }
+
+    // -----------------------------------------------------------------------
+    // 8d — Inverse include: load a collection OF derived entities from the
+    // other side (School.Students). Element type resolution must pick the
+    // derived CLR type for each collection member.
+    // -----------------------------------------------------------------------
+
+    [Fact]
+    public async Task Include_CollectionOfDerivedType_FromInverseSide_PopulatesDerivedElements()
+    {
+        await using var context = fixture.GetDbContext();
+
+        var school = await context.Schools
+            .Include(sc => sc.Students)
+            .SingleAsync(sc => sc.SchoolId == 1);
+
+        var student = Assert.Single(school.Students);
+        Assert.IsType<BloggingFixture.Student>(student);
+        Assert.Equal("Sam Student", student.Name);
+        Assert.Equal(1, student.SchoolId);
+    }
+
+    // -----------------------------------------------------------------------
+    // 8e — Abstract TPH base: querying the base set must materialise only the
+    // concrete derived types (the abstract base is never instantiated).
+    // -----------------------------------------------------------------------
+
+    [Fact]
+    public async Task Query_AbstractBaseSet_MaterializesConcreteDerivedTypes()
+    {
+        await using var context = fixture.GetDbContext();
+
+        var animals = await context.Set<BloggingFixture.Animal>()
+            .OrderBy(a => a.AnimalId)
+            .ToListAsync();
+
+        Assert.Equal(2, animals.Count);
+
+        var dog = Assert.IsType<BloggingFixture.Dog>(animals[0]);
+        Assert.Equal("Rex", dog.Name);
+        Assert.Equal("Beagle", dog.Breed);
+
+        var cat = Assert.IsType<BloggingFixture.Cat>(animals[1]);
+        Assert.Equal("Whiskers", cat.Name);
+        Assert.True(cat.Indoor);
+    }
+
+    [Fact]
+    public async Task OfType_OnAbstractBase_FiltersToConcreteDerivedType()
+    {
+        await using var context = fixture.GetDbContext();
+
+        var dogs = await context.Set<BloggingFixture.Animal>()
+            .OfType<BloggingFixture.Dog>()
+            .ToListAsync();
+
+        var dog = Assert.Single(dogs);
+        Assert.Equal("Beagle", dog.Breed);
     }
 
     // -----------------------------------------------------------------------


### PR DESCRIPTION
The provider had no working entity-inheritance support. Implementing Include on a derived navigation surfaced three gaps, all fixed here.

Write path (CouchbaseDatabaseWrapper.HydrateObjectFromEntity): the document builder skipped all shadow properties, dropping EF Core's TPH discriminator. As a result OfType<TDerived>(), Find, and Includes on a derived navigation matched no documents. Persist the discriminator property even though it is a shadow property.

Owned collections on a derived type were neither projected nor materialised when the base type was queried (T = Person) or via Find; only OfType<TDerived>() worked, and OwnsOne worked only because TPH projects all scalar columns. Fix both layers:
- CouchbaseShapedQueryCompilingExpressionVisitor: project owned- collection fields declared on derived types so they reach the result JSON (derived types share the owner table, so the column ref is valid and null for base rows).
- CouchbaseQueryEnumerable: gather owned-collection navigations across the inclusive hierarchy and apply each one only to rows whose runtime type declares it, guarded so non-inheritance queries stay zero-cost.

Add a Student/Teacher : Person (TPH) test model with reference, nested, collection, and owned (OwnsOne/OwnsMany) navigations, and cover the derived-type surface in EagerLoadingTests: OfType + Include, cast-style Include without OfType, ThenInclude off a derived nav, collection navigations, multi-derived-type discriminator filtering, filtered include, Find resolution, update/delete round-trips, and owned types on a derived type (query and write round-trip).