### PR TITLE
Support one DbContext spanning multiple buckets (same cluster)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to the EF Core Couchbase DB provider are documented in this 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project aims to follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- **One `DbContext` spanning multiple buckets (same cluster).** A single context can now map
+  different entities to different buckets on the same cluster. Give an entity an explicit keyspace
+  with `ToCouchbaseCollection(bucket, scope, collection)` or the new three-argument
+  `[CouchbaseKeyspace(bucket, scope, collection)]`; entities without an explicit bucket continue to
+  use the context's configured bucket. Reads, `Find`, N1QL queries, `SaveChanges`, and
+  `EnsureCreated` all resolve each entity's own bucket. Buckets must share one physical cluster
+  (cross-cluster queries/transactions are not possible — use `ServiceKey` with a context per
+  cluster). See [Configuration](docs/configuration.md#one-context-spanning-multiple-buckets).
+
 ## [2.0.0-beta.2] - 2026-06-24
 
 ### Added

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -48,8 +48,12 @@ The [CouchbaseDbContextOptionsBuilder](https://github.com/couchbaselabs/couchbas
 
 ## Multiple buckets and clusters
 
-A `DbContext` maps to a single bucket (and scope). To work with **multiple buckets**, use
-**one `DbContext` per bucket**. Each context is registered independently and targets its own
+By default a `DbContext` targets a single configured bucket (and scope), and every entity is
+stored there. You can either use **one `DbContext` per bucket**, or map **individual entities to
+different buckets on the same cluster** within a single context (see
+[One context spanning multiple buckets](#one-context-spanning-multiple-buckets) below).
+
+For the context-per-bucket approach, each context is registered independently and targets its own
 bucket:
 
 ```csharp
@@ -111,9 +115,39 @@ builder.Services.AddCouchbase<WestContext>(westClusterOptions,
 `ServiceKey` selects which keyed cluster a context binds to. If a `ServiceKey` is set but no
 matching keyed cluster was registered, configuration fails with a clear error.
 
+### One context spanning multiple buckets
+
+A single `DbContext` can map different entities to different buckets, as long as those buckets
+live on the **same cluster** (same connection string). Give an entity an explicit keyspace with
+the three-argument `ToCouchbaseCollection(bucket, scope, collection)`:
+
+```csharp
+protected override void OnModelCreating(ModelBuilder modelBuilder)
+{
+    // Order is stored in the "orders" bucket, Customer in the "users" bucket.
+    modelBuilder.Entity<Order>().ToCouchbaseCollection("orders", "sales", "order");
+    modelBuilder.Entity<Customer>().ToCouchbaseCollection("users", "identity", "customer");
+
+    // Entities without an explicit bucket fall back to the context's configured Bucket/Scope.
+    modelBuilder.ConfigureToCouchbase(this);
+}
+```
+
+Or with the attribute form:
+
+```csharp
+[CouchbaseKeyspace("users", "identity", "customer")] // bucket, scope, collection
+public class Customer { /* ... */ }
+```
+
+Reads, `Find`, queries, and `SaveChanges` all resolve each entity's own bucket automatically, and
+`EnsureCreated` creates the scopes/collections in each bucket. N1QL queries and multi-document
+transactions work across these buckets because they share one cluster.
+
 > [!NOTE]
-> A single `DbContext` cannot span multiple buckets — every entity in a context is stored in that
-> context's configured bucket. Use a separate context per bucket. See [Limitations](limitations.md).
+> Buckets mapped within one context must be on the **same** physical cluster. To reach buckets on
+> **different** clusters, use a separate context per cluster with `ServiceKey` (above) — a single
+> query or transaction cannot span clusters. See [Limitations](limitations.md).
 
 ## Controlling Querying Casing
 SQL++ is based off JSON, thus is case sensitive both from the Query perspective and the query output. What this means is that your Keyspaces (Bucket, Scopes and Collections), the SQL++ query casing and your entities must have consistent casing.

--- a/docs/limitations.md
+++ b/docs/limitations.md
@@ -52,11 +52,13 @@ See also [Querying](Queries.md) and [Configuration](configuration.md).
 
 ## Buckets and contexts
 
-* **A single `DbContext` maps to one bucket.** Every entity in a context is stored in that
-  context's configured bucket; a context cannot span multiple buckets. To work with multiple
-  buckets, use one `DbContext` per bucket. Multiple contexts can share a single `Cluster`, and
-  multiple physical clusters are supported via keyed registration — see
-  [Configuration](configuration.md#multiple-buckets-and-clusters).
+* **A `DbContext` can span multiple buckets only within one cluster.** Entities default to the
+  context's configured bucket, but individual entities can be mapped to other buckets on the
+  **same** cluster (via `ToCouchbaseCollection(bucket, scope, collection)` or the three-argument
+  `[CouchbaseKeyspace]`). Buckets on **different** physical clusters cannot be mixed in one
+  context — a single N1QL query or transaction cannot span clusters. Use one `DbContext` per
+  cluster (with keyed `ServiceKey` registration) for that. Multiple contexts can also share a
+  single `Cluster`. See [Configuration](configuration.md#multiple-buckets-and-clusters).
 
 ## Inheritance
 

--- a/src/Couchbase.EntityFrameworkCore/Extensions/CouchbaseModelBuilderExtensions.cs
+++ b/src/Couchbase.EntityFrameworkCore/Extensions/CouchbaseModelBuilderExtensions.cs
@@ -49,19 +49,38 @@ public static class CouchbaseModelBuilderExtensions
 
             var tableName = entityType.GetTableName();
             if (tableName is null) continue;
-            if (toLowerCaseNaming.HasValue && toLowerCaseNaming.Value)
+
+            var toLowerCase = toLowerCaseNaming is true;
+
+            // Already a full keyspace (Bucket.Scope.Collection): the entity was mapped to an
+            // explicit bucket/scope (e.g. ToCouchbaseCollection(bucket, scope, collection)).
+            // Bucket and scope are case-sensitive in Couchbase, so never touch them here — only
+            // optionally normalize the collection segment to match the bare-collection path.
+            if (CouchbaseKeyspace.TryParse(tableName, out var existingKeyspace))
+            {
+                if (toLowerCase)
+                {
+                    var collection = existingKeyspace!.Value.Collection.ToLowerInvariant();
+                    if (collection != existingKeyspace.Value.Collection)
+                    {
+                        entityType.SetTableName(new CouchbaseKeyspace(
+                            existingKeyspace.Value.Bucket, existingKeyspace.Value.Scope, collection).ToString());
+                    }
+                }
+                continue;
+            }
+
+            // tableName is just the collection name; lowercase it (if requested), then compose
+            // the full keyspace from the DbContext-configured bucket and scope.
+            if (toLowerCase)
             {
                 tableName = tableName.ToLowerInvariant();
             }
-
-            // Skip if already a full keyspace (Bucket.Scope.Collection)
-            if (CouchbaseKeyspace.TryParse(tableName, out _)) continue;
 
             // Check for scope override annotation (set by CouchbaseKeyspaceAttribute with scope)
             var scopeOverride = entityType.FindAnnotation(CouchbaseKeyspaceConvention.ScopeOverrideAnnotation)?.Value as string;
             var scope = scopeOverride ?? dbContextOptions.Scope;
 
-            // tableName is just the collection name, add bucket and scope
             var keyspace = new CouchbaseKeyspace(dbContextOptions.Bucket, scope, tableName);
             entityType.SetTableName(keyspace.ToString());
         }

--- a/src/Couchbase.EntityFrameworkCore/Metadata/Conventions/CouchbaseKeyspaceConvention.cs
+++ b/src/Couchbase.EntityFrameworkCore/Metadata/Conventions/CouchbaseKeyspaceConvention.cs
@@ -21,6 +21,18 @@ public class CouchbaseKeyspaceConvention : TypeAttributeConventionBase<Couchbase
         CouchbaseKeyspaceAttribute keyspaceAttribute,
         IConventionContext<IConventionEntityTypeBuilder> context)
     {
+        // When the attribute specifies an explicit bucket, store the full keyspace
+        // (Bucket.Scope.Collection) directly as the table name. ConfigureToCouchbase then
+        // leaves it untouched (it only fills in the bucket/scope for bare collection names),
+        // so the entity is mapped to a bucket other than the DbContext's configured one.
+        if (keyspaceAttribute.Bucket is not null)
+        {
+            var keyspace = new Metadata.CouchbaseKeyspace(
+                keyspaceAttribute.Bucket, keyspaceAttribute.Scope!, keyspaceAttribute.Collection);
+            entityTypeBuilder.ToTable(keyspace.ToString());
+            return;
+        }
+
         // Set the collection name as the table name
         entityTypeBuilder.ToTable(keyspaceAttribute.Collection);
 

--- a/src/Couchbase.EntityFrameworkCore/Metadata/Conventions/CouchbaseKeyspaceConvention.cs
+++ b/src/Couchbase.EntityFrameworkCore/Metadata/Conventions/CouchbaseKeyspaceConvention.cs
@@ -23,8 +23,9 @@ public class CouchbaseKeyspaceConvention : TypeAttributeConventionBase<Couchbase
     {
         // When the attribute specifies an explicit bucket, store the full keyspace
         // (Bucket.Scope.Collection) directly as the table name. ConfigureToCouchbase then
-        // leaves it untouched (it only fills in the bucket/scope for bare collection names),
-        // so the entity is mapped to a bucket other than the DbContext's configured one.
+        // preserves the bucket and scope (it only fills in bucket/scope for bare collection
+        // names, and at most lowercases the collection segment), so the entity is mapped to a
+        // bucket other than the DbContext's configured one.
         if (keyspaceAttribute.Bucket is not null)
         {
             var keyspace = new Metadata.CouchbaseKeyspace(

--- a/src/Couchbase.EntityFrameworkCore/Metadata/CouchbaseKeyspaceAttribute.cs
+++ b/src/Couchbase.EntityFrameworkCore/Metadata/CouchbaseKeyspaceAttribute.cs
@@ -58,6 +58,30 @@ public class CouchbaseKeyspaceAttribute : Attribute
     }
 
     /// <summary>
+    /// Initializes a new instance with an explicit bucket, scope, and collection.
+    /// Use this to map an entity to a bucket other than the DbContext's configured bucket
+    /// (a single DbContext may span multiple buckets on the same cluster).
+    /// </summary>
+    /// <param name="bucket">The bucket name (overrides the DbContext-level bucket).</param>
+    /// <param name="scope">The scope name.</param>
+    /// <param name="collection">The collection name.</param>
+    public CouchbaseKeyspaceAttribute(string bucket, string scope, string collection)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(bucket);
+        ArgumentException.ThrowIfNullOrEmpty(scope);
+        ArgumentException.ThrowIfNullOrEmpty(collection);
+        Bucket = bucket;
+        Scope = scope;
+        Collection = collection;
+        HasScopeOverride = true;
+    }
+
+    /// <summary>
+    /// Gets the bucket name, or <c>null</c> if the bucket should be inherited from DbContext configuration.
+    /// </summary>
+    public string? Bucket { get; }
+
+    /// <summary>
     /// Gets the scope name, or <c>null</c> if the scope should be inherited from DbContext configuration.
     /// </summary>
     public string? Scope { get; }

--- a/src/Couchbase.EntityFrameworkCore/Storage/Internal/CouchbaseClientWrapper.cs
+++ b/src/Couchbase.EntityFrameworkCore/Storage/Internal/CouchbaseClientWrapper.cs
@@ -18,7 +18,6 @@ namespace Couchbase.EntityFrameworkCore.Storage.Internal;
 
 public class CouchbaseClientWrapper : ICouchbaseClientWrapper
 {
-    private IBucket? _bucket;
     private readonly IBucketProvider _bucketProvider;
     private readonly ICouchbaseDbContextOptionsBuilder _couchbaseDbContextOptionsBuilder;
     private readonly ILogger<CouchbaseClientWrapper> _logger;
@@ -151,27 +150,20 @@ public class CouchbaseClientWrapper : ICouchbaseClientWrapper
 
             var parsed = ParseKeyspace(keyspace);
 
-            // Validate that the keyspace bucket matches the configured bucket
-            // This prevents inconsistent behavior where queries target one bucket
-            // but KV operations target another
-            var configuredBucket = _couchbaseDbContextOptionsBuilder.Bucket;
-            if (!string.Equals(parsed.Bucket, configuredBucket, StringComparison.OrdinalIgnoreCase))
-            {
-                throw new InvalidOperationException(
-                    $"Keyspace bucket mismatch: The keyspace {parsed.ToSqlString()} specifies bucket '{parsed.Bucket}', " +
-                    $"but the DbContext is configured to use bucket '{configuredBucket}'. " +
-                    $"Ensure the entity mapping matches the DbContext bucket configuration.");
-            }
-
-            _bucket = await _bucketProvider.GetBucketAsync(configuredBucket).ConfigureAwait(false);
-            var collection = _bucket.Scope(parsed.Scope).Collection(parsed.Collection);
+            // Open the bucket named by the entity's keyspace. A single DbContext may span
+            // multiple buckets on the same cluster; each entity's keyspace carries its own
+            // bucket, so we resolve per-keyspace rather than forcing the configured bucket.
+            // The bucket provider caches open buckets, and the resolved collection is cached
+            // per keyspace below, so this does not re-open a bucket on the hot path.
+            var bucket = await _bucketProvider.GetBucketAsync(parsed.Bucket).ConfigureAwait(false);
+            var collection = bucket.Scope(parsed.Scope).Collection(parsed.Collection);
 
             _keyspaceCache[keyspace] = new CachedKeyspace(parsed.ToSqlString(), collection);
             return collection;
         }
         catch (InvalidOperationException)
         {
-            throw; // Re-throw bucket mismatch errors without wrapping
+            throw; // Surface configuration/state errors without wrapping them as keyspace errors.
         }
         catch (ArgumentException)
         {

--- a/src/Couchbase.EntityFrameworkCore/Storage/Internal/CouchbaseDatabaseCreator.cs
+++ b/src/Couchbase.EntityFrameworkCore/Storage/Internal/CouchbaseDatabaseCreator.cs
@@ -190,7 +190,8 @@ public class CouchbaseDatabaseCreator :  RelationalDatabaseCreator
                 }
                 catch (CollectionExistsException)
                 {
-                    _logger.LogWarning("Couchbase collection already exists.");
+                    _logger.LogWarning("Couchbase collection {Keyspace} already exists.",
+                        new CouchbaseKeyspace(bucketName, scopeName, collectionName).ToSqlString());
                 }
             }
         }

--- a/src/Couchbase.EntityFrameworkCore/Storage/Internal/CouchbaseDatabaseCreator.cs
+++ b/src/Couchbase.EntityFrameworkCore/Storage/Internal/CouchbaseDatabaseCreator.cs
@@ -186,9 +186,9 @@ public class CouchbaseDatabaseCreator :  RelationalDatabaseCreator
                 {
                     _logger.LogWarning(
                         "Collection '{CollectionName}' for entity '{EntityName}' targets non-default scope '{ScopeName}' " +
-                        "and will not be auto-created. The scope may not exist. " +
+                        "in bucket '{BucketName}' and will not be auto-created. The scope may not exist. " +
                         "Create the scope and collection manually, or enable AutoCreateScopes in DbContext options.",
-                        collectionName, entityName, scopeName);
+                        collectionName, entityName, scopeName, bucketName);
                     continue;
                 }
 

--- a/src/Couchbase.EntityFrameworkCore/Storage/Internal/CouchbaseDatabaseCreator.cs
+++ b/src/Couchbase.EntityFrameworkCore/Storage/Internal/CouchbaseDatabaseCreator.cs
@@ -146,12 +146,20 @@ public class CouchbaseDatabaseCreator :  RelationalDatabaseCreator
             var manager = (await GetBucketAsync(bucketName)).Collections;
             var existingScopes = (await manager.GetAllScopesAsync()).Select(s => s.Name).ToHashSet();
 
-            // The configured scope is always ensured; other scopes only when AutoCreateScopes
-            // is enabled (otherwise their collections are skipped with a warning below).
-            var scopesToEnsure = new HashSet<string> { configuredScope };
-            if (_couchbaseDbContextOptionsBuilder.AutoCreateScopes)
+            // Only ensure scopes we will actually create a collection in: the configured scope
+            // (always created) and, when AutoCreateScopes is enabled, any other scope. Scopes
+            // that would only ever hold skipped collections are left alone so we don't create
+            // empty scopes — or trip permission failures — in buckets that don't need them.
+            var scopesToEnsure = entries
+                .Where(e => e.Scope == configuredScope || _couchbaseDbContextOptionsBuilder.AutoCreateScopes)
+                .Select(e => e.Scope)
+                .ToHashSet();
+
+            // The configured bucket always ensures the configured scope, even with an empty
+            // model (preserves the pre-multi-bucket behavior).
+            if (bucketName == _couchbaseDbContextOptionsBuilder.Bucket)
             {
-                scopesToEnsure.UnionWith(entries.Select(e => e.Scope));
+                scopesToEnsure.Add(configuredScope);
             }
 
             foreach (var scope in scopesToEnsure)

--- a/src/Couchbase.EntityFrameworkCore/Storage/Internal/CouchbaseDatabaseCreator.cs
+++ b/src/Couchbase.EntityFrameworkCore/Storage/Internal/CouchbaseDatabaseCreator.cs
@@ -106,7 +106,7 @@ public class CouchbaseDatabaseCreator :  RelationalDatabaseCreator
         // Always process the configured bucket so its configured scope is ensured even when no
         // entity maps to it (preserves the pre-multi-bucket behavior).
         byBucket[_couchbaseDbContextOptionsBuilder.Bucket] =
-            new List<(string, string, string)>();
+            new List<(string Scope, string Collection, string EntityName)>();
 
         foreach (var entityType in _designTimeModel.Model.GetEntityTypes())
         {
@@ -136,7 +136,7 @@ public class CouchbaseDatabaseCreator :  RelationalDatabaseCreator
 
             if (!byBucket.TryGetValue(bucketName, out var entries))
             {
-                byBucket[bucketName] = entries = new List<(string, string, string)>();
+                byBucket[bucketName] = entries = new List<(string Scope, string Collection, string EntityName)>();
             }
             entries.Add((scopeName, collectionName, entityType.ClrType.Name));
         }

--- a/src/Couchbase.EntityFrameworkCore/Storage/Internal/CouchbaseDatabaseCreator.cs
+++ b/src/Couchbase.EntityFrameworkCore/Storage/Internal/CouchbaseDatabaseCreator.cs
@@ -53,7 +53,10 @@ public class CouchbaseDatabaseCreator :  RelationalDatabaseCreator
         _cluster = await clusterProvider.GetClusterAsync();
     }
 
-    private async Task<IBucket> GetBucketAsync(CancellationToken cancellationToken = default)
+    private Task<IBucket> GetBucketAsync(CancellationToken cancellationToken = default)
+        => GetBucketAsync(_couchbaseDbContextOptionsBuilder.Bucket, cancellationToken);
+
+    private async Task<IBucket> GetBucketAsync(string bucketName, CancellationToken cancellationToken = default)
     {
         const int maxRetries = 10;
         const int delayMs = 500;
@@ -64,19 +67,19 @@ public class CouchbaseDatabaseCreator :  RelationalDatabaseCreator
 
             try
             {
-                return await _cluster.BucketAsync(_couchbaseDbContextOptionsBuilder.Bucket);
+                return await _cluster.BucketAsync(bucketName);
             }
             catch (Exception e)
             {
                 if (attempt == maxRetries)
                 {
                     _logger.LogError(e, "Failed to retrieve Couchbase bucket '{BucketName}' after {MaxRetries} attempts",
-                        _couchbaseDbContextOptionsBuilder.Bucket, maxRetries);
+                        bucketName, maxRetries);
                     throw;
                 }
 
                 _logger.LogWarning(e, "Couchbase bucket '{BucketName}' could not be retrieved (attempt {Attempt}/{MaxRetries}). Retrying...",
-                    _couchbaseDbContextOptionsBuilder.Bucket, attempt, maxRetries);
+                    bucketName, attempt, maxRetries);
 
                 await Task.Delay(delayMs, cancellationToken);
             }
@@ -91,30 +94,19 @@ public class CouchbaseDatabaseCreator :  RelationalDatabaseCreator
         return true;
     }
 
-    private async Task CreateScopeAsync()
-    {
-        var manager = (await GetBucketAsync()).Collections;
-        var scopes = await manager.GetAllScopesAsync();
-        if(!scopes.Contains(new ScopeSpec(_couchbaseDbContextOptionsBuilder.Scope)))
-        {
-            try
-            {
-                await manager.CreateScopeAsync(_couchbaseDbContextOptionsBuilder.Scope);
-            }
-            catch (ScopeExistsException)
-            {
-                _logger.LogWarning("Couchbase scope already exists.");
-            }
-        }
-    }
-
     private async Task CreateCollectionsAsync()
     {
-        var manager = (await GetBucketAsync()).Collections;
+        var configuredScope = _couchbaseDbContextOptionsBuilder.Scope;
 
-        // Collect all collections and their scopes from the model
-        var collections = new List<(string Scope, string Collection, string EntityName)>();
-        var nonDefaultScopes = new HashSet<string>();
+        // Group each entity's keyspace by bucket. A single DbContext may map entities to
+        // multiple buckets on the same cluster, so scopes and collections are created in the
+        // bucket named by each entity's keyspace rather than only the configured bucket.
+        var byBucket = new Dictionary<string, List<(string Scope, string Collection, string EntityName)>>();
+
+        // Always process the configured bucket so its configured scope is ensured even when no
+        // entity maps to it (preserves the pre-multi-bucket behavior).
+        byBucket[_couchbaseDbContextOptionsBuilder.Bucket] =
+            new List<(string, string, string)>();
 
         foreach (var entityType in _designTimeModel.Model.GetEntityTypes())
         {
@@ -124,67 +116,82 @@ public class CouchbaseDatabaseCreator :  RelationalDatabaseCreator
                 continue;
             }
 
+            string bucketName;
             string collectionName;
             string scopeName;
 
             if (CouchbaseKeyspace.TryParse(tableName, out var keyspace))
             {
-                collectionName = keyspace!.Value.Collection;
+                bucketName = keyspace!.Value.Bucket;
+                collectionName = keyspace.Value.Collection;
                 scopeName = keyspace.Value.Scope;
             }
             else
             {
-                // Fallback: use table name as collection name in default scope
+                // Fallback: use table name as collection name in the configured bucket/scope.
+                bucketName = _couchbaseDbContextOptionsBuilder.Bucket;
                 collectionName = tableName;
-                scopeName = _couchbaseDbContextOptionsBuilder.Scope;
+                scopeName = configuredScope;
             }
 
-            collections.Add((scopeName, collectionName, entityType.ClrType.Name));
-
-            if (scopeName != _couchbaseDbContextOptionsBuilder.Scope)
+            if (!byBucket.TryGetValue(bucketName, out var entries))
             {
-                nonDefaultScopes.Add(scopeName);
+                byBucket[bucketName] = entries = new List<(string, string, string)>();
             }
+            entries.Add((scopeName, collectionName, entityType.ClrType.Name));
         }
 
-        // Create non-default scopes if AutoCreateScopes is enabled
-        if (_couchbaseDbContextOptionsBuilder.AutoCreateScopes && nonDefaultScopes.Count > 0)
+        foreach (var (bucketName, entries) in byBucket)
         {
-            foreach (var scope in nonDefaultScopes)
+            var manager = (await GetBucketAsync(bucketName)).Collections;
+            var existingScopes = (await manager.GetAllScopesAsync()).Select(s => s.Name).ToHashSet();
+
+            // The configured scope is always ensured; other scopes only when AutoCreateScopes
+            // is enabled (otherwise their collections are skipped with a warning below).
+            var scopesToEnsure = new HashSet<string> { configuredScope };
+            if (_couchbaseDbContextOptionsBuilder.AutoCreateScopes)
             {
+                scopesToEnsure.UnionWith(entries.Select(e => e.Scope));
+            }
+
+            foreach (var scope in scopesToEnsure)
+            {
+                if (existingScopes.Contains(scope))
+                {
+                    continue;
+                }
                 try
                 {
                     await manager.CreateScopeAsync(scope);
-                    _logger.LogDebug("Created scope {ScopeName}", scope);
+                    _logger.LogDebug("Created scope {ScopeName} in bucket {BucketName}", scope, bucketName);
                 }
                 catch (ScopeExistsException)
                 {
                     // Scope already exists, continue
                 }
             }
-        }
 
-        // Create collections
-        foreach (var (scopeName, collectionName, entityName) in collections)
-        {
-            // Skip non-default scope collections if AutoCreateScopes is disabled
-            if (scopeName != _couchbaseDbContextOptionsBuilder.Scope && !_couchbaseDbContextOptionsBuilder.AutoCreateScopes)
+            foreach (var (scopeName, collectionName, entityName) in entries)
             {
-                _logger.LogWarning(
-                    "Collection '{CollectionName}' for entity '{EntityName}' targets non-default scope '{ScopeName}' " +
-                    "and will not be auto-created. The scope may not exist. " +
-                    "Create the scope and collection manually, or enable AutoCreateScopes in DbContext options.",
-                    collectionName, entityName, scopeName);
-                continue;
-            }
+                // Skip non-default scope collections if AutoCreateScopes is disabled
+                if (scopeName != configuredScope && !_couchbaseDbContextOptionsBuilder.AutoCreateScopes)
+                {
+                    _logger.LogWarning(
+                        "Collection '{CollectionName}' for entity '{EntityName}' targets non-default scope '{ScopeName}' " +
+                        "and will not be auto-created. The scope may not exist. " +
+                        "Create the scope and collection manually, or enable AutoCreateScopes in DbContext options.",
+                        collectionName, entityName, scopeName);
+                    continue;
+                }
 
-            try
-            {
-                await manager.CreateCollectionAsync(scopeName, collectionName, new CreateCollectionSettings());
-            }
-            catch (CollectionExistsException)
-            {
-                _logger.LogWarning("Couchbase collection already exists.");
+                try
+                {
+                    await manager.CreateCollectionAsync(scopeName, collectionName, new CreateCollectionSettings());
+                }
+                catch (CollectionExistsException)
+                {
+                    _logger.LogWarning("Couchbase collection already exists.");
+                }
             }
         }
     }
@@ -433,9 +440,9 @@ public class CouchbaseDatabaseCreator :  RelationalDatabaseCreator
             created = true;
         }
 
-        // Always ensure scope, collections, and sequences exist
-        // even if bucket already existed (they use IF NOT EXISTS / catch-exists patterns)
-        await CreateScopeAsync();
+        // Always ensure scopes, collections, and sequences exist even if the bucket already
+        // existed (they use IF NOT EXISTS / catch-exists patterns). CreateCollectionsAsync
+        // ensures the required scopes per bucket before creating collections.
         await CreateCollectionsAsync();
         await CreateSequencesAsync();
 

--- a/tests/Couchbase.EntityFrameworkCore.IntegrationTests/Tests/KeyspaceMappingIntegrationTests.cs
+++ b/tests/Couchbase.EntityFrameworkCore.IntegrationTests/Tests/KeyspaceMappingIntegrationTests.cs
@@ -99,6 +99,22 @@ public class KeyspaceMappingIntegrationTests
         Assert.Equal("other-bucket.other-scope.other-collection", tableName);
     }
 
+    [Fact]
+    public void ConfigureToCouchbase_WithLowerCaseNaming_PreservesFullKeyspaceBucketAndScopeCase()
+    {
+        // Bucket and scope are case-sensitive in Couchbase. When an entity is mapped to an
+        // explicit full keyspace, toLowerCaseNaming must not rewrite the bucket/scope (which
+        // would break bucket resolution at runtime) — only the collection segment is lowercased.
+        using var context = CreateContext<ConfigureToCouchbaseMixedCaseKeyspaceContext>();
+        var entityType = context.Model.FindEntityType(typeof(TestEntity))!;
+
+        var tableName = entityType.GetTableName();
+        Assert.True(CouchbaseKeyspace.TryParse(tableName!, out var keyspace));
+        Assert.Equal("Mixed-Bucket", keyspace!.Value.Bucket);       // preserved
+        Assert.Equal("Mixed-Scope", keyspace.Value.Scope);          // preserved
+        Assert.Equal("mixed-collection", keyspace.Value.Collection); // lowercased
+    }
+
     #endregion
 
     #region CouchbaseKeyspaceAttribute Tests
@@ -301,6 +317,18 @@ public class KeyspaceMappingIntegrationTests
         {
             modelBuilder.Entity<TestEntity>().ToTable("other-bucket.other-scope.other-collection");
             modelBuilder.ConfigureToCouchbase(this);
+        }
+    }
+
+    private class ConfigureToCouchbaseMixedCaseKeyspaceContext : DbContext
+    {
+        public ConfigureToCouchbaseMixedCaseKeyspaceContext(DbContextOptions options) : base(options) { }
+        public DbSet<TestEntity> TestEntities { get; set; } = null!;
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            modelBuilder.Entity<TestEntity>().ToCouchbaseCollection("Mixed-Bucket", "Mixed-Scope", "Mixed-Collection");
+            modelBuilder.ConfigureToCouchbase(this, toLowerCaseNaming: true);
         }
     }
 

--- a/tests/Couchbase.EntityFrameworkCore.IntegrationTests/Tests/MultiBucketSingleContextTests.cs
+++ b/tests/Couchbase.EntityFrameworkCore.IntegrationTests/Tests/MultiBucketSingleContextTests.cs
@@ -1,0 +1,106 @@
+using Couchbase.EntityFrameworkCode.IntegrationTests.Fixtures;
+using Couchbase.EntityFrameworkCore.Extensions;
+using Couchbase.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace Couchbase.EntityFrameworkCode.IntegrationTests.Tests;
+
+/// <summary>
+/// Multi-bucket single-context coverage (Scope B): a single DbContext maps different entity
+/// types to different buckets on the same cluster. Writes in one SaveChanges fan out to both
+/// buckets, queries and Find target the correct bucket, and the two buckets stay isolated even
+/// when they share scope/collection names and primary-key values.
+/// </summary>
+[Collection(CouchbaseTestingCollection.Name)]
+public class MultiBucketSingleContextTests(BloggingFixture fixture)
+{
+    [Fact]
+    public async Task SingleContext_SpanningTwoBuckets_WritesReadsAndQueriesEachBucket()
+    {
+        var services = new ServiceCollection();
+        services.AddCouchbase<SpanningContext>(
+            new global::Couchbase.ClusterOptions()
+                .WithConnectionString(fixture.Host)
+                .WithCredentials(fixture.Username, fixture.Password),
+            o =>
+            {
+                // "default" is the configured (primary) bucket; Gizmo overrides to "secondary".
+                o.Bucket = "default";
+                o.Scope = "isolation";
+                // Read-after-write consistency so the reads below see the just-written docs.
+                o.ScanConsistency = global::Couchbase.Query.QueryScanConsistency.RequestPlus;
+            },
+            o => o.UseCamelCaseNamingConvention());
+
+        await using var provider = services.BuildServiceProvider();
+
+        // Write the same PK (1) into both buckets with distinct values, in one SaveChanges.
+        await using (var scope = provider.CreateAsyncScope())
+        {
+            var context = scope.ServiceProvider.GetRequiredService<SpanningContext>();
+
+            // Exercises per-bucket EnsureCreated (creates isolation.widget in both buckets).
+            await context.Database.EnsureCreatedAsync();
+
+            context.Update(new Widget { Id = 1, Name = "widget-in-default" });
+            context.Update(new Gizmo { Id = 1, Name = "gizmo-in-secondary" });
+            await context.SaveChangesAsync();
+        }
+
+        // Read back in a fresh context (no identity-map carryover).
+        await using (var scope = provider.CreateAsyncScope())
+        {
+            var context = scope.ServiceProvider.GetRequiredService<SpanningContext>();
+
+            // KV path (Find) resolves each entity's own bucket.
+            var widget = await context.Widgets.FindAsync(1);
+            var gizmo = await context.Gizmos.FindAsync(1);
+
+            Assert.NotNull(widget);
+            Assert.NotNull(gizmo);
+            // Same key, same scope/collection, different bucket → no cross-talk.
+            Assert.Equal("widget-in-default", widget!.Name);
+            Assert.Equal("gizmo-in-secondary", gizmo!.Name);
+
+            // Query path (N1QL) targets the correct bucket in the FROM clause.
+            var widgetsByName = await context.Widgets
+                .Where(w => w.Name == "widget-in-default").ToListAsync();
+            var gizmosByName = await context.Gizmos
+                .Where(g => g.Name == "gizmo-in-secondary").ToListAsync();
+
+            Assert.Single(widgetsByName);
+            Assert.Single(gizmosByName);
+            // A widget value must never surface from the secondary bucket's collection.
+            Assert.Empty(await context.Gizmos.Where(g => g.Name == "widget-in-default").ToListAsync());
+        }
+    }
+
+    public class Widget
+    {
+        public int Id { get; set; }
+        public string Name { get; set; } = null!;
+    }
+
+    public class Gizmo
+    {
+        public int Id { get; set; }
+        public string Name { get; set; } = null!;
+    }
+
+    public sealed class SpanningContext(DbContextOptions<SpanningContext> options) : DbContext(options)
+    {
+        public DbSet<Widget> Widgets { get; set; } = null!;
+        public DbSet<Gizmo> Gizmos { get; set; } = null!;
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            // Both buckets expose an identical isolation.widget keyspace (see AppHost), so the
+            // two entity types differ only by bucket.
+            modelBuilder.Entity<Widget>().ToCouchbaseCollection("default", "isolation", "widget");
+            modelBuilder.Entity<Gizmo>().ToCouchbaseCollection("secondary", "isolation", "widget");
+            modelBuilder.ConfigureToCouchbase(this, true);
+        }
+    }
+}

--- a/tests/Couchbase.EntityFrameworkCore.IntegrationTests/Tests/MultiBucketSingleContextTests.cs
+++ b/tests/Couchbase.EntityFrameworkCore.IntegrationTests/Tests/MultiBucketSingleContextTests.cs
@@ -1,9 +1,6 @@
 using Couchbase.EntityFrameworkCode.IntegrationTests.Fixtures;
 using Couchbase.EntityFrameworkCore.Extensions;
-using Couchbase.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore;
-using Microsoft.Extensions.DependencyInjection;
-using Xunit;
 
 namespace Couchbase.EntityFrameworkCode.IntegrationTests.Tests;
 

--- a/tests/Couchbase.EntityFrameworkCore.UnitTests/Couchbase/EntityFrameworkCore/Metadata/KeyspaceMappingTests.cs
+++ b/tests/Couchbase.EntityFrameworkCore.UnitTests/Couchbase/EntityFrameworkCore/Metadata/KeyspaceMappingTests.cs
@@ -149,6 +149,34 @@ public class KeyspaceMappingTests
     }
 
     [Fact]
+    public void CouchbaseKeyspaceAttribute_WithCollectionOnly_HasNullBucket()
+    {
+        var attribute = new CouchbaseKeyspaceAttribute("users");
+
+        Assert.Null(attribute.Bucket);
+    }
+
+    [Fact]
+    public void CouchbaseKeyspaceAttribute_WithBucketScopeAndCollection_SetsAllValues()
+    {
+        var attribute = new CouchbaseKeyspaceAttribute("secondary", "custom-scope", "products");
+
+        Assert.Equal("secondary", attribute.Bucket);
+        Assert.Equal("custom-scope", attribute.Scope);
+        Assert.Equal("products", attribute.Collection);
+        Assert.True(attribute.HasScopeOverride);
+    }
+
+    [Fact]
+    public void CouchbaseKeyspaceAttribute_ThrowsOnNullBucketScopeOrCollection()
+    {
+        Assert.ThrowsAny<ArgumentException>(() => new CouchbaseKeyspaceAttribute(null!, "scope", "collection"));
+        Assert.ThrowsAny<ArgumentException>(() => new CouchbaseKeyspaceAttribute("bucket", null!, "collection"));
+        Assert.ThrowsAny<ArgumentException>(() => new CouchbaseKeyspaceAttribute("bucket", "scope", null!));
+        Assert.ThrowsAny<ArgumentException>(() => new CouchbaseKeyspaceAttribute("", "scope", "collection"));
+    }
+
+    [Fact]
     public void CouchbaseKeyspaceAttribute_ThrowsOnNullCollection()
     {
         Assert.ThrowsAny<ArgumentException>(() => new CouchbaseKeyspaceAttribute(null!));

--- a/tests/Couchbase.EntityFrameworkCore.UnitTests/Couchbase/EntityFrameworkCore/Storage/Internal/CouchbaseClientWrapperTests.cs
+++ b/tests/Couchbase.EntityFrameworkCore.UnitTests/Couchbase/EntityFrameworkCore/Storage/Internal/CouchbaseClientWrapperTests.cs
@@ -102,34 +102,19 @@ public class CouchbaseClientWrapperTests
     }
 
     [Fact]
-    public async Task GetCollectionAsync_WithMismatchedBucket_ThrowsInvalidOperationException()
+    public async Task GetCollectionAsync_WithDifferentBucket_OpensThatBucket()
     {
-        // Arrange: Keyspace bucket doesn't match configured bucket
-        var keyspace = "different-bucket.MyScope.MyCollection";
-
-        var wrapper = new CouchbaseClientWrapper(
-            _mockBucketProvider.Object,
-            _mockOptions.Object,
-            _mockLogger.Object);
-
-        // Act & Assert
-        var exception = await Assert.ThrowsAsync<InvalidOperationException>(
-            () => wrapper.GetCollectionAsync(keyspace));
-
-        Assert.Contains("bucket mismatch", exception.Message, StringComparison.OrdinalIgnoreCase);
-        Assert.Contains("different-bucket", exception.Message);
-        Assert.Contains("test-bucket", exception.Message);
-    }
-
-    [Fact]
-    public async Task GetCollectionAsync_WithMatchingBucketDifferentCase_Succeeds()
-    {
-        // Arrange: Keyspace bucket matches configured bucket (case-insensitive)
-        var keyspace = "TEST-BUCKET.MyScope.MyCollection";
+        // A single context may span multiple buckets on the same cluster: a keyspace naming a
+        // bucket other than the configured one opens that bucket rather than being rejected.
+        var keyspace = "other-bucket.MyScope.MyCollection";
+        var mockOtherBucket = new Mock<IBucket>();
+        var mockOtherScope = new Mock<IScope>();
         var mockCollection = new Mock<ICouchbaseCollection>();
 
-        _mockBucket.Setup(b => b.Scope("MyScope")).Returns(_mockScope.Object);
-        _mockScope.Setup(s => s.Collection("MyCollection")).Returns(mockCollection.Object);
+        _mockBucketProvider.Setup(p => p.GetBucketAsync("other-bucket"))
+            .ReturnsAsync(mockOtherBucket.Object);
+        mockOtherBucket.Setup(b => b.Scope("MyScope")).Returns(mockOtherScope.Object);
+        mockOtherScope.Setup(s => s.Collection("MyCollection")).Returns(mockCollection.Object);
 
         var wrapper = new CouchbaseClientWrapper(
             _mockBucketProvider.Object,
@@ -139,8 +124,38 @@ public class CouchbaseClientWrapperTests
         // Act
         var collection = await wrapper.GetCollectionAsync(keyspace);
 
-        // Assert - Should succeed with case-insensitive bucket match
+        // Assert - resolves the collection from the keyspace's own bucket.
         Assert.Same(mockCollection.Object, collection);
+        _mockBucketProvider.Verify(p => p.GetBucketAsync("other-bucket"), Times.Once);
+    }
+
+    [Fact]
+    public async Task GetCollectionAsync_UsesKeyspaceBucketNameVerbatim()
+    {
+        // Bucket names are case-sensitive in Couchbase; the keyspace's bucket segment is used
+        // exactly as written, not coerced to the context's configured bucket.
+        var keyspace = "Exact-Bucket.MyScope.MyCollection";
+        var mockExactBucket = new Mock<IBucket>();
+        var mockExactScope = new Mock<IScope>();
+        var mockCollection = new Mock<ICouchbaseCollection>();
+
+        _mockBucketProvider.Setup(p => p.GetBucketAsync("Exact-Bucket"))
+            .ReturnsAsync(mockExactBucket.Object);
+        mockExactBucket.Setup(b => b.Scope("MyScope")).Returns(mockExactScope.Object);
+        mockExactScope.Setup(s => s.Collection("MyCollection")).Returns(mockCollection.Object);
+
+        var wrapper = new CouchbaseClientWrapper(
+            _mockBucketProvider.Object,
+            _mockOptions.Object,
+            _mockLogger.Object);
+
+        // Act
+        var collection = await wrapper.GetCollectionAsync(keyspace);
+
+        // Assert - opened the exact bucket named in the keyspace, not "test-bucket".
+        Assert.Same(mockCollection.Object, collection);
+        _mockBucketProvider.Verify(p => p.GetBucketAsync("Exact-Bucket"), Times.Once);
+        _mockBucketProvider.Verify(p => p.GetBucketAsync("test-bucket"), Times.Never);
     }
 
     [Fact]

--- a/tests/Couchbase.EntityFrameworkCore.UnitTests/Couchbase/EntityFrameworkCore/Storage/Internal/CouchbaseDatabaseCreatorTests.cs
+++ b/tests/Couchbase.EntityFrameworkCore.UnitTests/Couchbase/EntityFrameworkCore/Storage/Internal/CouchbaseDatabaseCreatorTests.cs
@@ -370,6 +370,58 @@ public class CouchbaseDatabaseCreatorTests
     }
 
     [Fact]
+    public async Task EnsureCreatedAsync_SecondaryBucketDifferentScope_DoesNotCreateConfiguredScopeThere()
+    {
+        // A single context maps an entity to a non-configured scope in a secondary bucket, with
+        // AutoCreateScopes disabled. The configured scope must NOT be created in that secondary
+        // bucket — nothing will be stored there, so creating it is unnecessary and can trip
+        // permission failures.
+        _mockOptions.Setup(o => o.Bucket).Returns("my-bucket");
+        _mockOptions.Setup(o => o.Scope).Returns("my-scope");
+        _mockOptions.Setup(o => o.AutoCreateScopes).Returns(false);
+
+        _mockBucketManager.Setup(m => m.GetBucketAsync("my-bucket", It.IsAny<GetBucketOptions>()))
+            .ReturnsAsync(new BucketSettings { Name = "my-bucket" });
+
+        // Configured bucket: the configured scope already exists.
+        _mockCluster.Setup(c => c.BucketAsync("my-bucket")).ReturnsAsync(_mockBucket.Object);
+        _mockCollectionManager.Setup(m => m.GetAllScopesAsync(It.IsAny<GetAllScopesOptions>()))
+            .ReturnsAsync(new List<ScopeSpec> { new ScopeSpec("my-scope") });
+
+        // Secondary bucket with its own collection manager, exposing only the default scope.
+        var mockSecondaryBucket = new Mock<IBucket>();
+        var mockSecondaryCollectionManager = new Mock<ICouchbaseCollectionManager>();
+        mockSecondaryBucket.Setup(b => b.Collections).Returns(mockSecondaryCollectionManager.Object);
+        mockSecondaryCollectionManager.Setup(m => m.GetAllScopesAsync(It.IsAny<GetAllScopesOptions>()))
+            .ReturnsAsync(new List<ScopeSpec> { new ScopeSpec("_default") });
+        _mockCluster.Setup(c => c.BucketAsync("secondary")).ReturnsAsync(mockSecondaryBucket.Object);
+
+        // Entity lives in secondary.other-scope.OtherCollection.
+        var mockEntityType = new Mock<IEntityType>();
+        var mockTableNameAnnotation = new Mock<IAnnotation>();
+        mockTableNameAnnotation.Setup(a => a.Value).Returns("secondary.other-scope.OtherCollection");
+        mockEntityType.Setup(e => e.FindAnnotation("Relational:TableName")).Returns(mockTableNameAnnotation.Object);
+        mockEntityType.Setup(e => e.ClrType).Returns(typeof(TestEntity));
+        mockEntityType.Setup(e => e.GetProperties()).Returns(Array.Empty<IProperty>());
+        _mockModel.Setup(m => m.GetEntityTypes()).Returns(new[] { mockEntityType.Object });
+
+        var creator = CreateCreator();
+
+        // Act
+        await creator.EnsureCreatedAsync();
+
+        // Assert - nothing is created in the secondary bucket: not the configured scope, not the
+        // non-default scope (AutoCreateScopes off), and not the collection.
+        mockSecondaryCollectionManager.Verify(
+            m => m.CreateScopeAsync("my-scope", It.IsAny<CreateScopeOptions>()), Times.Never);
+        mockSecondaryCollectionManager.Verify(
+            m => m.CreateScopeAsync("other-scope", It.IsAny<CreateScopeOptions>()), Times.Never);
+        mockSecondaryCollectionManager.Verify(
+            m => m.CreateCollectionAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CreateCollectionSettings>()),
+            Times.Never);
+    }
+
+    [Fact]
     public async Task EnsureCreatedAsync_WithAutoCreateScopes_CreatesNonDefaultScopes()
     {
         // Arrange


### PR DESCRIPTION
A single DbContext can now map different entities to different buckets on the same cluster, instead of being limited to one configured bucket. Most of the machinery already existed — the full Bucket.Scope.Collection keyspace is stored as the EF table name and flows through both the query FROM clause and the KV write path, and N1QL already runs at the cluster level — so this mainly removes the guard that forced a single bucket and resolves each entity's own bucket.

Scope is same-cluster only: buckets mapped within one context must share a connection string. Cross-cluster in one context remains unsupported (a single N1QL query or transaction cannot span clusters) — use ServiceKey with a context per cluster for that.

- CouchbaseClientWrapper: remove the bucket-mismatch guard and open the bucket named by each entity's keyspace (verbatim, case-sensitive) rather than the configured bucket; drop the single _bucket field (the collection cache already keys per keyspace).
- CouchbaseDatabaseCreator: EnsureCreated groups entity keyspaces by bucket and creates scopes/collections in each; GetBucketAsync is parameterized by bucket name. The configured bucket is always processed so its scope is ensured even with an empty model. Server-side sequences still target the configured bucket.
- CouchbaseKeyspaceAttribute: add a three-argument (bucket, scope, collection) constructor for parity with ToCouchbaseCollection; the keyspace convention stores the full keyspace so ConfigureToCouchbase preserves it.
- Tests: add MultiBucketSingleContextTests (one context spanning the default and secondary buckets — write, read, query, isolation) and attribute unit tests; update the wrapper/creator unit tests that asserted the old single-bucket guard and scope-creation flow.
- Docs: add a "One context spanning multiple buckets" section to configuration.md, update limitations.md, and add a CHANGELOG [Unreleased] entry.