### PR TITLE
Clear remaining CS86xx nullability warnings

### DIFF
--- a/src/Couchbase.EntityFrameworkCore/Annotations.cs
+++ b/src/Couchbase.EntityFrameworkCore/Annotations.cs
@@ -1,5 +1,9 @@
 using System;
 
+// Vendored JetBrains.Annotations attribute definitions — not part of the provider's own code,
+// so opt out of nullable analysis rather than hand-annotating third-party boilerplate.
+#nullable disable
+
 #pragma warning disable 1591
 // ReSharper disable UnusedMember.Global
 // ReSharper disable UnusedParameter.Local

--- a/src/Couchbase.EntityFrameworkCore/Extensions/CouchbaseDatabaseFacadeExtensions.cs
+++ b/src/Couchbase.EntityFrameworkCore/Extensions/CouchbaseDatabaseFacadeExtensions.cs
@@ -89,12 +89,13 @@ public static class CouchbaseDatabaseFacadeExtensions
     public static async Task<ICluster> GetCouchbaseClientAsync(
         this DatabaseFacade databaseFacade)
     {
-        var connectionString = databaseFacade.GetConnectionString();
+        var connectionString = databaseFacade.GetConnectionString()
+            ?? throw new InvalidOperationException("No Couchbase connection string is configured.");
         var options = new ClusterOptions().WithConnectionString(connectionString);
-        if (options.TryGetRawParameter("bucket", out var bucketName))
+        if (options.TryGetRawParameter("bucket", out var bucketName) && bucketName != null)
         {
             var bucketProvider = databaseFacade.GetService<IBucketProvider>();
-            var bucket = await bucketProvider.GetBucketAsync(bucketName.ToString()).ConfigureAwait(false);
+            var bucket = await bucketProvider.GetBucketAsync(bucketName.ToString()!).ConfigureAwait(false);
             return bucket.Cluster;
         }
         throw new CouchbaseException("No couchbase connection string found.");
@@ -102,7 +103,8 @@ public static class CouchbaseDatabaseFacadeExtensions
 
     public static ICluster GetCouchbaseClient(this DatabaseFacade databaseFacade)
     {
-        var connectionString = databaseFacade.GetConnectionString();
+        var connectionString = databaseFacade.GetConnectionString()
+            ?? throw new InvalidOperationException("No Couchbase connection string is configured.");
         return GetService<IClusterProvider>(databaseFacade, connectionString).GetClusterAsync().GetAwaiter().GetResult();
     }
 
@@ -120,25 +122,27 @@ public static class CouchbaseDatabaseFacadeExtensions
 
     public static void EnsureClean(this DatabaseFacade databaseFacade)
     {
-        var connectionString = databaseFacade.GetConnectionString();
+        var connectionString = databaseFacade.GetConnectionString()
+            ?? throw new InvalidOperationException("No Couchbase connection string is configured.");
         var clusterOptions = new ClusterOptions().WithConnectionString(connectionString);
 
         if (clusterOptions.TryGetRawParameter("bucket", out object? bucketName) && bucketName != null)
         {
             var couchbaseClient = GetCouchbaseClient(databaseFacade);
-            couchbaseClient.Buckets.FlushBucketAsync(bucketName.ToString()).GetAwaiter().GetResult();
+            couchbaseClient.Buckets.FlushBucketAsync(bucketName.ToString()!).GetAwaiter().GetResult();
         }
     }
 
     public static async Task EnsureCleanAsync(this DatabaseFacade databaseFacade)
     {
-        var connectionString = databaseFacade.GetConnectionString();
+        var connectionString = databaseFacade.GetConnectionString()
+            ?? throw new InvalidOperationException("No Couchbase connection string is configured.");
         var clusterOptions = new ClusterOptions().WithConnectionString(connectionString);
 
         if (clusterOptions.TryGetRawParameter("bucket", out var bucketName) && bucketName != null)
         {
             var couchbaseClient = await GetCouchbaseClientAsync(databaseFacade).ConfigureAwait(false);
-            await couchbaseClient.Buckets.FlushBucketAsync(bucketName.ToString()).ConfigureAwait(false);
+            await couchbaseClient.Buckets.FlushBucketAsync(bucketName.ToString()!).ConfigureAwait(false);
         }
     }
 

--- a/src/Couchbase.EntityFrameworkCore/Extensions/CouchbaseDatabaseFacadeExtensions.cs
+++ b/src/Couchbase.EntityFrameworkCore/Extensions/CouchbaseDatabaseFacadeExtensions.cs
@@ -98,14 +98,16 @@ public static class CouchbaseDatabaseFacadeExtensions
             var bucket = await bucketProvider.GetBucketAsync(bucketName.ToString()!).ConfigureAwait(false);
             return bucket.Cluster;
         }
-        throw new CouchbaseException("No couchbase connection string found.");
+        throw new CouchbaseException("No Couchbase bucket was specified in the connection string.");
     }
 
     public static ICluster GetCouchbaseClient(this DatabaseFacade databaseFacade)
     {
         var connectionString = databaseFacade.GetConnectionString()
             ?? throw new InvalidOperationException("No Couchbase connection string is configured.");
-        return GetService<IClusterProvider>(databaseFacade, connectionString).GetClusterAsync().GetAwaiter().GetResult();
+        return Couchbase.EntityFrameworkCore.Internal.AsyncHelper.RunSync(
+            static state => state.GetClusterAsync(),
+            GetService<IClusterProvider>(databaseFacade, connectionString));
     }
 
     private static TService GetService<TService>(IInfrastructure<IServiceProvider> databaseFacade, string connectionString)
@@ -129,7 +131,9 @@ public static class CouchbaseDatabaseFacadeExtensions
         if (clusterOptions.TryGetRawParameter("bucket", out object? bucketName) && bucketName != null)
         {
             var couchbaseClient = GetCouchbaseClient(databaseFacade);
-            couchbaseClient.Buckets.FlushBucketAsync(bucketName.ToString()!).GetAwaiter().GetResult();
+            Couchbase.EntityFrameworkCore.Internal.AsyncHelper.RunSync(
+                static state => state.client.Buckets.FlushBucketAsync(state.bucket),
+                (client: couchbaseClient, bucket: bucketName.ToString()!));
         }
     }
 

--- a/src/Couchbase.EntityFrameworkCore/Extensions/EntityTypeExtensions.cs
+++ b/src/Couchbase.EntityFrameworkCore/Extensions/EntityTypeExtensions.cs
@@ -8,13 +8,17 @@ public static class EntityTypeExtensions
 {
     public static string GetCollectionName(this IEntityType entityType)
     {
-        return entityType.GetTableName();
+        return entityType.GetTableName()
+            ?? throw new InvalidOperationException(
+                $"Entity type '{entityType.DisplayName()}' is not mapped to a collection.");
     }
 
     public static string GetPrimaryKey(this IEntityType entityType, object entity)
     {
-        var keys = entityType.FindPrimaryKey().Properties
-            .ToArray(); //TODO If no primary key found we should fail hard
+        var keys = (entityType.FindPrimaryKey()
+                ?? throw new InvalidOperationException(
+                    $"Entity type '{entityType.DisplayName()}' has no primary key defined."))
+            .Properties.ToArray();
 
         var compositeKey = new StringBuilder();
         foreach (var property in entity.GetType().GetProperties().Reverse())

--- a/src/Couchbase.EntityFrameworkCore/Infrastructure/CouchbaseDbContextOptionsBuilder.cs
+++ b/src/Couchbase.EntityFrameworkCore/Infrastructure/CouchbaseDbContextOptionsBuilder.cs
@@ -8,11 +8,8 @@ namespace Couchbase.EntityFrameworkCore.Infrastructure;
 
 public class CouchbaseDbContextOptionsBuilder : ICouchbaseDbContextOptionsBuilder
 {
-    private readonly string _connectionString;
-
     public CouchbaseDbContextOptionsBuilder(DbContextOptionsBuilder dbContextOptionsBuilder, string connectionString)
     {
-        _connectionString = connectionString;
         OptionsBuilder = dbContextOptionsBuilder;
         ClusterOptions = new ClusterOptions().WithConnectionString(connectionString);
     }
@@ -30,9 +27,11 @@ public class CouchbaseDbContextOptionsBuilder : ICouchbaseDbContextOptionsBuilde
 
     public ClusterOptions ClusterOptions { get; }
 
-    public string Bucket { get; set; }
+    // Assigned during configuration (the couchbaseDbContextOptions action), not at construction;
+    // the provider validates they are set before use.
+    public string Bucket { get; set; } = null!;
 
-    public string Scope { get; set; }
+    public string Scope { get; set; } = null!;
 
     public bool AutoCreateScopes { get; set; }
 

--- a/src/Couchbase.EntityFrameworkCore/Infrastructure/Internal/CouchbaseModelValidator.cs
+++ b/src/Couchbase.EntityFrameworkCore/Infrastructure/Internal/CouchbaseModelValidator.cs
@@ -23,7 +23,7 @@ public class CouchbaseModelValidator : RelationalModelValidator
 
     protected override void ValidatePropertyMapping(IModel model, IDiagnosticsLogger<DbLoggerCategory.Model.Validation> logger)
     {
-        IConventionModel conventionModel = model as IConventionModel;
+        IConventionModel? conventionModel = model as IConventionModel;
         if (conventionModel == null)
             return;
         

--- a/src/Couchbase.EntityFrameworkCore/Infrastructure/Internal/CouchbaseOptionsExtension.cs
+++ b/src/Couchbase.EntityFrameworkCore/Infrastructure/Internal/CouchbaseOptionsExtension.cs
@@ -24,7 +24,7 @@ public class CouchbaseOptionsExtension: RelationalOptionsExtension
     protected internal CouchbaseOptionsExtension(CouchbaseOptionsExtension copyFrom)
         : base(copyFrom)
     {
-        _couchbaseDbContextOptionsBuilder = copyFrom.CouchbaseDbContextOptionsBuilder;
+        _couchbaseDbContextOptionsBuilder = copyFrom._couchbaseDbContextOptionsBuilder;
     }
 
     public CouchbaseDbContextOptionsBuilder? CouchbaseDbContextOptionsBuilder => _couchbaseDbContextOptionsBuilder;
@@ -40,7 +40,7 @@ public class CouchbaseOptionsExtension: RelationalOptionsExtension
         services.AddCouchbase(options =>
         {
             options.WithLogging(_couchbaseDbContextOptionsBuilder.ClusterOptions.Logging);
-            options.WithConnectionString(_couchbaseDbContextOptionsBuilder.ClusterOptions.ConnectionString);
+            options.WithConnectionString(_couchbaseDbContextOptionsBuilder.ClusterOptions.ConnectionString!);
 
             // Use existing serializer if configured, otherwise default to System.Text.Json
             var existingSerializer = _couchbaseDbContextOptionsBuilder.ClusterOptions.Serializer;
@@ -67,8 +67,8 @@ public class CouchbaseOptionsExtension: RelationalOptionsExtension
                 // forces Authenticator-based configuration.
 #pragma warning disable CS0618 // Type or member is obsolete
                 options.WithPasswordAuthentication(
-                    _couchbaseDbContextOptionsBuilder.ClusterOptions.UserName,
-                    _couchbaseDbContextOptionsBuilder.ClusterOptions.Password);
+                    _couchbaseDbContextOptionsBuilder.ClusterOptions.UserName!,
+                    _couchbaseDbContextOptionsBuilder.ClusterOptions.Password!);
 #pragma warning restore CS0618
             }
         });
@@ -182,7 +182,7 @@ public class CouchbaseOptionsExtension: RelationalOptionsExtension
 
         public override void PopulateDebugInfo(IDictionary<string, string> debugInfo)
         {
-            debugInfo["Couchbase:ConnectionString"] = ConnectionString;
+            debugInfo["Couchbase:ConnectionString"] = ConnectionString ?? string.Empty;
         }
 
         public override CouchbaseOptionsExtension Extension => (CouchbaseOptionsExtension)base.Extension;

--- a/src/Couchbase.EntityFrameworkCore/Migrations/Internal/CouchbaseHistoryRepository.cs
+++ b/src/Couchbase.EntityFrameworkCore/Migrations/Internal/CouchbaseHistoryRepository.cs
@@ -8,7 +8,7 @@ public class CouchbaseHistoryRepository : HistoryRepository
     {
     }
 
-    protected override string ExistsSql { get; }
+    protected override string ExistsSql => throw new NotImplementedException();
     protected override bool InterpretExistsResult(object? value)
     {
         throw new NotImplementedException();

--- a/src/Couchbase.EntityFrameworkCore/Query/Internal/CouchbaseFromSqlQueryingEnumerable.cs
+++ b/src/Couchbase.EntityFrameworkCore/Query/Internal/CouchbaseFromSqlQueryingEnumerable.cs
@@ -132,9 +132,9 @@ public class CouchbaseFromSqlQueryingEnumerable<T> : IEnumerable<T>, IAsyncEnume
             {
                 //If the returned type is an entity add start change tracking
                 //Scalar values for functions like COUNT are not tracked.
-                if (entityType != null && _dbContext.Entry(doc).State != EntityState.Detached)
+                if (entityType != null && _dbContext.Entry(doc!).State != EntityState.Detached)
                 {
-                    _relationalQueryContext.StartTracking(entityType, doc, Snapshot.Empty);
+                    _relationalQueryContext.StartTracking(entityType, doc!, Snapshot.Empty);
                 }
             }
             catch (Exception e)
@@ -152,7 +152,7 @@ public class CouchbaseFromSqlQueryingEnumerable<T> : IEnumerable<T>, IAsyncEnume
         queryOptions.ScanConsistency(_couchbaseDbContextOptionsBuilder.ScanConsistency);
         foreach (CouchbaseParameter parameter in command.Parameters)
         {
-            queryOptions.Parameter(parameter.ParameterName, parameter.Value);
+            queryOptions.Parameter(parameter.ParameterName, parameter.Value!);
         }
 
         return queryOptions;

--- a/src/Couchbase.EntityFrameworkCore/Query/Internal/CouchbaseQueryEnumerable.cs
+++ b/src/Couchbase.EntityFrameworkCore/Query/Internal/CouchbaseQueryEnumerable.cs
@@ -324,7 +324,7 @@ public class CouchbaseQueryEnumerable<T> : IEnumerable<T>, IAsyncEnumerable<T>, 
         queryOptions.ScanConsistency(_couchbaseDbContextOptionsBuilder.ScanConsistency);
         foreach (CouchbaseParameter parameter in command.Parameters)
         {
-            queryOptions.Parameter(parameter.ParameterName, parameter.Value);
+            queryOptions.Parameter(parameter.ParameterName, parameter.Value!);
         }
 
         return queryOptions;

--- a/src/Couchbase.EntityFrameworkCore/Query/Internal/CouchbaseQuerySqlGenerator.cs
+++ b/src/Couchbase.EntityFrameworkCore/Query/Internal/CouchbaseQuerySqlGenerator.cs
@@ -770,8 +770,8 @@ public class CouchbaseQuerySqlGenerator : QuerySqlGenerator
         // standard SQL, because a custom translator could theoretically produce such a tree.
         if (sqlFunctionExpression.IsBuiltIn
             && sqlFunctionExpression.Name == "AVG"
-            && sqlFunctionExpression.Arguments.Count == 1
-            && sqlFunctionExpression.Arguments[0] is SqlUnaryExpression
+            && sqlFunctionExpression.Arguments is { Count: 1 } avgArguments
+            && avgArguments[0] is SqlUnaryExpression
                 { OperatorType: ExpressionType.Convert } numericCast
             && IsNumericType(numericCast.Type))
         {

--- a/src/Couchbase.EntityFrameworkCore/Query/Internal/CouchbaseShapedQueryCompilingExpressionVisitor.cs
+++ b/src/Couchbase.EntityFrameworkCore/Query/Internal/CouchbaseShapedQueryCompilingExpressionVisitor.cs
@@ -350,7 +350,7 @@ public class CouchbaseShapedQueryCompilingExpressionVisitor : RelationalShapedQu
                 innerSelect.AddToProjection(
                     new ColumnExpression(fieldName, ownerTable.Alias, typeof(object), null, true));
                 selectExpression.AddToProjection(
-                    new ColumnExpression(fieldName, innerSelect.Alias, typeof(object), null, true));
+                    new ColumnExpression(fieldName, innerSelect.Alias!, typeof(object), null, true));
             }
             else
             {

--- a/src/Couchbase.EntityFrameworkCore/Storage/Internal/CouchbaseCommand.cs
+++ b/src/Couchbase.EntityFrameworkCore/Storage/Internal/CouchbaseCommand.cs
@@ -1,5 +1,6 @@
 using System.Data;
 using System.Data.Common;
+using System.Diagnostics.CodeAnalysis;
 using System.Text.Json;
 using Couchbase.Query;
 using Couchbase.EntityFrameworkCore.Internal;
@@ -21,6 +22,7 @@ public class CouchbaseCommand : DbCommand
     // defaults to NotBounded to match the SDK default.
     internal QueryScanConsistency ScanConsistency { get; set; } = QueryScanConsistency.NotBounded;
 
+    [AllowNull]
     public override string CommandText
     {
         get => _commandText;
@@ -271,7 +273,8 @@ public class CouchbaseCommand : DbCommand
 
                 // Convert DBNull.Value to null for Couchbase SDK compatibility
                 var value = parameter.Value == DBNull.Value ? null : parameter.Value;
-                options.Parameter(parameter.ParameterName, value);
+                // A query parameter may legitimately bind to a null value.
+                options.Parameter(parameter.ParameterName, value!);
             }
         }
 

--- a/src/Couchbase.EntityFrameworkCore/Storage/Internal/CouchbaseConnection.cs
+++ b/src/Couchbase.EntityFrameworkCore/Storage/Internal/CouchbaseConnection.cs
@@ -1,5 +1,6 @@
 using System.Data;
 using System.Data.Common;
+using System.Diagnostics.CodeAnalysis;
 using Couchbase.EntityFrameworkCore.Infrastructure;
 using Couchbase.EntityFrameworkCore.Internal;
 using Couchbase.Extensions.DependencyInjection;
@@ -51,6 +52,7 @@ public class CouchbaseConnection : DbConnection
         _logger = logger;
     }
 
+    [AllowNull]
     public override string ConnectionString
     {
         get => _couchbaseDbContextOptionsBuilder.ConnectionString;

--- a/src/Couchbase.EntityFrameworkCore/Storage/Internal/CouchbaseDatabaseCreator.cs
+++ b/src/Couchbase.EntityFrameworkCore/Storage/Internal/CouchbaseDatabaseCreator.cs
@@ -22,7 +22,9 @@ public class CouchbaseDatabaseCreator :  RelationalDatabaseCreator
     private readonly IServiceProvider _serviceProvider;
     private readonly ICouchbaseDbContextOptionsBuilder _couchbaseDbContextOptionsBuilder;
     private readonly ISqlGenerationHelper _sqlGenerationHelper;
-    private ICluster _cluster;
+    // Lazily initialized by InitializeAsync before any use; null-forgiving avoids cascading
+    // nullable warnings at the (guaranteed-initialized) deref sites.
+    private ICluster _cluster = null!;
 
     public CouchbaseDatabaseCreator(RelationalDatabaseCreatorDependencies dependencies,
         IDatabase database,

--- a/src/Couchbase.EntityFrameworkCore/Storage/Internal/CouchbaseParameter.cs
+++ b/src/Couchbase.EntityFrameworkCore/Storage/Internal/CouchbaseParameter.cs
@@ -1,18 +1,19 @@
 using System.Data;
 using System.Data.Common;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Couchbase.EntityFrameworkCore.Storage.Internal;
 
 public class CouchbaseParameter : DbParameter
 {
-    private string _parameterName;
+    private string _parameterName = string.Empty;
     private object? _value;
 
     public CouchbaseParameter()
     {
     }
 
-    public CouchbaseParameter(string name, object value)
+    public CouchbaseParameter(string name, object? value)
     {
         _value = value;
         _parameterName = name;
@@ -27,13 +28,15 @@ public class CouchbaseParameter : DbParameter
     public override ParameterDirection Direction { get; set; }
     public override bool IsNullable { get; set; }
 
+    [AllowNull]
     public override string ParameterName
     {
         get => _parameterName;
-        set => _parameterName = value;
+        set => _parameterName = value ?? string.Empty;
     }
 
-    public override string SourceColumn { get; set; }
+    [AllowNull]
+    public override string SourceColumn { get; set; } = string.Empty;
 
     public override object? Value
     {

--- a/src/Couchbase.EntityFrameworkCore/Storage/Internal/EntityEntryExtensions.cs
+++ b/src/Couchbase.EntityFrameworkCore/Storage/Internal/EntityEntryExtensions.cs
@@ -16,11 +16,18 @@ public static class EntityEntryExtensions
     }
 
     static IReadOnlyList<IProperty> FindPrimaryKeyProperties<T>(this DbContext dbContext, T entity) {
-        return dbContext.Model.FindEntityType(typeof(T)).FindPrimaryKey().Properties;
+        var entityType = dbContext.Model.FindEntityType(typeof(T))
+            ?? throw new InvalidOperationException($"Entity type '{typeof(T).Name}' is not part of the model.");
+        var primaryKey = entityType.FindPrimaryKey()
+            ?? throw new InvalidOperationException($"Entity type '{typeof(T).Name}' has no primary key.");
+        return primaryKey.Properties;
     }
 
     static object GetPropertyValue<T>(this T entity, string name) {
-        return entity.GetType().GetProperty(name).GetValue(entity, null);
+        var property = entity!.GetType().GetProperty(name)
+            ?? throw new InvalidOperationException($"Property '{name}' was not found on type '{typeof(T).Name}'.");
+        // Primary-key values are non-null.
+        return property.GetValue(entity)!;
     }
 
 }


### PR DESCRIPTION
Resolve the last category of build warnings so the provider compiles clean under #nullable enable. No behavioral change — each fix is either a clarifying guard, a null-forgiving operator where the value is known non-null (or intentionally nullable), or an [AllowNull] annotation to match the base member's nullability contract.
- EntityEntryExtensions / EntityTypeExtensions: throw clear exceptions when EF metadata (entity type, primary key, table name) is missing instead of dereferencing possibly-null results.
- CouchbaseModelValidator: type the `as` result as nullable.
- CouchbaseDatabaseCreator: mark the lazily-initialized _cluster field null-forgiving to avoid cascading derefs.
- CouchbaseHistoryRepository: ExistsSql throws rather than being an uninitialized non-nullable auto-property.
- CouchbaseParameter: ctor accepts object? value (a parameter value may be null); forward null query parameter values explicitly.
- CouchbaseConnection / CouchbaseCommand: [AllowNull] on the ConnectionString / CommandText setters to match the overridden member.
- CouchbaseQuerySqlGenerator: pattern-match Arguments to guard null.
- CouchbaseShapedQueryCompilingExpressionVisitor: null-forgive the inner select alias. Provider builds with 0 warnings; 816 unit and 244 integration tests pass.