### PR TITLE
Migrate off obsolete EF Core and Couchbase SDK APIs

### DIFF
--- a/src/Couchbase.EntityFrameworkCore/Infrastructure/Internal/CouchbaseOptionsExtension.cs
+++ b/src/Couchbase.EntityFrameworkCore/Infrastructure/Internal/CouchbaseOptionsExtension.cs
@@ -53,13 +53,23 @@ public class CouchbaseOptionsExtension: RelationalOptionsExtension
                 options.WithSerializer(existingSerializer);
             }
 
-            if (_couchbaseDbContextOptionsBuilder.ClusterOptions.Authenticator == null)
+            if (_couchbaseDbContextOptionsBuilder.ClusterOptions.Authenticator != null)
             {
-                options.WithCredentials(_couchbaseDbContextOptionsBuilder.ClusterOptions.UserName, _couchbaseDbContextOptionsBuilder.ClusterOptions.Password);
+                options.WithAuthenticator(_couchbaseDbContextOptionsBuilder.ClusterOptions.Authenticator);
             }
             else
             {
-                options.WithAuthenticator(_couchbaseDbContextOptionsBuilder.ClusterOptions.Authenticator);
+                // No Authenticator was set, so the source ClusterOptions carries legacy
+                // username/password. Forward them via the supported WithPasswordAuthentication
+                // (equivalent to the obsolete WithCredentials). Reading UserName/Password is itself
+                // obsolete in the SDK and has no non-obsolete equivalent for legacy configs, so
+                // suppress locally — once the SDK removes those members this stops compiling and
+                // forces Authenticator-based configuration.
+#pragma warning disable CS0618 // Type or member is obsolete
+                options.WithPasswordAuthentication(
+                    _couchbaseDbContextOptionsBuilder.ClusterOptions.UserName,
+                    _couchbaseDbContextOptionsBuilder.ClusterOptions.Password);
+#pragma warning restore CS0618
             }
         });
 

--- a/src/Couchbase.EntityFrameworkCore/Query/Internal/CouchbaseQuerySqlGenerator.cs
+++ b/src/Couchbase.EntityFrameworkCore/Query/Internal/CouchbaseQuerySqlGenerator.cs
@@ -681,7 +681,7 @@ public class CouchbaseQuerySqlGenerator : QuerySqlGenerator
 
             Visit(
                 selectExpression.Limit
-                ?? new SqlConstantExpression(Expression.Constant(-1), selectExpression.Offset!.TypeMapping));
+                ?? new SqlConstantExpression(-1, selectExpression.Offset!.TypeMapping));
 
             if (selectExpression.Offset != null)
             {

--- a/src/Couchbase.EntityFrameworkCore/Storage/Internal/CouchbaseSaveChangesInterceptor.cs
+++ b/src/Couchbase.EntityFrameworkCore/Storage/Internal/CouchbaseSaveChangesInterceptor.cs
@@ -155,10 +155,9 @@ public class CouchbaseSaveChangesInterceptor : SaveChangesInterceptor
                     }
                 }
 
-                // Get the value generator from the selector
-                var generator = selector.Select(property, entityType);
-
-                if (generator == null)
+                // Get the value generator from the selector (throw if none — the documented
+                // replacement for the obsolete Select).
+                if (!selector.TrySelect(property, entityType, out var generator) || generator == null)
                 {
                     throw new InvalidOperationException(
                         $"Could not create value generator for property '{property.Name}' on entity '{entityType.ClrType.Name}'. " +

--- a/src/Couchbase.EntityFrameworkCore/ValueGeneration/CouchbaseValueGeneratorSelector.cs
+++ b/src/Couchbase.EntityFrameworkCore/ValueGeneration/CouchbaseValueGeneratorSelector.cs
@@ -59,47 +59,45 @@ public class CouchbaseValueGeneratorSelector : RelationalValueGeneratorSelector
     }
 
     /// <summary>
-    /// Selects a value generator for the given property.
+    /// Selects a value generator for the given property, preferring a Couchbase sequence or GUID
+    /// string generator when the corresponding annotation is present.
     /// </summary>
-    public override ValueGenerator? Select(IProperty property, ITypeBase typeBase)
-    {
-        // Check for sequence-based generation
-        var sequenceName = property.FindAnnotation(SequenceNameAnnotation)?.Value as string;
-        if (!string.IsNullOrEmpty(sequenceName))
-        {
-            return CreateSequenceValueGenerator(property, sequenceName);
-        }
-
-        // Check for GUID string generation
-        var guidStringFormat = property.FindAnnotation(GuidStringFormatAnnotation)?.Value as string;
-        if (guidStringFormat != null && property.ClrType == typeof(string))
-        {
-            return new CouchbaseGuidStringValueGenerator(guidStringFormat);
-        }
-
-        return base.Select(property, typeBase);
-    }
+    public override bool TrySelect(IProperty property, ITypeBase typeBase, out ValueGenerator? valueGenerator)
+        => TryCreateCouchbaseValueGenerator(property, out valueGenerator)
+            || base.TrySelect(property, typeBase, out valueGenerator);
 
     /// <summary>
-    /// Creates a value generator for the given property.
+    /// Creates a value generator for the given property, preferring a Couchbase sequence or GUID
+    /// string generator when the corresponding annotation is present.
     /// </summary>
-    public override ValueGenerator Create(IProperty property, ITypeBase typeBase)
+    public override bool TryCreate(IProperty property, ITypeBase typeBase, out ValueGenerator? valueGenerator)
+        => TryCreateCouchbaseValueGenerator(property, out valueGenerator)
+            || base.TryCreate(property, typeBase, out valueGenerator);
+
+    /// <summary>
+    /// Returns a Couchbase-specific value generator (sequence or GUID string) when the property is
+    /// annotated for one, otherwise <c>false</c> so the relational base can select a generator.
+    /// </summary>
+    private bool TryCreateCouchbaseValueGenerator(IProperty property, out ValueGenerator? valueGenerator)
     {
         // Check for sequence-based generation
         var sequenceName = property.FindAnnotation(SequenceNameAnnotation)?.Value as string;
         if (!string.IsNullOrEmpty(sequenceName))
         {
-            return CreateSequenceValueGenerator(property, sequenceName);
+            valueGenerator = CreateSequenceValueGenerator(property, sequenceName);
+            return true;
         }
 
         // Check for GUID string generation
         var guidStringFormat = property.FindAnnotation(GuidStringFormatAnnotation)?.Value as string;
         if (guidStringFormat != null && property.ClrType == typeof(string))
         {
-            return new CouchbaseGuidStringValueGenerator(guidStringFormat);
+            valueGenerator = new CouchbaseGuidStringValueGenerator(guidStringFormat);
+            return true;
         }
 
-        return base.Create(property, typeBase);
+        valueGenerator = null;
+        return false;
     }
 
     private ValueGenerator CreateSequenceValueGenerator(

--- a/tests/Couchbase.EntityFrameworkCore.UnitTests/Couchbase/EntityFrameworkCore/ValueGeneration/CouchbaseValueGeneratorSelectorTests.cs
+++ b/tests/Couchbase.EntityFrameworkCore.UnitTests/Couchbase/EntityFrameworkCore/ValueGeneration/CouchbaseValueGeneratorSelectorTests.cs
@@ -42,7 +42,7 @@ public class CouchbaseValueGeneratorSelectorTests
             "D");
 
         // Act
-        var generator = _selector.Select(property, typeBase);
+        Assert.True(_selector.TrySelect(property, typeBase, out var generator));
 
         // Assert
         Assert.NotNull(generator);
@@ -59,7 +59,7 @@ public class CouchbaseValueGeneratorSelectorTests
             "N");
 
         // Act
-        var generator = _selector.Select(property, typeBase);
+        Assert.True(_selector.TrySelect(property, typeBase, out var generator));
 
         // Assert
         var guidGenerator = Assert.IsType<CouchbaseGuidStringValueGenerator>(generator);
@@ -80,7 +80,7 @@ public class CouchbaseValueGeneratorSelectorTests
             format);
 
         // Act
-        var generator = _selector.Select(property, typeBase);
+        Assert.True(_selector.TrySelect(property, typeBase, out var generator));
 
         // Assert
         var guidGenerator = Assert.IsType<CouchbaseGuidStringValueGenerator>(generator);
@@ -97,7 +97,7 @@ public class CouchbaseValueGeneratorSelectorTests
             "D");
 
         // Act
-        var generator = _selector.Create(property, typeBase);
+        Assert.True(_selector.TryCreate(property, typeBase, out var generator));
 
         // Assert
         Assert.NotNull(generator);
@@ -115,7 +115,7 @@ public class CouchbaseValueGeneratorSelectorTests
             "test_seq");
 
         // Act & Assert - Sequence on string type should fail
-        var exception = Assert.Throws<InvalidOperationException>(() => _selector.Select(property, typeBase));
+        var exception = Assert.Throws<InvalidOperationException>(() => _selector.TrySelect(property, typeBase, out _));
         Assert.Contains("not supported", exception.Message);
     }
 
@@ -130,7 +130,7 @@ public class CouchbaseValueGeneratorSelectorTests
             "D");
 
         // Act
-        var stringGenerator = _selector.Select(stringProperty, stringTypeBase);
+        Assert.True(_selector.TrySelect(stringProperty, stringTypeBase, out var stringGenerator));
 
         // Assert - String property with annotation should return GUID string generator
         Assert.IsType<CouchbaseGuidStringValueGenerator>(stringGenerator);
@@ -150,7 +150,7 @@ public class CouchbaseValueGeneratorSelectorTests
             "test_seq");
 
         // Act
-        var generator = _selector.Select(property, typeBase);
+        Assert.True(_selector.TrySelect(property, typeBase, out var generator));
 
         // Assert
         Assert.NotNull(generator);
@@ -167,7 +167,7 @@ public class CouchbaseValueGeneratorSelectorTests
             "order_seq");
 
         // Act
-        var generator = _selector.Select(property, typeBase);
+        Assert.True(_selector.TrySelect(property, typeBase, out var generator));
 
         // Assert - Should return int generator for int property
         Assert.IsType<CouchbaseSequenceValueGenerator<int>>(generator);
@@ -188,7 +188,7 @@ public class CouchbaseValueGeneratorSelectorTests
         var property = entityType.FindProperty(nameof(StringEntity.Id))!;
 
         // Act & Assert - Should throw because sequence doesn't support string type
-        Assert.Throws<InvalidOperationException>(() => _selector.Select(property, entityType));
+        Assert.Throws<InvalidOperationException>(() => _selector.TrySelect(property, entityType, out _));
     }
 
     [Fact]
@@ -201,7 +201,7 @@ public class CouchbaseValueGeneratorSelectorTests
             "test_seq");
 
         // Act & Assert
-        var exception = Assert.Throws<InvalidOperationException>(() => _selector.Select(property, typeBase));
+        var exception = Assert.Throws<InvalidOperationException>(() => _selector.TrySelect(property, typeBase, out _));
         Assert.Contains("not supported", exception.Message);
     }
 


### PR DESCRIPTION
Clears all CS0618/CS0672 warnings in the provider by migrating three
deprecated-API usages to their supported replacements:

- ValueGeneratorSelector: replace the obsolete Select/Create overrides
  with TrySelect/TryCreate (shared helper preserves behavior — custom
  sequence/GUID generators still take precedence and unsupported sequence
  types still throw); migrate the caller in CouchbaseSaveChangesInterceptor
  and the selector unit tests to the try-pattern.
- CouchbaseQuerySqlGenerator: use the value-based SqlConstantExpression
  constructor instead of the obsolete ConstantExpression-based one in
  GenerateLimitOffset.
- CouchbaseOptionsExtension: forward legacy username/password via the
  supported WithPasswordAuthentication instead of the obsolete
  WithCredentials (the Authenticator path is unchanged). Reading the
  obsolete UserName/Password has no non-obsolete equivalent for legacy
  configs, so it is suppressed locally with a comment and will stop
  compiling once the SDK removes those members.

Verified: unit 816 and integration 242 (3 skipped) green, including the
auth path (live connection).