### PR TITLE
Thread CancellationToken through the KV write path

### DIFF
--- a/src/Couchbase.EntityFrameworkCore/Storage/Internal/CouchbaseClientWrapper.cs
+++ b/src/Couchbase.EntityFrameworkCore/Storage/Internal/CouchbaseClientWrapper.cs
@@ -35,14 +35,18 @@ public class CouchbaseClientWrapper : ICouchbaseClientWrapper
 
     public string BucketName => _couchbaseDbContextOptionsBuilder.Bucket;
 
-    public async Task<bool> DeleteDocument(string id, string keyspace)
+    public async Task<bool> DeleteDocument(string id, string keyspace, CancellationToken cancellationToken = default)
     {
         bool success;
         try
         {
-            var collection = await GetCollection(keyspace).ConfigureAwait(false);
-            await collection.RemoveAsync(id).ConfigureAwait(false);
+            var collection = await GetCollection(keyspace, cancellationToken).ConfigureAwait(false);
+            await collection.RemoveAsync(id, new RemoveOptions().CancellationToken(cancellationToken)).ConfigureAwait(false);
             success = true;
+        }
+        catch (OperationCanceledException)
+        {
+            throw; // Surface cancellation as-is rather than masking it as a DbUpdateException.
         }
         catch (Exception e)
         {
@@ -56,14 +60,18 @@ public class CouchbaseClientWrapper : ICouchbaseClientWrapper
         return success;
     }
 
-    public async Task<bool> CreateDocument<TEntity>(string id, string keyspace, TEntity entity)
+    public async Task<bool> CreateDocument<TEntity>(string id, string keyspace, TEntity entity, CancellationToken cancellationToken = default)
     {
         bool success;
         try
         {
-            var collection = await GetCollection(keyspace).ConfigureAwait(false);
-            await collection.InsertAsync(id, entity).ConfigureAwait(false);
+            var collection = await GetCollection(keyspace, cancellationToken).ConfigureAwait(false);
+            await collection.InsertAsync(id, entity, new InsertOptions().CancellationToken(cancellationToken)).ConfigureAwait(false);
             success = true;
+        }
+        catch (OperationCanceledException)
+        {
+            throw; // Surface cancellation as-is rather than masking it as a DbUpdateException.
         }
         catch (Exception e)
         {
@@ -77,14 +85,18 @@ public class CouchbaseClientWrapper : ICouchbaseClientWrapper
         return success;
     }
 
-    public async Task<bool> UpdateDocument<TEntity>(string id, string keyspace, TEntity entity)
+    public async Task<bool> UpdateDocument<TEntity>(string id, string keyspace, TEntity entity, CancellationToken cancellationToken = default)
     {
         bool success;
         try
         {
-            var collection = await GetCollection(keyspace).ConfigureAwait(false);
-            await collection.UpsertAsync(id, entity).ConfigureAwait(false);
+            var collection = await GetCollection(keyspace, cancellationToken).ConfigureAwait(false);
+            await collection.UpsertAsync(id, entity, new UpsertOptions().CancellationToken(cancellationToken)).ConfigureAwait(false);
             success = true;
+        }
+        catch (OperationCanceledException)
+        {
+            throw; // Surface cancellation as-is rather than masking it as a DbUpdateException.
         }
         catch (Exception e)
         {
@@ -98,37 +110,37 @@ public class CouchbaseClientWrapper : ICouchbaseClientWrapper
         return success;
     }
 
-    public async Task<ICouchbaseCollection> GetCollectionAsync(string keyspace)
+    public async Task<ICouchbaseCollection> GetCollectionAsync(string keyspace, CancellationToken cancellationToken = default)
     {
-        return await GetCollection(keyspace).ConfigureAwait(false);
+        return await GetCollection(keyspace, cancellationToken).ConfigureAwait(false);
     }
 
-    public async Task EnqueueTransactionalInsert<TEntity>(CouchbaseDbTransaction transaction, string id, string keyspace, TEntity entity)
+    public async Task EnqueueTransactionalInsert<TEntity>(CouchbaseDbTransaction transaction, string id, string keyspace, TEntity entity, CancellationToken cancellationToken = default)
     {
-        var collection = await GetCollection(keyspace).ConfigureAwait(false);
+        var collection = await GetCollection(keyspace, cancellationToken).ConfigureAwait(false);
         transaction.EnqueueInsert(collection, id, entity!);
     }
 
-    public async Task EnqueueTransactionalUpsert<TEntity>(CouchbaseDbTransaction transaction, string id, string keyspace, TEntity entity)
+    public async Task EnqueueTransactionalUpsert<TEntity>(CouchbaseDbTransaction transaction, string id, string keyspace, TEntity entity, CancellationToken cancellationToken = default)
     {
-        var collection = await GetCollection(keyspace).ConfigureAwait(false);
+        var collection = await GetCollection(keyspace, cancellationToken).ConfigureAwait(false);
         transaction.EnqueueUpsert(collection, id, entity!);
     }
 
-    public async Task EnqueueTransactionalRemove(CouchbaseDbTransaction transaction, string id, string keyspace)
+    public async Task EnqueueTransactionalRemove(CouchbaseDbTransaction transaction, string id, string keyspace, CancellationToken cancellationToken = default)
     {
-        var collection = await GetCollection(keyspace).ConfigureAwait(false);
+        var collection = await GetCollection(keyspace, cancellationToken).ConfigureAwait(false);
         transaction.EnqueueRemove(collection, id);
     }
 
-    private async Task<ICouchbaseCollection> GetCollection(string keyspace)
+    private async Task<ICouchbaseCollection> GetCollection(string keyspace, CancellationToken cancellationToken = default)
     {
         if (_keyspaceCache.TryGetValue(keyspace, out var cached))
         {
             return cached.Collection;
         }
 
-        await _semaphore.WaitAsync().ConfigureAwait(false);
+        await _semaphore.WaitAsync(cancellationToken).ConfigureAwait(false);
         try
         {
             // Double-check after acquiring lock

--- a/src/Couchbase.EntityFrameworkCore/Storage/Internal/CouchbaseDatabaseWrapper.cs
+++ b/src/Couchbase.EntityFrameworkCore/Storage/Internal/CouchbaseDatabaseWrapper.cs
@@ -208,13 +208,13 @@ public class CouchbaseDatabaseWrapper : Database
                 switch (write.Kind)
                 {
                     case CouchbaseWriteKind.Delete:
-                        await _couchbaseClient.EnqueueTransactionalRemove(transaction, write.Key, write.Keyspace).ConfigureAwait(false);
+                        await _couchbaseClient.EnqueueTransactionalRemove(transaction, write.Key, write.Keyspace, cancellationToken).ConfigureAwait(false);
                         break;
                     case CouchbaseWriteKind.Upsert:
-                        await _couchbaseClient.EnqueueTransactionalUpsert(transaction, write.Key, write.Keyspace, write.Document!).ConfigureAwait(false);
+                        await _couchbaseClient.EnqueueTransactionalUpsert(transaction, write.Key, write.Keyspace, write.Document!, cancellationToken).ConfigureAwait(false);
                         break;
                     case CouchbaseWriteKind.Insert:
-                        await _couchbaseClient.EnqueueTransactionalInsert(transaction, write.Key, write.Keyspace, write.Document!).ConfigureAwait(false);
+                        await _couchbaseClient.EnqueueTransactionalInsert(transaction, write.Key, write.Keyspace, write.Document!, cancellationToken).ConfigureAwait(false);
                         break;
                 }
                 transactionalCount++;
@@ -228,8 +228,10 @@ public class CouchbaseDatabaseWrapper : Database
         // in-flight) rather than a deterministic prefix — Parallel.ForEachAsync stops scheduling new
         // writes on the first exception, but in-flight writes have already been sent. Use a Couchbase
         // transaction (the sequential branch above) when all-or-nothing semantics are required.
-        // The external CancellationToken is honored at the scheduling level via ParallelOptions; the
-        // individual KV calls are not yet cancellable (ICouchbaseClientWrapper takes no token).
+        // The external CancellationToken is honored both at the scheduling level (via ParallelOptions)
+        // and per write (passed to each KV call). We pass the external token deliberately, not the
+        // loop's combined token, so a sibling write's failure does not cancel in-flight writes — that
+        // keeps the surfaced exception the original DbUpdateException rather than a cancellation.
         var successCount = 0;
         await Parallel.ForEachAsync(
             pendingWrites,
@@ -238,9 +240,9 @@ public class CouchbaseDatabaseWrapper : Database
             {
                 var written = write.Kind switch
                 {
-                    CouchbaseWriteKind.Delete => await _couchbaseClient.DeleteDocument(write.Key, write.Keyspace).ConfigureAwait(false),
-                    CouchbaseWriteKind.Upsert => await _couchbaseClient.UpdateDocument(write.Key, write.Keyspace, write.Document!).ConfigureAwait(false),
-                    CouchbaseWriteKind.Insert => await _couchbaseClient.CreateDocument(write.Key, write.Keyspace, write.Document!).ConfigureAwait(false),
+                    CouchbaseWriteKind.Delete => await _couchbaseClient.DeleteDocument(write.Key, write.Keyspace, cancellationToken).ConfigureAwait(false),
+                    CouchbaseWriteKind.Upsert => await _couchbaseClient.UpdateDocument(write.Key, write.Keyspace, write.Document!, cancellationToken).ConfigureAwait(false),
+                    CouchbaseWriteKind.Insert => await _couchbaseClient.CreateDocument(write.Key, write.Keyspace, write.Document!, cancellationToken).ConfigureAwait(false),
                     _ => false
                 };
                 if (written)

--- a/src/Couchbase.EntityFrameworkCore/Storage/Internal/ICouchbaseClientWrapper.cs
+++ b/src/Couchbase.EntityFrameworkCore/Storage/Internal/ICouchbaseClientWrapper.cs
@@ -4,33 +4,33 @@ namespace Couchbase.EntityFrameworkCore.Storage.Internal;
 
 public interface ICouchbaseClientWrapper
 {
-    Task<bool> DeleteDocument(string id, string keyspace);
+    Task<bool> DeleteDocument(string id, string keyspace, CancellationToken cancellationToken = default);
 
-    Task<bool> CreateDocument<TEntity>(string id, string keyspace, TEntity entity);
+    Task<bool> CreateDocument<TEntity>(string id, string keyspace, TEntity entity, CancellationToken cancellationToken = default);
 
-    Task<bool> UpdateDocument<TEntity>(string id, string keyspace, TEntity entity);
+    Task<bool> UpdateDocument<TEntity>(string id, string keyspace, TEntity entity, CancellationToken cancellationToken = default);
 
     string BucketName { get; }
 
     /// <summary>
     /// Gets the collection for the specified keyspace.
     /// </summary>
-    Task<ICouchbaseCollection> GetCollectionAsync(string keyspace);
+    Task<ICouchbaseCollection> GetCollectionAsync(string keyspace, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Enqueues a document insert operation on the given transaction.
     /// </summary>
-    Task EnqueueTransactionalInsert<TEntity>(CouchbaseDbTransaction transaction, string id, string keyspace, TEntity entity);
+    Task EnqueueTransactionalInsert<TEntity>(CouchbaseDbTransaction transaction, string id, string keyspace, TEntity entity, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Enqueues a document upsert operation on the given transaction.
     /// </summary>
-    Task EnqueueTransactionalUpsert<TEntity>(CouchbaseDbTransaction transaction, string id, string keyspace, TEntity entity);
+    Task EnqueueTransactionalUpsert<TEntity>(CouchbaseDbTransaction transaction, string id, string keyspace, TEntity entity, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Enqueues a document remove operation on the given transaction.
     /// </summary>
-    Task EnqueueTransactionalRemove(CouchbaseDbTransaction transaction, string id, string keyspace);
+    Task EnqueueTransactionalRemove(CouchbaseDbTransaction transaction, string id, string keyspace, CancellationToken cancellationToken = default);
 }
 
 /* ************************************************************

--- a/tests/Couchbase.EntityFrameworkCore.IntegrationTests/Tests/CrudTests.cs
+++ b/tests/Couchbase.EntityFrameworkCore.IntegrationTests/Tests/CrudTests.cs
@@ -1,6 +1,8 @@
 using Couchbase.EntityFrameworkCode.IntegrationTests.Fixtures;
 using Couchbase.EntityFrameworkCore.Extensions;
+using Couchbase.EntityFrameworkCore.Storage.Internal;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Infrastructure;
 using Xunit.Abstractions;
 
 namespace Couchbase.EntityFrameworkCode.IntegrationTests.Tests;
@@ -241,6 +243,34 @@ public class CrudTests(
         cts.Cancel();
 
         await Assert.ThrowsAnyAsync<OperationCanceledException>(() => context.SaveChangesAsync(cts.Token));
+    }
+
+    // Directly exercises that the CancellationToken is threaded into the KV call (not just observed
+    // by EF/Parallel scheduling): warm the collection cache first so the cancelled call skips the
+    // semaphore and goes straight to the SDK operation, which must surface OperationCanceledException.
+    [Fact]
+    public async Task Test_ClientWrapper_ThreadsCancellationIntoKvCall()
+    {
+        await using var context = bloggingFixture.GetDbContext();
+        var wrapper = context.GetService<ICouchbaseClientWrapper>();
+        var keyspace = $"{wrapper.BucketName}.blogs.blog";
+        var id = $"ct-test-{Guid.NewGuid():N}";
+
+        // Warm the keyspace cache (and create a document to remove).
+        await wrapper.CreateDocument(id, keyspace, new { type = "ct-test" });
+        try
+        {
+            using var cts = new CancellationTokenSource();
+            cts.Cancel();
+
+            await Assert.ThrowsAnyAsync<OperationCanceledException>(
+                () => wrapper.DeleteDocument(id, keyspace, cts.Token));
+        }
+        finally
+        {
+            // Best-effort cleanup (the cancelled delete above should not have removed the document).
+            try { await wrapper.DeleteDocument(id, keyspace); } catch { /* ignore */ }
+        }
     }
 
     [Fact]

--- a/tests/Couchbase.EntityFrameworkCore.IntegrationTests/Tests/CrudTests.cs
+++ b/tests/Couchbase.EntityFrameworkCore.IntegrationTests/Tests/CrudTests.cs
@@ -225,6 +225,24 @@ public class CrudTests(
         }
     }
 
+    // The provider threads the CancellationToken through the KV write path; a cancelled save must
+    // surface as an OperationCanceledException, not a wrapped DbUpdateException.
+    [Fact]
+    public async Task Test_SaveChanges_HonorsCancellation()
+    {
+        await using var context = travelSampleFixture.GetDbContext();
+        context.Add(new TravelSampleFixture.Airline
+        {
+            Type = "airline", Id = Random.Shared.Next(1_000_000, int.MaxValue),
+            Callsign = "CANCEL", Country = "United States", Icao = "CXL", Iata = "CX", Name = "Cancel Air"
+        });
+
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => context.SaveChangesAsync(cts.Token));
+    }
+
     [Fact]
     public async Task Test_RemoveAsync()
     {


### PR DESCRIPTION
Add a CancellationToken (default) to the ICouchbaseClientWrapper write methods and forward it to the SDK Remove/Insert/Upsert calls and the collection-cache semaphore, so KV writes are cancellable end-to-end. SaveChanges passes the external token to both the transactional and parallel write paths (the external token, not the Parallel loop's, so a sibling failure still surfaces its DbUpdateException). Cancellation now surfaces as OperationCanceledException instead of being masked as a DbUpdateException. Add a test asserting a cancelled SaveChanges throws OperationCanceledException