### PR TITLE
 Support multiple buckets & clusters via `ServiceKey` (shared cluster reuse)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to the EF Core Couchbase DB provider are documented in this 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project aims to follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [2.0.0-beta.2] - 2026-06-24
 
 ### Added
 
@@ -68,4 +68,5 @@ See [`docs/limitations.md`](docs/limitations.md). Highlights: EF Core Migrations
 supported (use `EnsureCreatedAsync`); synchronous query/save APIs are not supported;
 TPT/TPC inheritance is not supported; nested data must be modeled as owned types.
 
+[2.0.0-beta.2]: https://github.com/couchbaselabs/couchbase-efcore-provider/releases/tag/2.0.0-beta.2
 [2.0.0-beta.1]: https://github.com/couchbaselabs/couchbase-efcore-provider/releases/tag/2.0.0-beta.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to the EF Core Couchbase DB provider are documented in this 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project aims to follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- **Multiple buckets and clusters.** Use one `DbContext` per bucket; register multiple contexts
+  via `AddCouchbase<TContext>`. When a Couchbase cluster is registered in application DI, contexts
+  reuse that single shared `Cluster` (one cluster, many buckets — per Couchbase guidance) instead
+  of each owning its own. For multiple physical clusters, register a keyed cluster per server
+  (`AddKeyedCouchbase`) and select it per context with the new
+  `CouchbaseDbContextOptionsBuilder.ServiceKey`. Falls back to the previous per-context
+  cluster-ownership behavior when no application cluster is registered. See
+  [Configuration](docs/configuration.md#multiple-buckets-and-clusters).
+
 ## [2.0.0-beta.1] - 2026-06-23
 
 The 2.0 line is the first fully functional release of the provider. 1.0 was a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,58 @@
+# Changelog
+
+All notable changes to the EF Core Couchbase DB provider are documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project aims to follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [2.0.0-beta.1] - 2026-06-23
+
+The 2.0 line is the first fully functional release of the provider. 1.0 was a
+deliberately limited release; users are expected to move to 2.0. This is a prerelease —
+APIs may still change before GA.
+
+### Requirements
+
+- **Targets .NET 10** (`net10.0`).
+
+### Added
+
+- **Eager loading** via `Include` / `ThenInclude` for foreign-key navigations, plus
+  `AutoInclude` and `IgnoreAutoIncludes` support.
+- **Owned types** — `OwnsOne` and `OwnsMany`, including nested owned types at arbitrary
+  depth, embedded in the owner's document. Read and write paths both supported.
+- **Filtered includes** — e.g. `Include(b => b.Posts.Where(...))`.
+- **Many-to-many** — both the explicit join-entity pattern and transparent skip
+  navigations (`HasMany().WithMany()`).
+- **Inheritance (TPH)** — table-per-hierarchy with a discriminator: `OfType<TDerived>()`,
+  `Include` on navigations declared on a derived type, owned types on a derived type, and
+  `Find`/`FindAsync` resolution. Map derived types to the same collection as the base to
+  opt in.
+- **Value converters** on non-owned entities (`HasConversion`, including `ConvertsNulls`).
+- **Query scan consistency** option — defaults to `NotBounded`; set `RequestPlus` via the
+  options builder for read-after-write consistency on queries.
+- **ADO.NET data reader** (`CouchbaseDbDataReader`) underpinning the query pipeline,
+  including `FromSql` support.
+
+### Changed
+
+- Keyspace handling and resolution improvements.
+- Dependency updates and build/packaging cleanup.
+
+### Fixed
+
+- `AVG` aggregate translation in the SQL++ generator.
+
+### Documentation
+
+- Filled in [`docs/limitations.md`](docs/limitations.md) with the current known
+  limitations (Migrations, async-only I/O, scan consistency, owned-type requirement for
+  nested data, TPH-only inheritance, supported value-generation types).
+
+### Known limitations
+
+See [`docs/limitations.md`](docs/limitations.md). Highlights: EF Core Migrations are not
+supported (use `EnsureCreatedAsync`); synchronous query/save APIs are not supported;
+TPT/TPC inheritance is not supported; nested data must be modeled as owned types.
+
+[2.0.0-beta.1]: https://github.com/couchbaselabs/couchbase-efcore-provider/releases/tag/2.0.0-beta.1

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -46,6 +46,75 @@ Configuring the SDK is largely the same for EF Core Couchbase DB Provider. The S
 ## EF Core Couchbase DN Provider options
 The [CouchbaseDbContextOptionsBuilder](https://github.com/couchbaselabs/couchbase-efcore-provider/blob/main/src/Couchbase.EntityFrameworkCore/Infrastructure/CouchbaseDbContextOptionsBuilder.cs) handles configuration options specific to the provider.
 
+## Multiple buckets and clusters
+
+A `DbContext` maps to a single bucket (and scope). To work with **multiple buckets**, use
+**one `DbContext` per bucket**. Each context is registered independently and targets its own
+bucket:
+
+```csharp
+builder.Services.AddCouchbase<OrdersContext>(clusterOptions,
+    o => { o.Bucket = "orders"; o.Scope = "sales"; });
+
+builder.Services.AddCouchbase<UsersContext>(clusterOptions,
+    o => { o.Bucket = "users";  o.Scope = "identity"; });
+```
+
+### Sharing a single cluster (recommended)
+
+Couchbase recommends a **single `Cluster` object per application**, cached and reused — one
+cluster can open many buckets. To have your contexts share one cluster, register the Couchbase
+SDK in your application's DI container (via the
+[Couchbase DI library](https://docs.couchbase.com/dotnet-sdk/current/howtos/managing-connections.html#connection-di)),
+and the provider will reuse it for every context bound to it:
+
+```csharp
+// One shared cluster for the whole application.
+builder.Services.AddCouchbase(o =>
+{
+    o.ConnectionString = "couchbase://localhost";
+    o.WithCredentials("Administrator", "password");
+});
+
+// Both contexts reuse the shared cluster, each targeting its own bucket.
+builder.Services.AddCouchbase<OrdersContext>(clusterOptions, o => { o.Bucket = "orders"; o.Scope = "sales"; });
+builder.Services.AddCouchbase<UsersContext>(clusterOptions,  o => { o.Bucket = "users";  o.Scope = "identity"; });
+```
+
+If no cluster is registered in application DI, each context creates and owns its own cluster
+(the original behavior). Cluster sharing only applies when contexts are registered through
+`AddCouchbase<TContext>` — the application must register the cluster in DI for it to be shared.
+
+### Multiple clusters
+
+When an application must talk to **more than one physical Couchbase Server cluster**, register a
+**keyed** cluster per server and point each context at the right one with `ServiceKey`:
+
+```csharp
+builder.Services.AddKeyedCouchbase("east", o =>
+{
+    o.ConnectionString = "couchbase://east.example.com";
+    o.WithCredentials("Administrator", "password");
+});
+builder.Services.AddKeyedCouchbase("west", o =>
+{
+    o.ConnectionString = "couchbase://west.example.com";
+    o.WithCredentials("Administrator", "password");
+});
+
+builder.Services.AddCouchbase<EastContext>(eastClusterOptions,
+    o => { o.ServiceKey = "east"; o.Bucket = "orders"; o.Scope = "sales"; });
+builder.Services.AddCouchbase<WestContext>(westClusterOptions,
+    o => { o.ServiceKey = "west"; o.Bucket = "orders"; o.Scope = "sales"; });
+```
+
+`ServiceKey` selects which keyed cluster a context binds to. If a `ServiceKey` is set but no
+matching keyed cluster was registered, configuration fails with a clear error.
+
+> [!NOTE]
+> A single `DbContext` cannot span multiple buckets — every entity in a context is stored in that
+> context's configured bucket. Use a separate context per bucket. See [Limitations](limitations.md).
+
 ## Controlling Querying Casing
 SQL++ is based off JSON, thus is case sensitive both from the Query perspective and the query output. What this means is that your Keyspaces (Bucket, Scopes and Collections), the SQL++ query casing and your entities must have consistent casing.
 

--- a/docs/limitations.md
+++ b/docs/limitations.md
@@ -25,12 +25,7 @@ See also [Modeling](modeling.md).
 
 ## Asynchronous I/O only
 
-  is asynchronous, so the synchronous code paths throw `NotSupportedException` in Release builds. Use the
-
-  is asynchronous, so the synchronous code paths throw `NotSupportedException`. Use the
-  async variants throughout: `ToListAsync`, `FirstAsync`, `SingleAsync`,
-  `FindAsync`, `SaveChangesAsync`, `EnsureCreatedAsync`, and so on.
-
+The Couchbase SDK is asynchronous, so the synchronous EF Core code paths throw `NotSupportedException` in Release builds. Use the async variants throughout: `ToListAsync`, `FirstAsync`, `SingleAsync`, `FindAsync`, `SaveChangesAsync`, `EnsureCreatedAsync`, and so on.
 ## Querying and consistency
 
 * **Query scan consistency defaults to `NotBounded`.** Because secondary (GSI) indexes
@@ -73,7 +68,6 @@ See also [Querying](Queries.md) and [Configuration](configuration.md).
 * **Table-per-type (TPT) and table-per-concrete-type (TPC) are not supported.**
 
 ## Value generation and keys
-* **Sequence-based value generation supports numeric types only:** `int`, `long`,
 * **Sequence-based value generation supports integer types only:** `int`, `long`,
   `short`, `byte`, `uint`, `ulong`, `ushort`, and `decimal`. Other CLR types throw at
   model build / value-generation time.

--- a/docs/limitations.md
+++ b/docs/limitations.md
@@ -4,7 +4,7 @@ The EF Core Couchbase DB provider maps EF Core onto Couchbase using SQL++ (N1QL)
 and the Key/Value API. The large majority of EF Core concepts work as described in
 [the EF Core documentation](https://learn.microsoft.com/en-us/ef/core/) and in the
 other pages of this guide. This page lists the areas that are **not** supported, or
-that behave differently from a relational provider, as of the `2.0.0-beta.1` release.
+that behave differently from a relational provider, as of the `2.0.0-beta.2` release.
 
 Several of these stem from Couchbase being a document database: features that are
 specific to relational schemas (migrations, views, stored procedures, table schema)
@@ -77,6 +77,6 @@ See also [Querying](Queries.md) and [Configuration](configuration.md).
 ---
 
 > [!NOTE]
-> This list reflects the `2.0.0-beta.1` prerelease. As the provider evolves, items here
+> This list reflects the `2.0.0-beta.2` prerelease. As the provider evolves, items here
 > may become supported; check the release notes and the other pages in this guide for
 > the latest behavior.

--- a/docs/limitations.md
+++ b/docs/limitations.md
@@ -68,7 +68,7 @@ See also [Querying](Queries.md) and [Configuration](configuration.md).
 * **Table-per-type (TPT) and table-per-concrete-type (TPC) are not supported.**
 
 ## Value generation and keys
-* **Sequence-based value generation supports integer types only:** `int`, `long`,
+* **Sequence-based value generation supports a fixed set of numeric types:** `int`, `long`,
   `short`, `byte`, `uint`, `ulong`, `ushort`, and `decimal`. Other CLR types throw at
   model build / value-generation time.
 * **Generated `Guid` primary keys are partially supported** — see

--- a/docs/limitations.md
+++ b/docs/limitations.md
@@ -55,6 +55,14 @@ See also [Modeling](modeling.md).
 
 See also [Querying](Queries.md) and [Configuration](configuration.md).
 
+## Buckets and contexts
+
+* **A single `DbContext` maps to one bucket.** Every entity in a context is stored in that
+  context's configured bucket; a context cannot span multiple buckets. To work with multiple
+  buckets, use one `DbContext` per bucket. Multiple contexts can share a single `Cluster`, and
+  multiple physical clusters are supported via keyed registration — see
+  [Configuration](configuration.md#multiple-buckets-and-clusters).
+
 ## Inheritance
 
 * **Table-per-hierarchy (TPH) is supported.** Derived types share a single collection

--- a/docs/limitations.md
+++ b/docs/limitations.md
@@ -4,7 +4,7 @@ The EF Core Couchbase DB provider maps EF Core onto Couchbase using SQL++ (N1QL)
 and the Key/Value API. The large majority of EF Core concepts work as described in
 [the EF Core documentation](https://learn.microsoft.com/en-us/ef/core/) and in the
 other pages of this guide. This page lists the areas that are **not** supported, or
-that behave differently from a relational provider, in the current 2.0 pre-release.
+that behave differently from a relational provider, as of the `2.0.0-beta.1` release.
 
 Several of these stem from Couchbase being a document database: features that are
 specific to relational schemas (migrations, views, stored procedures, table schema)
@@ -65,7 +65,7 @@ See also [Querying](Queries.md) and [Configuration](configuration.md).
 * **Table-per-type (TPT) and table-per-concrete-type (TPC) are not supported.**
 
 ## Value generation and keys
-* **Sequence-based value generation supports numeric types only:** `int`, `long`,
+* **Sequence-based value generation supports numeric types only:** `int`, `long`,
 * **Sequence-based value generation supports integer types only:** `int`, `long`,
   `short`, `byte`, `uint`, `ulong`, `ushort`, and `decimal`. Other CLR types throw at
   model build / value-generation time.
@@ -75,6 +75,6 @@ See also [Querying](Queries.md) and [Configuration](configuration.md).
 ---
 
 > [!NOTE]
-> This list reflects the current pre-release. As the provider evolves, items here may
-> become supported; check the release notes and the other pages in this guide for the
-> latest behavior.
+> This list reflects the `2.0.0-beta.1` prerelease. As the provider evolves, items here
+> may become supported; check the release notes and the other pages in this guide for
+> the latest behavior.

--- a/src/Couchbase.EntityFrameworkCore/Couchbase.EntityFrameworkCore.csproj
+++ b/src/Couchbase.EntityFrameworkCore/Couchbase.EntityFrameworkCore.csproj
@@ -5,7 +5,7 @@
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-        <Version>2.0.0-pre.1</Version>
+        <Version>2.0.0-beta.1</Version>
         <Title>EF Core Couchbase DB Provider</Title>
         <Authors>Couchbase, Inc.</Authors>
         <Copyright>Couchbase, Inc. (c) 2026</Copyright>

--- a/src/Couchbase.EntityFrameworkCore/Couchbase.EntityFrameworkCore.csproj
+++ b/src/Couchbase.EntityFrameworkCore/Couchbase.EntityFrameworkCore.csproj
@@ -5,7 +5,7 @@
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-        <Version>2.0.0-beta.1</Version>
+        <Version>2.0.0-beta.2</Version>
         <Title>EF Core Couchbase DB Provider</Title>
         <Authors>Couchbase, Inc.</Authors>
         <Copyright>Couchbase, Inc. (c) 2026</Copyright>

--- a/src/Couchbase.EntityFrameworkCore/CouchbaseDbContextOptionsExtensions.cs
+++ b/src/Couchbase.EntityFrameworkCore/CouchbaseDbContextOptionsExtensions.cs
@@ -10,12 +10,16 @@ namespace Couchbase.EntityFrameworkCore;
 public static class CouchbaseDbContextOptionsExtensions
 {
   public static DbContextOptionsBuilder UseCouchbase(
-      this DbContextOptionsBuilder optionsBuilder, 
+      this DbContextOptionsBuilder optionsBuilder,
       ClusterOptions clusterOptions,
-      Action<CouchbaseDbContextOptionsBuilder>? couchbaseActionOptions = null)
+      Action<CouchbaseDbContextOptionsBuilder>? couchbaseActionOptions = null,
+      IServiceProvider? applicationServiceProvider = null)
   {
     var couchbaseDbContextOptionsBuilder = new CouchbaseDbContextOptionsBuilder(optionsBuilder, clusterOptions);
     couchbaseActionOptions?.Invoke(couchbaseDbContextOptionsBuilder);
+    // Captured when configured through AddCouchbase<TContext>; enables resolving an
+    // application-registered shared cluster (one Cluster per server across buckets).
+    couchbaseDbContextOptionsBuilder.ApplicationServiceProvider = applicationServiceProvider;
 
     var extension = CouchbaseDbContextOptionsBuilderExtensions.GetOrCreateExtension(optionsBuilder, clusterOptions, couchbaseDbContextOptionsBuilder);
     ((IDbContextOptionsBuilderInfrastructure) optionsBuilder).AddOrUpdateExtension(extension);

--- a/src/Couchbase.EntityFrameworkCore/CouchbaseDbContextOptionsExtensions.cs
+++ b/src/Couchbase.EntityFrameworkCore/CouchbaseDbContextOptionsExtensions.cs
@@ -12,8 +12,17 @@ public static class CouchbaseDbContextOptionsExtensions
   public static DbContextOptionsBuilder UseCouchbase(
       this DbContextOptionsBuilder optionsBuilder,
       ClusterOptions clusterOptions,
-      Action<CouchbaseDbContextOptionsBuilder>? couchbaseActionOptions = null,
-      IServiceProvider? applicationServiceProvider = null)
+      Action<CouchbaseDbContextOptionsBuilder>? couchbaseActionOptions = null)
+      => optionsBuilder.UseCouchbase(clusterOptions, couchbaseActionOptions, applicationServiceProvider: null);
+
+  // The applicationServiceProvider parameter is required (not optional) so this overload has a
+  // distinct arity from the one above — preserving binary compatibility for consumers compiled
+  // against the original 3-parameter signature, and avoiding overload ambiguity.
+  public static DbContextOptionsBuilder UseCouchbase(
+      this DbContextOptionsBuilder optionsBuilder,
+      ClusterOptions clusterOptions,
+      Action<CouchbaseDbContextOptionsBuilder>? couchbaseActionOptions,
+      IServiceProvider? applicationServiceProvider)
   {
     var couchbaseDbContextOptionsBuilder = new CouchbaseDbContextOptionsBuilder(optionsBuilder, clusterOptions);
     couchbaseActionOptions?.Invoke(couchbaseDbContextOptionsBuilder);

--- a/src/Couchbase.EntityFrameworkCore/Extensions/CouchbaseServiceCollectionExtensions.cs
+++ b/src/Couchbase.EntityFrameworkCore/Extensions/CouchbaseServiceCollectionExtensions.cs
@@ -35,10 +35,12 @@ public static class CouchbaseServiceCollectionExtensions
         Action<ICouchbaseDbContextOptionsBuilder>? couchbaseOptionsAction = null,
         Action<DbContextOptionsBuilder>? optionsAction = null)
         where TContext : DbContext
-        => serviceCollection.AddDbContext<TContext>((_, options) =>
+        => serviceCollection.AddDbContext<TContext>((serviceProvider, options) =>
         {
             optionsAction?.Invoke(options);
-            options.UseCouchbase(clusterOptions, couchbaseOptionsAction);
+            // Pass the application's service provider so the context can bind to an
+            // application-registered shared cluster (keyed by ServiceKey).
+            options.UseCouchbase(clusterOptions, couchbaseOptionsAction, serviceProvider);
         });
 
     public static IServiceCollection AddEntityFrameworkCouchbase(this IServiceCollection serviceCollection,

--- a/src/Couchbase.EntityFrameworkCore/Infrastructure/CouchbaseDbContextOptionsBuilder.cs
+++ b/src/Couchbase.EntityFrameworkCore/Infrastructure/CouchbaseDbContextOptionsBuilder.cs
@@ -41,6 +41,17 @@ public class CouchbaseDbContextOptionsBuilder : ICouchbaseDbContextOptionsBuilde
 
     public QueryScanConsistency ScanConsistency { get; set; } = QueryScanConsistency.NotBounded;
 
+    public object? ServiceKey { get; set; }
+
+    /// <summary>
+    /// The application's service provider, captured by <c>AddCouchbase&lt;TContext&gt;</c> so the
+    /// provider can resolve an application-registered shared cluster (see <see cref="ServiceKey"/>).
+    /// Not part of the service-provider cache key — it is the stable application root. Null when the
+    /// context is configured outside DI (plain <c>UseCouchbase</c>), in which case the provider owns
+    /// its own cluster.
+    /// </summary>
+    public IServiceProvider? ApplicationServiceProvider { get; set; }
+
     DbContextOptionsBuilder ICouchbaseDbContextOptionsBuilder.OptionsBuilder => OptionsBuilder;
 }
 
@@ -95,6 +106,21 @@ public interface ICouchbaseDbContextOptionsBuilder
     /// consistency — at the cost of higher latency.
     /// </summary>
     public QueryScanConsistency ScanConsistency { get; set; }
+
+    /// <summary>
+    /// Optional key identifying which application-registered Couchbase cluster this context
+    /// should use. When set, the provider resolves a shared <c>IClusterProvider</c> via keyed
+    /// dependency injection (<c>services.AddKeyedCouchbase(serviceKey, ...)</c>) from the
+    /// application's service provider — so a single <c>Cluster</c> per server is reused across
+    /// contexts and buckets, per Couchbase guidance. Set a distinct key per physical Couchbase
+    /// Server cluster when an application must talk to more than one.
+    /// </summary>
+    /// <remarks>
+    /// When <c>null</c>, the provider uses the unkeyed application-registered cluster if one
+    /// exists (<c>services.AddCouchbase(...)</c>), otherwise it falls back to registering and
+    /// owning its own cluster from <see cref="ClusterOptions"/> (the original behavior).
+    /// </remarks>
+    public object? ServiceKey { get; set; }
 }
 
 /* ************************************************************

--- a/src/Couchbase.EntityFrameworkCore/Infrastructure/CouchbaseDbContextOptionsBuilder.cs
+++ b/src/Couchbase.EntityFrameworkCore/Infrastructure/CouchbaseDbContextOptionsBuilder.cs
@@ -2,6 +2,7 @@ using System.Text.Json;
 using Couchbase.EntityFrameworkCore.Extensions;
 using Couchbase.Query;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace Couchbase.EntityFrameworkCore.Infrastructure;
 
@@ -43,14 +44,37 @@ public class CouchbaseDbContextOptionsBuilder : ICouchbaseDbContextOptionsBuilde
 
     public object? ServiceKey { get; set; }
 
+    private IServiceProvider? _applicationServiceProvider;
+
     /// <summary>
     /// The application's service provider, captured by <c>AddCouchbase&lt;TContext&gt;</c> so the
     /// provider can resolve an application-registered shared cluster (see <see cref="ServiceKey"/>).
-    /// Not part of the service-provider cache key — it is the stable application root. Null when the
-    /// context is configured outside DI (plain <c>UseCouchbase</c>), in which case the provider owns
-    /// its own cluster.
+    /// Null when the context is configured outside DI (plain <c>UseCouchbase</c>), in which case the
+    /// provider owns its own cluster.
     /// </summary>
-    public IServiceProvider? ApplicationServiceProvider { get; set; }
+    /// <remarks>
+    /// Setting this eagerly captures the container's stable identity (<see cref="ApplicationContainerIdentity"/>)
+    /// while the provider is alive, because the captured provider may be a scope that is later
+    /// disposed — and the service-provider cache key must not resolve services from a disposed
+    /// provider during later equality checks.
+    /// </remarks>
+    public IServiceProvider? ApplicationServiceProvider
+    {
+        get => _applicationServiceProvider;
+        set
+        {
+            _applicationServiceProvider = value;
+            ApplicationContainerIdentity = value?.GetService<IServiceScopeFactory>();
+        }
+    }
+
+    /// <summary>
+    /// A stable per-container identity (the application root's <see cref="IServiceScopeFactory"/>),
+    /// captured when <see cref="ApplicationServiceProvider"/> is set. Used as part of the
+    /// service-provider cache key so internal providers bound to one application container are not
+    /// reused by another. Null when configured outside DI.
+    /// </summary>
+    public object? ApplicationContainerIdentity { get; private set; }
 
     DbContextOptionsBuilder ICouchbaseDbContextOptionsBuilder.OptionsBuilder => OptionsBuilder;
 }

--- a/src/Couchbase.EntityFrameworkCore/Infrastructure/Internal/CouchbaseOptionsExtension.cs
+++ b/src/Couchbase.EntityFrameworkCore/Infrastructure/Internal/CouchbaseOptionsExtension.cs
@@ -139,15 +139,27 @@ public class CouchbaseOptionsExtension: RelationalOptionsExtension
 
         public override string LogFragment => $"Using Custom Couchbase Provider - ConnectionString: {ConnectionString}";
 
+        // A stable identity for the application's DI container, or null when configured outside DI
+        // (plain UseCouchbase). ApplyServices can bind an application-registered shared cluster into
+        // the (process-wide cached) internal service provider, so the cache key must distinguish
+        // application containers — otherwise a different root IServiceProvider with the same
+        // connection/bucket/scope/key could reuse an internal provider wired to the wrong
+        // container's cluster (or to a cluster from a disposed container). The identity (the root's
+        // IServiceScopeFactory) is captured eagerly when ApplicationServiceProvider is set, so this
+        // equality/hash path never resolves services from a possibly-disposed provider.
+        private object? ApplicationContainerIdentity
+            => Extension._couchbaseDbContextOptionsBuilder.ApplicationContainerIdentity;
+
         public override int GetServiceProviderHashCode() => HashCode.Combine(
             ConnectionString,
             Extension._couchbaseDbContextOptionsBuilder.Bucket,
             Extension._couchbaseDbContextOptionsBuilder.Scope,
-            Extension._couchbaseDbContextOptionsBuilder.ServiceKey);
+            Extension._couchbaseDbContextOptionsBuilder.ServiceKey,
+            RuntimeHelpers.GetHashCode(ApplicationContainerIdentity));
 
         // Must be consistent with GetServiceProviderHashCode: two contexts can share an internal
-        // service provider only when their connection string, bucket, scope, and service key all
-        // match. Each distinct (connection, bucket, scope, key) registers its own Couchbase
+        // service provider only when their connection string, bucket, scope, service key, and
+        // application container all match. Each distinct combination registers its own Couchbase
         // cluster/bucket provider (see ApplyServices), so collapsing them onto one provider would
         // resolve the wrong bucket or cluster.
         public override bool ShouldUseSameServiceProvider(DbContextOptionsExtensionInfo other)
@@ -155,7 +167,8 @@ public class CouchbaseOptionsExtension: RelationalOptionsExtension
                 && ConnectionString == otherInfo.ConnectionString
                 && Extension._couchbaseDbContextOptionsBuilder.Bucket == otherInfo.Extension._couchbaseDbContextOptionsBuilder.Bucket
                 && Extension._couchbaseDbContextOptionsBuilder.Scope == otherInfo.Extension._couchbaseDbContextOptionsBuilder.Scope
-                && Equals(Extension._couchbaseDbContextOptionsBuilder.ServiceKey, otherInfo.Extension._couchbaseDbContextOptionsBuilder.ServiceKey);
+                && Equals(Extension._couchbaseDbContextOptionsBuilder.ServiceKey, otherInfo.Extension._couchbaseDbContextOptionsBuilder.ServiceKey)
+                && ReferenceEquals(ApplicationContainerIdentity, otherInfo.ApplicationContainerIdentity);
 
         public override void PopulateDebugInfo(IDictionary<string, string> debugInfo)
         {

--- a/src/Couchbase.EntityFrameworkCore/Infrastructure/Internal/CouchbaseOptionsExtension.cs
+++ b/src/Couchbase.EntityFrameworkCore/Infrastructure/Internal/CouchbaseOptionsExtension.cs
@@ -6,6 +6,7 @@ using Couchbase;
 using Couchbase.EntityFrameworkCore.Extensions;
 using Couchbase.Extensions.DependencyInjection;
 using Couchbase.EntityFrameworkCore.Utils;
+using Couchbase.EntityFrameworkCore.Storage.Internal;
 using Couchbase.Core.IO.Serializers;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 
@@ -62,7 +63,61 @@ public class CouchbaseOptionsExtension: RelationalOptionsExtension
             }
         });
 
+        // If the application registered its own Couchbase cluster in DI, bind this context to that
+        // shared IClusterProvider (one Cluster per server, opens many buckets — per Couchbase
+        // guidance) instead of the per-context cluster registered above. The application owns the
+        // cluster's lifetime, so it is wrapped to prevent EF's internal provider from disposing it.
+        var sharedClusterProvider = TryResolveSharedClusterProvider();
+        if (sharedClusterProvider is not null)
+        {
+            for (var i = services.Count - 1; i >= 0; i--)
+            {
+                var serviceType = services[i].ServiceType;
+                if (serviceType == typeof(IClusterProvider) || serviceType == typeof(IBucketProvider))
+                {
+                    services.RemoveAt(i);
+                }
+            }
+
+            services.AddSingleton<IClusterProvider>(new NonOwningClusterProvider(sharedClusterProvider));
+            services.AddSingleton<IBucketProvider>(sp =>
+                new SharedClusterBucketProvider(sp.GetRequiredService<IClusterProvider>()));
+        }
+
         services.AddEntityFrameworkCouchbase(this);
+    }
+
+    /// <summary>
+    /// Resolves an application-registered <see cref="IClusterProvider"/> to share, or null when the
+    /// context owns its own cluster (no application provider captured, or none registered in DI).
+    /// </summary>
+    private IClusterProvider? TryResolveSharedClusterProvider()
+    {
+        var applicationServiceProvider = _couchbaseDbContextOptionsBuilder.ApplicationServiceProvider;
+        if (applicationServiceProvider is null)
+        {
+            return null;
+        }
+
+        var serviceKey = _couchbaseDbContextOptionsBuilder.ServiceKey;
+        if (serviceKey is null)
+        {
+            // Use the unkeyed application cluster if one was registered (services.AddCouchbase(...)).
+            return applicationServiceProvider.GetService<IClusterProvider>();
+        }
+
+        // A ServiceKey was specified: the keyed cluster must exist — fail loudly otherwise so a
+        // misconfiguration is not silently masked by spinning up a separate per-context cluster.
+        var keyedClusterProvider = applicationServiceProvider.GetKeyedService<IClusterProvider>(serviceKey);
+        if (keyedClusterProvider is null)
+        {
+            throw new InvalidOperationException(
+                $"No keyed Couchbase cluster is registered for ServiceKey '{serviceKey}'. " +
+                $"Call services.AddKeyedCouchbase(\"{serviceKey}\", ...) before " +
+                $"AddCouchbase<TContext>(..., o => o.ServiceKey = \"{serviceKey}\").");
+        }
+
+        return keyedClusterProvider;
     }
 
     public override void Validate(IDbContextOptions options)
@@ -84,17 +139,23 @@ public class CouchbaseOptionsExtension: RelationalOptionsExtension
 
         public override string LogFragment => $"Using Custom Couchbase Provider - ConnectionString: {ConnectionString}";
 
-        public override int GetServiceProviderHashCode() => HashCode.Combine(ConnectionString, Extension._couchbaseDbContextOptionsBuilder.Bucket, Extension._couchbaseDbContextOptionsBuilder.Scope);
+        public override int GetServiceProviderHashCode() => HashCode.Combine(
+            ConnectionString,
+            Extension._couchbaseDbContextOptionsBuilder.Bucket,
+            Extension._couchbaseDbContextOptionsBuilder.Scope,
+            Extension._couchbaseDbContextOptionsBuilder.ServiceKey);
 
         // Must be consistent with GetServiceProviderHashCode: two contexts can share an internal
-        // service provider only when their connection string, bucket, and scope all match. Each
-        // distinct (connection, bucket, scope) registers its own Couchbase cluster/bucket provider
-        // (see ApplyServices), so collapsing them onto one provider would resolve the wrong bucket.
+        // service provider only when their connection string, bucket, scope, and service key all
+        // match. Each distinct (connection, bucket, scope, key) registers its own Couchbase
+        // cluster/bucket provider (see ApplyServices), so collapsing them onto one provider would
+        // resolve the wrong bucket or cluster.
         public override bool ShouldUseSameServiceProvider(DbContextOptionsExtensionInfo other)
             => other is CouchbaseOptionsExtensionInfo otherInfo
                 && ConnectionString == otherInfo.ConnectionString
                 && Extension._couchbaseDbContextOptionsBuilder.Bucket == otherInfo.Extension._couchbaseDbContextOptionsBuilder.Bucket
-                && Extension._couchbaseDbContextOptionsBuilder.Scope == otherInfo.Extension._couchbaseDbContextOptionsBuilder.Scope;
+                && Extension._couchbaseDbContextOptionsBuilder.Scope == otherInfo.Extension._couchbaseDbContextOptionsBuilder.Scope
+                && Equals(Extension._couchbaseDbContextOptionsBuilder.ServiceKey, otherInfo.Extension._couchbaseDbContextOptionsBuilder.ServiceKey);
 
         public override void PopulateDebugInfo(IDictionary<string, string> debugInfo)
         {

--- a/src/Couchbase.EntityFrameworkCore/Infrastructure/Internal/CouchbaseOptionsExtension.cs
+++ b/src/Couchbase.EntityFrameworkCore/Infrastructure/Internal/CouchbaseOptionsExtension.cs
@@ -86,7 +86,15 @@ public class CouchbaseOptionsExtension: RelationalOptionsExtension
 
         public override int GetServiceProviderHashCode() => HashCode.Combine(ConnectionString, Extension._couchbaseDbContextOptionsBuilder.Bucket, Extension._couchbaseDbContextOptionsBuilder.Scope);
 
-        public override bool ShouldUseSameServiceProvider(DbContextOptionsExtensionInfo other) => other is CouchbaseOptionsExtensionInfo;
+        // Must be consistent with GetServiceProviderHashCode: two contexts can share an internal
+        // service provider only when their connection string, bucket, and scope all match. Each
+        // distinct (connection, bucket, scope) registers its own Couchbase cluster/bucket provider
+        // (see ApplyServices), so collapsing them onto one provider would resolve the wrong bucket.
+        public override bool ShouldUseSameServiceProvider(DbContextOptionsExtensionInfo other)
+            => other is CouchbaseOptionsExtensionInfo otherInfo
+                && ConnectionString == otherInfo.ConnectionString
+                && Extension._couchbaseDbContextOptionsBuilder.Bucket == otherInfo.Extension._couchbaseDbContextOptionsBuilder.Bucket
+                && Extension._couchbaseDbContextOptionsBuilder.Scope == otherInfo.Extension._couchbaseDbContextOptionsBuilder.Scope;
 
         public override void PopulateDebugInfo(IDictionary<string, string> debugInfo)
         {

--- a/src/Couchbase.EntityFrameworkCore/Storage/Internal/CouchbaseSharedClusterProviders.cs
+++ b/src/Couchbase.EntityFrameworkCore/Storage/Internal/CouchbaseSharedClusterProviders.cs
@@ -1,0 +1,39 @@
+using Couchbase.Extensions.DependencyInjection;
+
+namespace Couchbase.EntityFrameworkCore.Storage.Internal;
+
+/// <summary>
+/// Wraps an application-registered <see cref="IClusterProvider"/> so that EF Core's internal
+/// service provider can resolve it without taking ownership of its lifetime. Per Couchbase
+/// guidance a single <see cref="ICluster"/> is shared per process; the application owns and
+/// disposes it, so <see cref="DisposeAsync"/> here is intentionally a no-op.
+/// </summary>
+internal sealed class NonOwningClusterProvider(IClusterProvider inner) : IClusterProvider
+{
+    public ValueTask<ICluster> GetClusterAsync() => inner.GetClusterAsync();
+
+    // Do not dispose the application-owned cluster provider.
+    public void Dispose() { }
+
+    public ValueTask DisposeAsync() => ValueTask.CompletedTask;
+}
+
+/// <summary>
+/// An <see cref="IBucketProvider"/> that opens buckets from a shared <see cref="IClusterProvider"/>
+/// (one cluster, many buckets). Used when a context binds to an application-registered cluster so
+/// that all of the provider's data paths reuse the same <see cref="ICluster"/> instead of each
+/// context spinning up its own.
+/// </summary>
+internal sealed class SharedClusterBucketProvider(IClusterProvider clusterProvider) : IBucketProvider
+{
+    public async ValueTask<IBucket> GetBucketAsync(string bucketName)
+    {
+        var cluster = await clusterProvider.GetClusterAsync().ConfigureAwait(false);
+        return await cluster.BucketAsync(bucketName).ConfigureAwait(false);
+    }
+
+    // The cluster provider is application-owned; this adapter holds only a reference.
+    public void Dispose() { }
+
+    public ValueTask DisposeAsync() => ValueTask.CompletedTask;
+}

--- a/src/Couchbase.EntityFrameworkCore/Storage/Internal/CouchbaseSharedClusterProviders.cs
+++ b/src/Couchbase.EntityFrameworkCore/Storage/Internal/CouchbaseSharedClusterProviders.cs
@@ -1,3 +1,4 @@
+using Couchbase; // ICluster, IBucket
 using Couchbase.Extensions.DependencyInjection;
 
 namespace Couchbase.EntityFrameworkCore.Storage.Internal;

--- a/tests/AppHost/AppHost.cs
+++ b/tests/AppHost/AppHost.cs
@@ -12,6 +12,14 @@ defaultBucket.WithScope("contoso",
     "courseAssignment"
 ]);
 defaultBucket.WithScope("ownedtypes", ["customer"]);
+// Shared scope/collection used by the multi-bucket isolation test — the same
+// scope and collection name also exists in the secondary bucket below, so the
+// test can prove context-per-bucket isolation with an identical keyspace shape.
+defaultBucket.WithScope("isolation", ["widget"]);
+
+// Second bucket on the same cluster for the multi-bucket DI isolation test.
+var secondaryBucket = couchbase.AddBucket("secondary");
+secondaryBucket.WithScope("isolation", ["widget"]);
 
 var sampleBucket = couchbase.AddSampleBucket("travel-sample", "travel-sample");
 builder.Build().Run();

--- a/tests/Couchbase.EntityFrameworkCore.IntegrationTests/Tests/MultiBucketDependencyInjectionTests.cs
+++ b/tests/Couchbase.EntityFrameworkCore.IntegrationTests/Tests/MultiBucketDependencyInjectionTests.cs
@@ -124,7 +124,7 @@ public class MultiBucketDependencyInjectionTests(BloggingFixture fixture)
 
         var appCluster = await provider.GetRequiredService<IClusterProvider>().GetClusterAsync();
 
-        using var scope = provider.CreateScope();
+        await using var scope = provider.CreateAsyncScope();
         var primary = scope.ServiceProvider.GetRequiredService<PrimaryWidgetContext>();
         var secondary = scope.ServiceProvider.GetRequiredService<SecondaryWidgetContext>();
 
@@ -164,7 +164,7 @@ public class MultiBucketDependencyInjectionTests(BloggingFixture fixture)
         var clusterA = await provider.GetRequiredKeyedService<IClusterProvider>("clusterA").GetClusterAsync();
         var clusterB = await provider.GetRequiredKeyedService<IClusterProvider>("clusterB").GetClusterAsync();
 
-        using var scope = provider.CreateScope();
+        await using var scope = provider.CreateAsyncScope();
         var primary = scope.ServiceProvider.GetRequiredService<PrimaryWidgetContext>();
         var secondary = scope.ServiceProvider.GetRequiredService<SecondaryWidgetContext>();
 

--- a/tests/Couchbase.EntityFrameworkCore.IntegrationTests/Tests/MultiBucketDependencyInjectionTests.cs
+++ b/tests/Couchbase.EntityFrameworkCore.IntegrationTests/Tests/MultiBucketDependencyInjectionTests.cs
@@ -1,0 +1,103 @@
+using Couchbase.EntityFrameworkCode.IntegrationTests.Fixtures;
+using Couchbase.EntityFrameworkCore.Extensions;
+using Couchbase.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace Couchbase.EntityFrameworkCode.IntegrationTests.Tests;
+
+/// <summary>
+/// Multi-bucket DI coverage (Scope A — context-per-bucket): two DbContexts share a cluster,
+/// scope, and collection name, differing only by bucket. Writing the same key to each must
+/// not collide — each context resolves its own bucket and reads back only its own document.
+/// This is the strict isolation proof that DependencyInjectionTests (which uses two different
+/// schemas) does not provide.
+/// </summary>
+[Collection(CouchbaseTestingCollection.Name)]
+public class MultiBucketDependencyInjectionTests(BloggingFixture fixture)
+{
+    [Fact]
+    public async Task TwoContexts_OnDifferentBuckets_AreIsolated()
+    {
+        var services = new ServiceCollection();
+        services.AddCouchbase<PrimaryWidgetContext>(
+            NewClusterOptions(),
+            o => ConfigureBucket(o, "default"),
+            o => o.UseCamelCaseNamingConvention());
+        services.AddCouchbase<SecondaryWidgetContext>(
+            NewClusterOptions(),
+            o => ConfigureBucket(o, "secondary"),
+            o => o.UseCamelCaseNamingConvention());
+
+        await using var provider = services.BuildServiceProvider();
+
+        // Write the same key (WidgetId = 1) to each bucket with a distinct value.
+        await using (var scope = provider.CreateAsyncScope())
+        {
+            var primary = scope.ServiceProvider.GetRequiredService<PrimaryWidgetContext>();
+            var secondary = scope.ServiceProvider.GetRequiredService<SecondaryWidgetContext>();
+
+            await primary.Database.EnsureCreatedAsync();
+            await secondary.Database.EnsureCreatedAsync();
+
+            primary.Update(new Widget { WidgetId = 1, Name = "from-default" });
+            await primary.SaveChangesAsync();
+
+            secondary.Update(new Widget { WidgetId = 1, Name = "from-secondary" });
+            await secondary.SaveChangesAsync();
+        }
+
+        // Read back in fresh contexts (no identity-map carryover).
+        await using (var scope = provider.CreateAsyncScope())
+        {
+            var primary = scope.ServiceProvider.GetRequiredService<PrimaryWidgetContext>();
+            var secondary = scope.ServiceProvider.GetRequiredService<SecondaryWidgetContext>();
+
+            var fromPrimary = await primary.Widgets.FindAsync(1);
+            var fromSecondary = await secondary.Widgets.FindAsync(1);
+
+            Assert.NotNull(fromPrimary);
+            Assert.NotNull(fromSecondary);
+            // Same key, same scope/collection, different bucket → no cross-talk.
+            Assert.Equal("from-default", fromPrimary!.Name);
+            Assert.Equal("from-secondary", fromSecondary!.Name);
+        }
+    }
+
+    private global::Couchbase.ClusterOptions NewClusterOptions()
+        => new global::Couchbase.ClusterOptions()
+            .WithConnectionString(fixture.Host)
+            .WithCredentials(fixture.Username, fixture.Password);
+
+    private static void ConfigureBucket(ICouchbaseDbContextOptionsBuilder options, string bucket)
+    {
+        options.Bucket = bucket;
+        options.Scope = "isolation";
+        // Read-after-write consistency so the FindAsync below sees the just-written document.
+        options.ScanConsistency = global::Couchbase.Query.QueryScanConsistency.RequestPlus;
+    }
+
+    public class Widget
+    {
+        public int WidgetId { get; set; }
+        public string Name { get; set; } = null!;
+    }
+
+    public abstract class WidgetContextBase(DbContextOptions options) : DbContext(options)
+    {
+        public DbSet<Widget> Widgets { get; set; } = null!;
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            modelBuilder.Entity<Widget>().ToCouchbaseCollection(this, "widget");
+            modelBuilder.ConfigureToCouchbase(this, true);
+        }
+    }
+
+    public sealed class PrimaryWidgetContext(DbContextOptions<PrimaryWidgetContext> options)
+        : WidgetContextBase(options);
+
+    public sealed class SecondaryWidgetContext(DbContextOptions<SecondaryWidgetContext> options)
+        : WidgetContextBase(options);
+}

--- a/tests/Couchbase.EntityFrameworkCore.IntegrationTests/Tests/MultiBucketDependencyInjectionTests.cs
+++ b/tests/Couchbase.EntityFrameworkCore.IntegrationTests/Tests/MultiBucketDependencyInjectionTests.cs
@@ -1,7 +1,9 @@
 using Couchbase.EntityFrameworkCode.IntegrationTests.Fixtures;
 using Couchbase.EntityFrameworkCore.Extensions;
 using Couchbase.EntityFrameworkCore.Infrastructure;
+using Couchbase.Extensions.DependencyInjection;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.Extensions.DependencyInjection;
 using Xunit;
 
@@ -63,6 +65,39 @@ public class MultiBucketDependencyInjectionTests(BloggingFixture fixture)
             Assert.Equal("from-default", fromPrimary!.Name);
             Assert.Equal("from-secondary", fromSecondary!.Name);
         }
+    }
+
+    [Fact]
+    public void ContextsWithDifferentConnectionStrings_ResolveDistinctClusterProviders()
+    {
+        // Multi-cluster isolation: two contexts registered with different connection strings
+        // must each get their own Couchbase cluster/bucket provider — no singleton bleed where
+        // the second context silently reuses the first cluster. We assert provider identity
+        // only (resolving IBucketProvider does not open a connection), so the second connection
+        // string need not be reachable — avoiding a heavyweight second Couchbase container.
+        var services = new ServiceCollection();
+        services.AddCouchbase<PrimaryWidgetContext>(
+            new global::Couchbase.ClusterOptions()
+                .WithConnectionString(fixture.Host)
+                .WithCredentials(fixture.Username, fixture.Password),
+            o => ConfigureBucket(o, "default"));
+        services.AddCouchbase<SecondaryWidgetContext>(
+            new global::Couchbase.ClusterOptions()
+                .WithConnectionString("couchbase://cluster-b.invalid")
+                .WithCredentials("user", "password"),
+            o => ConfigureBucket(o, "default"));
+
+        using var provider = services.BuildServiceProvider();
+        using var scope = provider.CreateScope();
+        var primary = scope.ServiceProvider.GetRequiredService<PrimaryWidgetContext>();
+        var secondary = scope.ServiceProvider.GetRequiredService<SecondaryWidgetContext>();
+
+        var primaryBucketProvider = primary.GetService<IBucketProvider>();
+        var secondaryBucketProvider = secondary.GetService<IBucketProvider>();
+
+        Assert.NotNull(primaryBucketProvider);
+        Assert.NotNull(secondaryBucketProvider);
+        Assert.NotSame(primaryBucketProvider, secondaryBucketProvider);
     }
 
     private global::Couchbase.ClusterOptions NewClusterOptions()

--- a/tests/Couchbase.EntityFrameworkCore.IntegrationTests/Tests/MultiBucketDependencyInjectionTests.cs
+++ b/tests/Couchbase.EntityFrameworkCore.IntegrationTests/Tests/MultiBucketDependencyInjectionTests.cs
@@ -100,15 +100,88 @@ public class MultiBucketDependencyInjectionTests(BloggingFixture fixture)
         Assert.NotSame(primaryBucketProvider, secondaryBucketProvider);
     }
 
+    [Fact]
+    public async Task AppRegisteredCluster_IsSharedAcrossContextsAndBuckets()
+    {
+        // When the application registers its own cluster in DI, every context bound to it (across
+        // buckets) reuses the SAME ICluster — one Cluster per server, per Couchbase guidance —
+        // instead of each context spinning up its own.
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddCouchbase(o =>
+        {
+            o.ConnectionString = fixture.Host;
+            o.WithCredentials(fixture.Username, fixture.Password);
+        });
+        // Distinct scope so this test gets its own EF internal service-provider cache key
+        // (EF caches internal providers process-wide by connection string/bucket/scope/key).
+        services.AddCouchbase<PrimaryWidgetContext>(NewClusterOptions(),
+            o => ConfigureBucket(o, "default", "clustershared"), o => o.UseCamelCaseNamingConvention());
+        services.AddCouchbase<SecondaryWidgetContext>(NewClusterOptions(),
+            o => ConfigureBucket(o, "secondary", "clustershared"), o => o.UseCamelCaseNamingConvention());
+
+        await using var provider = services.BuildServiceProvider();
+
+        var appCluster = await provider.GetRequiredService<IClusterProvider>().GetClusterAsync();
+
+        using var scope = provider.CreateScope();
+        var primary = scope.ServiceProvider.GetRequiredService<PrimaryWidgetContext>();
+        var secondary = scope.ServiceProvider.GetRequiredService<SecondaryWidgetContext>();
+
+        var primaryCluster = await primary.GetService<IClusterProvider>().GetClusterAsync();
+        var secondaryCluster = await secondary.GetService<IClusterProvider>().GetClusterAsync();
+
+        Assert.Same(appCluster, primaryCluster);
+        Assert.Same(appCluster, secondaryCluster);
+    }
+
+    [Fact]
+    public async Task ServiceKey_BindsEachContextToItsKeyedCluster()
+    {
+        // Multiple physical clusters: each context selects its cluster by ServiceKey, and contexts
+        // with different keys resolve distinct ICluster instances.
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddKeyedCouchbase("clusterA", o =>
+        {
+            o.ConnectionString = fixture.Host;
+            o.WithCredentials(fixture.Username, fixture.Password);
+        });
+        services.AddKeyedCouchbase("clusterB", o =>
+        {
+            o.ConnectionString = fixture.Host;
+            o.WithCredentials(fixture.Username, fixture.Password);
+        });
+        services.AddCouchbase<PrimaryWidgetContext>(NewClusterOptions(),
+            o => { ConfigureBucket(o, "default"); o.ServiceKey = "clusterA"; },
+            o => o.UseCamelCaseNamingConvention());
+        services.AddCouchbase<SecondaryWidgetContext>(NewClusterOptions(),
+            o => { ConfigureBucket(o, "secondary"); o.ServiceKey = "clusterB"; },
+            o => o.UseCamelCaseNamingConvention());
+
+        await using var provider = services.BuildServiceProvider();
+
+        var clusterA = await provider.GetRequiredKeyedService<IClusterProvider>("clusterA").GetClusterAsync();
+        var clusterB = await provider.GetRequiredKeyedService<IClusterProvider>("clusterB").GetClusterAsync();
+
+        using var scope = provider.CreateScope();
+        var primary = scope.ServiceProvider.GetRequiredService<PrimaryWidgetContext>();
+        var secondary = scope.ServiceProvider.GetRequiredService<SecondaryWidgetContext>();
+
+        Assert.Same(clusterA, await primary.GetService<IClusterProvider>().GetClusterAsync());
+        Assert.Same(clusterB, await secondary.GetService<IClusterProvider>().GetClusterAsync());
+        Assert.NotSame(clusterA, clusterB);
+    }
+
     private global::Couchbase.ClusterOptions NewClusterOptions()
         => new global::Couchbase.ClusterOptions()
             .WithConnectionString(fixture.Host)
             .WithCredentials(fixture.Username, fixture.Password);
 
-    private static void ConfigureBucket(ICouchbaseDbContextOptionsBuilder options, string bucket)
+    private static void ConfigureBucket(ICouchbaseDbContextOptionsBuilder options, string bucket, string scope = "isolation")
     {
         options.Bucket = bucket;
-        options.Scope = "isolation";
+        options.Scope = scope;
         // Read-after-write consistency so the FindAsync below sees the just-written document.
         options.ScanConsistency = global::Couchbase.Query.QueryScanConsistency.RequestPlus;
     }

--- a/tests/Couchbase.EntityFrameworkCore.UnitTests/Couchbase/EntityFrameworkCore/Infrastructure/CouchbaseOptionsExtensionInfoTests.cs
+++ b/tests/Couchbase.EntityFrameworkCore.UnitTests/Couchbase/EntityFrameworkCore/Infrastructure/CouchbaseOptionsExtensionInfoTests.cs
@@ -7,9 +7,9 @@ namespace Couchbase.EntityFrameworkCore.UnitTests.Couchbase.EntityFrameworkCore.
 
 /// <summary>
 /// Verifies that <c>CouchbaseOptionsExtensionInfo.ShouldUseSameServiceProvider</c> is consistent
-/// with <c>GetServiceProviderHashCode</c>. Both must key on (connection string, bucket, scope) so
-/// that contexts pointing at different buckets/clusters get their own internal service provider —
-/// each registers its own Couchbase cluster/bucket provider. (Multi-bucket DI, step 1.)
+/// with <c>GetServiceProviderHashCode</c>. Both must key on (connection string, bucket, scope,
+/// service key) so that contexts pointing at different buckets/clusters get their own internal
+/// service provider — each registers its own Couchbase cluster/bucket provider. (Multi-bucket DI, step 1.)
 /// </summary>
 public class CouchbaseOptionsExtensionInfoTests
 {
@@ -61,6 +61,29 @@ public class CouchbaseOptionsExtensionInfoTests
     {
         var a = Extension(connectionString: "couchbase://host-a").Info;
         var b = Extension(connectionString: "couchbase://host-b").Info;
+
+        Assert.False(a.ShouldUseSameServiceProvider(b));
+        Assert.NotEqual(a.GetServiceProviderHashCode(), b.GetServiceProviderHashCode());
+    }
+
+    [Fact]
+    public void DifferentServiceKey_DoesNotShare_AndDifferentHashCode()
+    {
+        var aBuilder = new CouchbaseDbContextOptionsBuilder(new DbContextOptionsBuilder(), "couchbase://localhost")
+        {
+            Bucket = "bucketA",
+            Scope = "scopeA",
+            ServiceKey = "clusterA"
+        };
+        var bBuilder = new CouchbaseDbContextOptionsBuilder(new DbContextOptionsBuilder(), "couchbase://localhost")
+        {
+            Bucket = "bucketA",
+            Scope = "scopeA",
+            ServiceKey = "clusterB"
+        };
+
+        var a = new CouchbaseOptionsExtension(aBuilder).Info;
+        var b = new CouchbaseOptionsExtension(bBuilder).Info;
 
         Assert.False(a.ShouldUseSameServiceProvider(b));
         Assert.NotEqual(a.GetServiceProviderHashCode(), b.GetServiceProviderHashCode());

--- a/tests/Couchbase.EntityFrameworkCore.UnitTests/Couchbase/EntityFrameworkCore/Infrastructure/CouchbaseOptionsExtensionInfoTests.cs
+++ b/tests/Couchbase.EntityFrameworkCore.UnitTests/Couchbase/EntityFrameworkCore/Infrastructure/CouchbaseOptionsExtensionInfoTests.cs
@@ -39,38 +39,39 @@ public class CouchbaseOptionsExtensionInfoTests
         Assert.Equal(a.GetServiceProviderHashCode(), b.GetServiceProviderHashCode());
     }
 
+    // The "Different…" tests assert only ShouldUseSameServiceProvider == false: that is the
+    // contract EF Core relies on to keep internal providers separate. Hash codes are not required
+    // to differ (collisions are permitted and disambiguated by ShouldUseSameServiceProvider), so
+    // asserting hash inequality would test a property that is not guaranteed even when correct.
     [Fact]
-    public void DifferentBucket_DoesNotShare_AndDifferentHashCode()
+    public void DifferentBucket_DoesNotShareServiceProvider()
     {
         var a = Extension(bucket: "bucketA").Info;
         var b = Extension(bucket: "bucketB").Info;
 
         Assert.False(a.ShouldUseSameServiceProvider(b));
-        Assert.NotEqual(a.GetServiceProviderHashCode(), b.GetServiceProviderHashCode());
     }
 
     [Fact]
-    public void DifferentScope_DoesNotShare_AndDifferentHashCode()
+    public void DifferentScope_DoesNotShareServiceProvider()
     {
         var a = Extension(scope: "scopeA").Info;
         var b = Extension(scope: "scopeB").Info;
 
         Assert.False(a.ShouldUseSameServiceProvider(b));
-        Assert.NotEqual(a.GetServiceProviderHashCode(), b.GetServiceProviderHashCode());
     }
 
     [Fact]
-    public void DifferentConnectionString_DoesNotShare_AndDifferentHashCode()
+    public void DifferentConnectionString_DoesNotShareServiceProvider()
     {
         var a = Extension(connectionString: "couchbase://host-a").Info;
         var b = Extension(connectionString: "couchbase://host-b").Info;
 
         Assert.False(a.ShouldUseSameServiceProvider(b));
-        Assert.NotEqual(a.GetServiceProviderHashCode(), b.GetServiceProviderHashCode());
     }
 
     [Fact]
-    public void DifferentServiceKey_DoesNotShare_AndDifferentHashCode()
+    public void DifferentServiceKey_DoesNotShareServiceProvider()
     {
         var aBuilder = new CouchbaseDbContextOptionsBuilder(new DbContextOptionsBuilder(), "couchbase://localhost")
         {
@@ -89,11 +90,10 @@ public class CouchbaseOptionsExtensionInfoTests
         var b = new CouchbaseOptionsExtension(bBuilder).Info;
 
         Assert.False(a.ShouldUseSameServiceProvider(b));
-        Assert.NotEqual(a.GetServiceProviderHashCode(), b.GetServiceProviderHashCode());
     }
 
     [Fact]
-    public void DifferentApplicationContainer_DoesNotShare_AndDifferentHashCode()
+    public void DifferentApplicationContainer_DoesNotShareServiceProvider()
     {
         // ApplyServices can bind a specific application container's shared cluster into the
         // (process-wide cached) internal provider, so two identical configurations in DIFFERENT
@@ -105,7 +105,6 @@ public class CouchbaseOptionsExtensionInfoTests
         var b = ExtensionWithApplicationProvider(containerB).Info;
 
         Assert.False(a.ShouldUseSameServiceProvider(b));
-        Assert.NotEqual(a.GetServiceProviderHashCode(), b.GetServiceProviderHashCode());
     }
 
     [Fact]

--- a/tests/Couchbase.EntityFrameworkCore.UnitTests/Couchbase/EntityFrameworkCore/Infrastructure/CouchbaseOptionsExtensionInfoTests.cs
+++ b/tests/Couchbase.EntityFrameworkCore.UnitTests/Couchbase/EntityFrameworkCore/Infrastructure/CouchbaseOptionsExtensionInfoTests.cs
@@ -1,0 +1,68 @@
+using Couchbase.EntityFrameworkCore.Infrastructure;
+using Couchbase.EntityFrameworkCore.Infrastructure.Internal;
+using Microsoft.EntityFrameworkCore;
+using Xunit;
+
+namespace Couchbase.EntityFrameworkCore.UnitTests.Couchbase.EntityFrameworkCore.Infrastructure;
+
+/// <summary>
+/// Verifies that <c>CouchbaseOptionsExtensionInfo.ShouldUseSameServiceProvider</c> is consistent
+/// with <c>GetServiceProviderHashCode</c>. Both must key on (connection string, bucket, scope) so
+/// that contexts pointing at different buckets/clusters get their own internal service provider —
+/// each registers its own Couchbase cluster/bucket provider. (Multi-bucket DI, step 1.)
+/// </summary>
+public class CouchbaseOptionsExtensionInfoTests
+{
+    private static CouchbaseOptionsExtension Extension(
+        string connectionString = "couchbase://localhost",
+        string bucket = "bucketA",
+        string scope = "scopeA")
+    {
+        var builder = new CouchbaseDbContextOptionsBuilder(new DbContextOptionsBuilder(), connectionString)
+        {
+            Bucket = bucket,
+            Scope = scope
+        };
+        return new CouchbaseOptionsExtension(builder);
+    }
+
+    [Fact]
+    public void SameConfig_SharesServiceProvider_AndSameHashCode()
+    {
+        var a = Extension().Info;
+        var b = Extension().Info;
+
+        Assert.True(a.ShouldUseSameServiceProvider(b));
+        Assert.Equal(a.GetServiceProviderHashCode(), b.GetServiceProviderHashCode());
+    }
+
+    [Fact]
+    public void DifferentBucket_DoesNotShare_AndDifferentHashCode()
+    {
+        var a = Extension(bucket: "bucketA").Info;
+        var b = Extension(bucket: "bucketB").Info;
+
+        Assert.False(a.ShouldUseSameServiceProvider(b));
+        Assert.NotEqual(a.GetServiceProviderHashCode(), b.GetServiceProviderHashCode());
+    }
+
+    [Fact]
+    public void DifferentScope_DoesNotShare_AndDifferentHashCode()
+    {
+        var a = Extension(scope: "scopeA").Info;
+        var b = Extension(scope: "scopeB").Info;
+
+        Assert.False(a.ShouldUseSameServiceProvider(b));
+        Assert.NotEqual(a.GetServiceProviderHashCode(), b.GetServiceProviderHashCode());
+    }
+
+    [Fact]
+    public void DifferentConnectionString_DoesNotShare_AndDifferentHashCode()
+    {
+        var a = Extension(connectionString: "couchbase://host-a").Info;
+        var b = Extension(connectionString: "couchbase://host-b").Info;
+
+        Assert.False(a.ShouldUseSameServiceProvider(b));
+        Assert.NotEqual(a.GetServiceProviderHashCode(), b.GetServiceProviderHashCode());
+    }
+}

--- a/tests/Couchbase.EntityFrameworkCore.UnitTests/Couchbase/EntityFrameworkCore/Infrastructure/CouchbaseOptionsExtensionInfoTests.cs
+++ b/tests/Couchbase.EntityFrameworkCore.UnitTests/Couchbase/EntityFrameworkCore/Infrastructure/CouchbaseOptionsExtensionInfoTests.cs
@@ -1,6 +1,8 @@
+using System;
 using Couchbase.EntityFrameworkCore.Infrastructure;
 using Couchbase.EntityFrameworkCore.Infrastructure.Internal;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
 using Xunit;
 
 namespace Couchbase.EntityFrameworkCore.UnitTests.Couchbase.EntityFrameworkCore.Infrastructure;
@@ -8,8 +10,9 @@ namespace Couchbase.EntityFrameworkCore.UnitTests.Couchbase.EntityFrameworkCore.
 /// <summary>
 /// Verifies that <c>CouchbaseOptionsExtensionInfo.ShouldUseSameServiceProvider</c> is consistent
 /// with <c>GetServiceProviderHashCode</c>. Both must key on (connection string, bucket, scope,
-/// service key) so that contexts pointing at different buckets/clusters get their own internal
-/// service provider — each registers its own Couchbase cluster/bucket provider. (Multi-bucket DI, step 1.)
+/// service key, and application container) so that contexts pointing at different buckets/clusters
+/// — or registered in different DI containers — get their own internal service provider, each
+/// registering its own Couchbase cluster/bucket provider. (Multi-bucket DI.)
 /// </summary>
 public class CouchbaseOptionsExtensionInfoTests
 {
@@ -87,5 +90,44 @@ public class CouchbaseOptionsExtensionInfoTests
 
         Assert.False(a.ShouldUseSameServiceProvider(b));
         Assert.NotEqual(a.GetServiceProviderHashCode(), b.GetServiceProviderHashCode());
+    }
+
+    [Fact]
+    public void DifferentApplicationContainer_DoesNotShare_AndDifferentHashCode()
+    {
+        // ApplyServices can bind a specific application container's shared cluster into the
+        // (process-wide cached) internal provider, so two identical configurations in DIFFERENT
+        // containers must not share an internal provider.
+        using var containerA = new ServiceCollection().BuildServiceProvider();
+        using var containerB = new ServiceCollection().BuildServiceProvider();
+
+        var a = ExtensionWithApplicationProvider(containerA).Info;
+        var b = ExtensionWithApplicationProvider(containerB).Info;
+
+        Assert.False(a.ShouldUseSameServiceProvider(b));
+        Assert.NotEqual(a.GetServiceProviderHashCode(), b.GetServiceProviderHashCode());
+    }
+
+    [Fact]
+    public void SameApplicationContainer_Shares_AndSameHashCode()
+    {
+        using var container = new ServiceCollection().BuildServiceProvider();
+
+        var a = ExtensionWithApplicationProvider(container).Info;
+        var b = ExtensionWithApplicationProvider(container).Info;
+
+        Assert.True(a.ShouldUseSameServiceProvider(b));
+        Assert.Equal(a.GetServiceProviderHashCode(), b.GetServiceProviderHashCode());
+    }
+
+    private static CouchbaseOptionsExtension ExtensionWithApplicationProvider(IServiceProvider applicationServiceProvider)
+    {
+        var builder = new CouchbaseDbContextOptionsBuilder(new DbContextOptionsBuilder(), "couchbase://localhost")
+        {
+            Bucket = "bucketA",
+            Scope = "scopeA",
+            ApplicationServiceProvider = applicationServiceProvider
+        };
+        return new CouchbaseOptionsExtension(builder);
     }
 }


### PR DESCRIPTION
## Summary

Adds first-class support for using the provider with **multiple buckets and multiple
Couchbase Server clusters** — one `DbContext` per bucket, reusing a single shared `Cluster`
per server (per Couchbase guidance) rather than each context opening its own. Targets
`2.0.0-beta.2`.

## Multiple buckets & clusters

- A `DbContext` registered via `AddCouchbase<TContext>` binds to an **application-registered
  shared `IClusterProvider`** when one exists in DI, so a single `Cluster` is reused across
  contexts and buckets. Falls back to the previous per-context cluster ownership when no
  application cluster is registered (non-breaking for existing single-bucket apps).
- New `CouchbaseDbContextOptionsBuilder.ServiceKey` selects among multiple clusters
  (registered with `AddKeyedCouchbase`) for applications that talk to more than one server.
- Implemented by capturing the application service provider in `AddCouchbase<TContext>` and
  resolving/overriding the cluster in `CouchbaseOptionsExtension.ApplyServices`, using a
  non-owning wrapper so EF's internal provider doesn't dispose the application-owned cluster.
  No changes to data-path consumers.

## Service-provider caching correctness

- `ShouldUseSameServiceProvider` now matches `GetServiceProviderHashCode` (connection string,
  bucket, scope, **service key**) — previously it returned `true` for any Couchbase context.
- The cache key also includes a stable **per-application-container identity** (the root
  `IServiceScopeFactory`, captured eagerly), so contexts in different DI containers can't share
  an internal provider bound to the wrong or disposed cluster.

## API

- `UseCouchbase(ClusterOptions, …)` split into two overloads so the original three-parameter
  binary signature is preserved.

## Docs

- New **"Multiple buckets and clusters"** section in `configuration.md`.
- `limitations.md` notes the one-context-per-bucket boundary and corrects the value-generation
  numeric-types wording.
- `CHANGELOG.md` entry under `2.0.0-beta.2`.

## Testing

- **Unit:** 816 passing — includes new `CouchbaseOptionsExtensionInfoTests` covering
  cache-key consistency across bucket, scope, connection string, service key, and container.
- **Integration** (live Couchbase via Aspire): 240 passing, 4 skipped — new coverage for
  multi-bucket isolation, keyed multi-cluster selection, and shared-cluster reuse.