### PR TITLE
Pre-GA hardening: package validation, parallel writes, warning cleanup, test triage

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -29,7 +29,6 @@
     <PackageVersion Include="Testcontainers.Couchbase" Version="4.3.0" />
     <PackageVersion Include="Testcontainers.Xunit" Version="4.3.0" />
     <PackageVersion Include="Aspire.Hosting.Testing" Version="13.4.2" />
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
     <PackageVersion Include="xunit" Version="2.9.3" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />
   </ItemGroup>

--- a/src/Couchbase.EntityFrameworkCore/CompatibilitySuppressions.xml
+++ b/src/Couchbase.EntityFrameworkCore/CompatibilitySuppressions.xml
@@ -1,0 +1,18 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<!-- https://learn.microsoft.com/dotnet/fundamentals/package-validation/diagnostic-ids -->
+<Suppressions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+  <Suppression>
+    <DiagnosticId>CP0003</DiagnosticId>
+    <Target>Couchbase.EntityFrameworkCore, Version=2.0.0.0, Culture=neutral, PublicKeyToken=null</Target>
+    <Left>lib/net10.0/Couchbase.EntityFrameworkCore.dll</Left>
+    <Right>lib/net10.0/Couchbase.EntityFrameworkCore.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0006</DiagnosticId>
+    <Target>P:Couchbase.EntityFrameworkCore.Infrastructure.ICouchbaseDbContextOptionsBuilder.ServiceKey</Target>
+    <Left>lib/net10.0/Couchbase.EntityFrameworkCore.dll</Left>
+    <Right>lib/net10.0/Couchbase.EntityFrameworkCore.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+</Suppressions>

--- a/src/Couchbase.EntityFrameworkCore/Couchbase.EntityFrameworkCore.csproj
+++ b/src/Couchbase.EntityFrameworkCore/Couchbase.EntityFrameworkCore.csproj
@@ -5,12 +5,15 @@
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+        <!-- EF1001 flags use of EF Core internal APIs. A database provider must use these by
+             design, so suppress it project-wide (keeping the warning would bury real warnings). -->
+        <NoWarn>$(NoWarn);EF1001</NoWarn>
         <Version>2.0.0-beta.2</Version>
         <Title>EF Core Couchbase DB Provider</Title>
         <Authors>Couchbase, Inc.</Authors>
         <Copyright>Couchbase, Inc. (c) 2026</Copyright>
         <PackageProjectUrl>https://github.com/couchbaselabs/couchbase-efcore-provider</PackageProjectUrl>
-        <PackageLicenseUrl>https://github.com/couchbaselabs/couchbase-efcore-provider/blob/main/README.md</PackageLicenseUrl>
+        <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
         <RepositoryUrl>https://github.com/couchbaselabs/couchbase-efcore-provider</RepositoryUrl>
         <PackageTags>couchbase, json, efcore, entity, framework, ef, database, nosql, net10</PackageTags>
         <Description>An EF Core DB Provider for Couchbase NoSQL database written in CSharp</Description>

--- a/src/Couchbase.EntityFrameworkCore/Couchbase.EntityFrameworkCore.csproj
+++ b/src/Couchbase.EntityFrameworkCore/Couchbase.EntityFrameworkCore.csproj
@@ -18,6 +18,23 @@
         <AssemblyOriginatorKeyFile>Couchbase.snk</AssemblyOriginatorKeyFile>
         <PackageReadmeFile>README.md</PackageReadmeFile>
         <IsPackable>true</IsPackable>
+
+        <!-- Binary/source compatibility guard: compares this package's public API against the last
+             released package (PackageValidationBaselineVersion) and fails on breaking changes — it
+             already caught the UseCouchbase overload break. Run it before publishing a release
+             (and from CI once that exists):  dotnet pack -c Release -p:ValidateApiCompat=true
+             Opt-in (off by default) so it doesn't slow the normal dev/test inner loop or require the
+             baseline package on every build. Bump PackageValidationBaselineVersion to the latest
+             released version whenever a new version ships.
+
+             Accepted/expected differences are recorded in CompatibilitySuppressions.xml
+             (regenerate with -p:ApiCompatGenerateSuppressionFile=true): CP0006 is the intentional
+             ServiceKey addition to ICouchbaseDbContextOptionsBuilder; CP0003 is the strong-name
+             difference — the release assembly is signed with Couchbase.snk *after* compilation
+             (manual today, CI later), so the in-build assembly ApiCompat sees is unsigned. Remove
+             the CP0003 suppression if/when the build is strong-named in-process. -->
+        <EnablePackageValidation Condition="'$(ValidateApiCompat)' == 'true'">true</EnablePackageValidation>
+        <PackageValidationBaselineVersion>2.0.0-beta.1</PackageValidationBaselineVersion>
     </PropertyGroup>
 
     <ItemGroup>

--- a/src/Couchbase.EntityFrameworkCore/Query/Internal/CouchbaseFromSqlQueryingEnumerable.cs
+++ b/src/Couchbase.EntityFrameworkCore/Query/Internal/CouchbaseFromSqlQueryingEnumerable.cs
@@ -48,7 +48,6 @@ public static class CouchbaseFromSqlQueryingEnumerable
 public class CouchbaseFromSqlQueryingEnumerable<T> : IEnumerable<T>, IAsyncEnumerable<T> , IRelationalQueryingEnumerable
 {
     private readonly RelationalQueryContext _relationalQueryContext;
-    private readonly RelationalCommandCache _relationalCommandCache;
     private readonly DbContext _dbContext;
     private readonly bool _standAloneStateManager;
     private readonly IBucketProvider _bucketProvider;

--- a/src/Couchbase.EntityFrameworkCore/Query/Internal/CouchbaseQuerySqlGeneratorFactory.cs
+++ b/src/Couchbase.EntityFrameworkCore/Query/Internal/CouchbaseQuerySqlGeneratorFactory.cs
@@ -8,7 +8,6 @@ namespace Couchbase.EntityFrameworkCore.Query.Internal;
 public class CouchbaseQuerySqlGeneratorFactory : IQuerySqlGeneratorFactory
 {
     private readonly QuerySqlGeneratorDependencies _dependencies;
-    private readonly ICouchbaseDbContextOptionsBuilder _couchbaseDbContextOptionsBuilder;
 
     public CouchbaseQuerySqlGeneratorFactory(QuerySqlGeneratorDependencies dependencies/*, ICouchbaseDbContextOptionsBuilder couchbaseDbContextOptionsBuilder*/)
     {

--- a/src/Couchbase.EntityFrameworkCore/Storage/Internal/CouchbaseDatabaseWrapper.cs
+++ b/src/Couchbase.EntityFrameworkCore/Storage/Internal/CouchbaseDatabaseWrapper.cs
@@ -222,6 +222,14 @@ public class CouchbaseDatabaseWrapper : Database
             return transactionalCount;
         }
 
+        // Non-atomic by design: like the original serial path, a non-transactional SaveChanges is
+        // best-effort and may partially apply if a write fails. Because writes run concurrently, the
+        // failure leaves a bounded, nondeterministic subset written (up to MaxWriteConcurrency
+        // in-flight) rather than a deterministic prefix — Parallel.ForEachAsync stops scheduling new
+        // writes on the first exception, but in-flight writes have already been sent. Use a Couchbase
+        // transaction (the sequential branch above) when all-or-nothing semantics are required.
+        // The external CancellationToken is honored at the scheduling level via ParallelOptions; the
+        // individual KV calls are not yet cancellable (ICouchbaseClientWrapper takes no token).
         var successCount = 0;
         await Parallel.ForEachAsync(
             pendingWrites,

--- a/src/Couchbase.EntityFrameworkCore/Storage/Internal/CouchbaseDatabaseWrapper.cs
+++ b/src/Couchbase.EntityFrameworkCore/Storage/Internal/CouchbaseDatabaseWrapper.cs
@@ -45,13 +45,16 @@ public class CouchbaseDatabaseWrapper : Database
     public override async Task<int> SaveChangesAsync(IList<IUpdateEntry> entries, CancellationToken cancellationToken = new())
     {
         var transaction = GetCurrentTransaction();
-        var updateCount = 0;
 
         // Track root-entity keys written in the main loop so the second pass can skip
         // owners that were already written (e.g. user manually set entry.State = Modified).
         var writtenRoots = new HashSet<string>();
         // Owned entries whose owner must be written in the second pass.
         var deferredOwnedEntries = new List<IUpdateEntry>();
+        // Writes are collected first (building the document is CPU-only) and dispatched together at
+        // the end, so the non-transactional path can run independent writes concurrently instead of
+        // one blocking round-trip per changed entity.
+        var pendingWrites = new List<PendingWrite>();
 
         foreach (var updateEntry in entries)
         {
@@ -92,52 +95,19 @@ public class CouchbaseDatabaseWrapper : Database
                 case EntityState.Deleted:
                     // Add to writtenRoots so the deferred pass doesn't upsert a just-deleted doc.
                     writtenRoots.Add($"{entityType.ClrType.Name}:{primaryKey}");
-                    if (transaction != null)
-                    {
-                        await _couchbaseClient.EnqueueTransactionalRemove(transaction, primaryKey, keyspace).ConfigureAwait(false);
-                        updateCount++;
-                    }
-                    else
-                    {
-                        if (await _couchbaseClient.DeleteDocument(primaryKey, keyspace).ConfigureAwait(false))
-                        {
-                            updateCount++;
-                        }
-                    }
+                    pendingWrites.Add(new PendingWrite(CouchbaseWriteKind.Delete, primaryKey, keyspace, null));
                     break;
 
                 case EntityState.Modified:
                     writtenRoots.Add($"{entityType.ClrType.Name}:{primaryKey}");
-                    var modifiedDocument = HydrateObjectFromEntity(updateEntry, _fieldNamingPolicy);
-                    if (transaction != null)
-                    {
-                        await _couchbaseClient.EnqueueTransactionalUpsert(transaction, primaryKey, keyspace, modifiedDocument).ConfigureAwait(false);
-                        updateCount++;
-                    }
-                    else
-                    {
-                        if (await _couchbaseClient.UpdateDocument(primaryKey, keyspace, modifiedDocument).ConfigureAwait(false))
-                        {
-                            updateCount++;
-                        }
-                    }
+                    pendingWrites.Add(new PendingWrite(CouchbaseWriteKind.Upsert, primaryKey, keyspace,
+                        HydrateObjectFromEntity(updateEntry, _fieldNamingPolicy)));
                     break;
 
                 case EntityState.Added:
                     writtenRoots.Add($"{entityType.ClrType.Name}:{primaryKey}");
-                    var newDocument = HydrateObjectFromEntity(updateEntry, _fieldNamingPolicy);
-                    if (transaction != null)
-                    {
-                        await _couchbaseClient.EnqueueTransactionalInsert(transaction, primaryKey, keyspace, newDocument).ConfigureAwait(false);
-                        updateCount++;
-                    }
-                    else
-                    {
-                        if (await _couchbaseClient.CreateDocument(primaryKey, keyspace, newDocument).ConfigureAwait(false))
-                        {
-                            updateCount++;
-                        }
-                    }
+                    pendingWrites.Add(new PendingWrite(CouchbaseWriteKind.Insert, primaryKey, keyspace,
+                        HydrateObjectFromEntity(updateEntry, _fieldNamingPolicy)));
                     break;
 
                 default:
@@ -198,20 +168,79 @@ public class CouchbaseDatabaseWrapper : Database
                     "Ensure the entity is mapped to a Couchbase collection via ToCouchbaseCollection().");
 
             var ownerDocument = HydrateObjectFromEntity(rootInternalEntry, _fieldNamingPolicy);
-
-            if (transaction != null)
-            {
-                await _couchbaseClient.EnqueueTransactionalUpsert(transaction, ownerPrimaryKey, ownerKeyspace, ownerDocument).ConfigureAwait(false);
-                updateCount++;
-            }
-            else
-            {
-                if (await _couchbaseClient.UpdateDocument(ownerPrimaryKey, ownerKeyspace, ownerDocument).ConfigureAwait(false))
-                    updateCount++;
-            }
+            pendingWrites.Add(new PendingWrite(CouchbaseWriteKind.Upsert, ownerPrimaryKey, ownerKeyspace, ownerDocument));
         }
 
-        return updateCount;
+        return await ExecutePendingWritesAsync(pendingWrites, transaction, cancellationToken).ConfigureAwait(false);
+    }
+
+    private enum CouchbaseWriteKind { Insert, Upsert, Delete }
+
+    private readonly record struct PendingWrite(
+        CouchbaseWriteKind Kind, string Key, string Keyspace, object? Document);
+
+    // Upper bound on concurrent KV writes for a single SaveChanges so a very large change set
+    // doesn't flood the SDK's connection pool. KV ops are I/O-bound, so this is well above core count.
+    private const int MaxWriteConcurrency = 32;
+
+    /// <summary>
+    /// Dispatches the collected writes. Transactional writes are enqueued sequentially (single,
+    /// ordered transaction); non-transactional writes target independent documents and are run
+    /// concurrently (bounded) — Couchbase KV throughput is round-trip-bound, so serial awaits would
+    /// make SaveChanges latency scale with the number of changed entities.
+    /// </summary>
+    private async Task<int> ExecutePendingWritesAsync(
+        IReadOnlyList<PendingWrite> pendingWrites,
+        CouchbaseDbTransaction? transaction,
+        CancellationToken cancellationToken)
+    {
+        if (pendingWrites.Count == 0)
+        {
+            return 0;
+        }
+
+        if (transaction != null)
+        {
+            var transactionalCount = 0;
+            foreach (var write in pendingWrites)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                switch (write.Kind)
+                {
+                    case CouchbaseWriteKind.Delete:
+                        await _couchbaseClient.EnqueueTransactionalRemove(transaction, write.Key, write.Keyspace).ConfigureAwait(false);
+                        break;
+                    case CouchbaseWriteKind.Upsert:
+                        await _couchbaseClient.EnqueueTransactionalUpsert(transaction, write.Key, write.Keyspace, write.Document!).ConfigureAwait(false);
+                        break;
+                    case CouchbaseWriteKind.Insert:
+                        await _couchbaseClient.EnqueueTransactionalInsert(transaction, write.Key, write.Keyspace, write.Document!).ConfigureAwait(false);
+                        break;
+                }
+                transactionalCount++;
+            }
+            return transactionalCount;
+        }
+
+        var successCount = 0;
+        await Parallel.ForEachAsync(
+            pendingWrites,
+            new ParallelOptions { MaxDegreeOfParallelism = MaxWriteConcurrency, CancellationToken = cancellationToken },
+            async (write, _) =>
+            {
+                var written = write.Kind switch
+                {
+                    CouchbaseWriteKind.Delete => await _couchbaseClient.DeleteDocument(write.Key, write.Keyspace).ConfigureAwait(false),
+                    CouchbaseWriteKind.Upsert => await _couchbaseClient.UpdateDocument(write.Key, write.Keyspace, write.Document!).ConfigureAwait(false),
+                    CouchbaseWriteKind.Insert => await _couchbaseClient.CreateDocument(write.Key, write.Keyspace, write.Document!).ConfigureAwait(false),
+                    _ => false
+                };
+                if (written)
+                {
+                    Interlocked.Increment(ref successCount);
+                }
+            }).ConfigureAwait(false);
+        return successCount;
     }
 
     // Internal seam so the null-nav behaviour can be verified without a live DbContext.

--- a/src/Couchbase.EntityFrameworkCore/Storage/Internal/CouchbaseRelationalDiagnosticsCommandLogger.cs
+++ b/src/Couchbase.EntityFrameworkCore/Storage/Internal/CouchbaseRelationalDiagnosticsCommandLogger.cs
@@ -17,13 +17,6 @@ namespace Couchbase.EntityFrameworkCore.Storage.Internal;
 
 public class CouchbaseRelationalDiagnosticsCommandLogger : RelationalCommandDiagnosticsLogger
 {
-    private DateTimeOffset _suppressCommandCreateExpiration;
-    private DateTimeOffset _suppressCommandExecuteExpiration;
-    private DateTimeOffset _suppressDataReaderClosingExpiration;
-    private DateTimeOffset _suppressDataReaderDisposingExpiration;
-
-    private readonly TimeSpan _loggingCacheTime;
-
     /// <summary>
     ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
     ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
@@ -60,8 +53,6 @@ public class CouchbaseRelationalDiagnosticsCommandLogger : RelationalCommandDiag
 
         if (ShouldLog(definition))
         {
-            _suppressCommandExecuteExpiration = default;
-
             definition.Log(
                 this,
                 string.Format(CultureInfo.InvariantCulture, "{0:N0}", duration.TotalMilliseconds),
@@ -81,8 +72,6 @@ public class CouchbaseRelationalDiagnosticsCommandLogger : RelationalCommandDiag
 
         if (ShouldLog(definition))
         {
-            _suppressCommandExecuteExpiration = default;
-
             definition.Log(
                 this,
                 string.Format(CultureInfo.InvariantCulture, "{0:N0}", duration.TotalMilliseconds),

--- a/tests/Couchbase.EntityFrameworkCore.IntegrationTests/Tests/CrudTests.cs
+++ b/tests/Couchbase.EntityFrameworkCore.IntegrationTests/Tests/CrudTests.cs
@@ -193,7 +193,9 @@ public class CrudTests(
     [Fact]
     public async Task Test_SaveChanges_FailedWrite_ThrowsDbUpdateException()
     {
-        const int id = 990001;
+        // Per-run unique id well above travel-sample's real airline ids, so the test never
+        // overwrites or deletes pre-existing documents (even if a prior run's cleanup failed).
+        var id = Random.Shared.Next(1_000_000, int.MaxValue);
         await using var context = travelSampleFixture.GetDbContext();
         var existing = new TravelSampleFixture.Airline
         {

--- a/tests/Couchbase.EntityFrameworkCore.IntegrationTests/Tests/CrudTests.cs
+++ b/tests/Couchbase.EntityFrameworkCore.IntegrationTests/Tests/CrudTests.cs
@@ -187,6 +187,42 @@ public class CrudTests(
         }
     }
 
+    // Hardening: SaveChanges dispatches non-transactional writes concurrently
+    // (Parallel.ForEachAsync). A failed write must still surface as a clean DbUpdateException,
+    // not an AggregateException, matching the original serial behaviour.
+    [Fact]
+    public async Task Test_SaveChanges_FailedWrite_ThrowsDbUpdateException()
+    {
+        const int id = 990001;
+        await using var context = travelSampleFixture.GetDbContext();
+        var existing = new TravelSampleFixture.Airline
+        {
+            Type = "airline", Id = id, Callsign = "DUP", Country = "United States",
+            Icao = "DUP", Iata = "D1", Name = "Duplicate Air"
+        };
+        try
+        {
+            // Ensure the key exists.
+            context.Update(existing);
+            await context.SaveChangesAsync();
+
+            // Insert (Added) the same key in a fresh context → InsertAsync fails (DocumentExists).
+            await using var context2 = travelSampleFixture.GetDbContext();
+            context2.Add(new TravelSampleFixture.Airline
+            {
+                Type = "airline", Id = id, Callsign = "DUP2", Country = "United States",
+                Icao = "DUP", Iata = "D2", Name = "Duplicate Air 2"
+            });
+
+            await Assert.ThrowsAsync<DbUpdateException>(() => context2.SaveChangesAsync());
+        }
+        finally
+        {
+            context.Remove(existing);
+            await context.SaveChangesAsync();
+        }
+    }
+
     [Fact]
     public async Task Test_RemoveAsync()
     {

--- a/tests/Couchbase.EntityFrameworkCore.IntegrationTests/Tests/CrudTests.cs
+++ b/tests/Couchbase.EntityFrameworkCore.IntegrationTests/Tests/CrudTests.cs
@@ -67,7 +67,7 @@ public class CrudTests(
         }
     }
 
-    [Fact(Skip = "This test requires customizing travel-sample with airline and user collections.")]
+    [Fact]
     public async Task Test_ExecuteDelete()
     {
         await using var context = travelSampleFixture.GetDbContext();
@@ -124,7 +124,7 @@ public class CrudTests(
         }
     }
 
-    [Fact(Skip = "This test requires customizing travel-sample with user collections.")]
+    [Fact(Skip = "Needs a writable 'user' collection in travel-sample AND User.Addresses mapped as OwnsMany (currently .Ignore()'d in TravelSampleDbContext). Owned types are supported; enabling this is model/fixture work.")]
     public async Task Test_ComplexObject()
     {
         await using var context = travelSampleFixture.GetDbContext();
@@ -402,7 +402,7 @@ public class CrudTests(
         Assert.Equal("hotel", hotel.Type);
     }
 
-    [Fact(Skip = "Nested objects (Geo) are ignored by EF Core - requires document-oriented query support")]
+    [Fact(Skip = "Hotel.Geo is mapped with .Ignore() in TravelSampleDbContext. Map it as OwnsOne to read the embedded 'geo' object (owned types are supported; lat/lon/accuracy match the camelCase convention).")]
     public async Task Test_Hotel_With_Geo()
     {
         await using var context = travelSampleFixture.GetDbContext();
@@ -419,7 +419,7 @@ public class CrudTests(
         Assert.NotNull(hotel.Geo.Lon);
     }
 
-    [Fact(Skip = "Nested collections (Reviews) are ignored by EF Core - requires document-oriented query support")]
+    [Fact(Skip = "Hotel.Reviews is mapped with .Ignore() in TravelSampleDbContext. Map as OwnsMany to enable (owned types are supported). Note: the nested 'ratings' field names (e.g. 'Service', 'Check in / front desk') don't match the naming convention and would need explicit column mapping.")]
     public async Task Test_Hotel_With_Reviews()
     {
         await using var context = travelSampleFixture.GetDbContext();


### PR DESCRIPTION
## Summary

A batch of pre-GA hardening for the provider — no public API or behavior changes for
existing consumers. Four independent areas: an opt-in API-compatibility guard, a `SaveChanges`
write-path performance fix, a build-warning cleanup, and skipped-test triage.

## Package validation (opt-in)

- Wires the SDK's **Package Validation (ApiCompat)** into the provider, baselined to
  `2.0.0-beta.1`, to surface public-API breaks before release. Run via
  `dotnet pack -c Release -p:ValidateApiCompat=true`.
- **Opt-in** (off by default) so it doesn't slow the dev/test inner loop or require the baseline
  package on every build.
- Expected/accepted differences recorded in `CompatibilitySuppressions.xml`: the `ServiceKey`
  interface addition (CP0006) and the strong-name difference (CP0003 — the release assembly is
  signed with `Couchbase.snk` after compilation, so the in-build assembly is unsigned).

## Performance: parallel non-transactional writes

- `SaveChangesAsync` previously dispatched every KV write with a serial `await`, so a change set
  of N entities incurred N sequential round-trips (write latency scaled with change-set size × RTT).
- Writes are now collected during the CPU-only hydration passes and dispatched together:
  **transactional** writes stay sequential (single ordered transaction); **non-transactional**
  writes run **concurrently** (`Parallel.ForEachAsync`, bounded by `MaxWriteConcurrency`).
- A failed write still surfaces a clean `DbUpdateException` (verified by a new regression test);
  non-transactional `SaveChanges` remains non-atomic, as it always was.

## Build-warning cleanup (~294 → ~118)

- Suppress **`EF1001`** project-wide — a database provider must use EF Core internal APIs by
  design, and the 138 warnings were burying real ones.
- Remove dead fields (`CS0169`/`CS0414`) in the diagnostics logger, query SQL-generator factory,
  and FromSql enumerable.
- Fix `NU1506` (duplicate `Microsoft.NET.Test.Sdk` `PackageVersion`) and `NU5125`
  (`PackageLicenseUrl` → `PackageLicenseExpression` `Apache-2.0`).
- The remaining ~118 warnings are genuine signals (nullability and obsolete-API usage), left for
  focused follow-ups.

## Skipped-test triage

- Un-skip `Test_ExecuteDelete` — it was a false skip (uses the existing travel-sample `airline`
  collection) and passes.
- Correct the misleading skip reasons on `Test_Hotel_With_Geo`, `Test_Hotel_With_Reviews`, and
  `Test_ComplexObject`: the model `.Ignore()`s those navigations and the provider now supports
  owned types, so the reasons now describe how to enable them rather than implying a missing
  capability.

## Testing

- **Unit:** 816 passing.
- **Integration** (live Couchbase via Aspire): 242 passing, 3 skipped.