### PR TITLE
Add cross-bucket multi-document transaction coverage

### DIFF
--- a/tests/Couchbase.EntityFrameworkCore.IntegrationTests/Fixtures/PollingHelper.cs
+++ b/tests/Couchbase.EntityFrameworkCore.IntegrationTests/Fixtures/PollingHelper.cs
@@ -36,7 +36,12 @@ public static class PollingHelper
         return await query();
     }
 
-    /// <summary>Polls <paramref name="condition"/> until it returns true or <paramref name="timeout"/> elapses.</summary>
+    /// <summary>
+    /// Polls <paramref name="condition"/> until it returns true, throwing <see cref="TimeoutException"/>
+    /// if it never does within <paramref name="timeout"/> — a test helper that silently returned on
+    /// timeout would let a caller's test continue (and potentially pass) despite the condition never
+    /// being satisfied.
+    /// </summary>
     public static async Task PollUntilAsync(
         Func<Task<bool>> condition,
         TimeSpan timeout,
@@ -53,5 +58,7 @@ public static class PollingHelper
             }
             await Task.Delay(interval);
         }
+
+        throw new TimeoutException($"Condition was not met within {timeout}.");
     }
 }

--- a/tests/Couchbase.EntityFrameworkCore.IntegrationTests/Fixtures/PollingHelper.cs
+++ b/tests/Couchbase.EntityFrameworkCore.IntegrationTests/Fixtures/PollingHelper.cs
@@ -1,0 +1,57 @@
+namespace Couchbase.EntityFrameworkCode.IntegrationTests.Fixtures;
+
+/// <summary>
+/// Shared polling helpers for tests that must tolerate eventual consistency (e.g. a KV read
+/// immediately after a transaction commit, or an N1QL query before an index catches up).
+/// Kept as a single implementation so timeout/interval semantics can't drift between the
+/// transaction-related test classes that need this.
+/// </summary>
+public static class PollingHelper
+{
+    /// <summary>
+    /// Repeatedly invokes <paramref name="query"/> until <paramref name="condition"/> is met or
+    /// <paramref name="timeout"/> elapses, returning the final result either way (letting a
+    /// caller's assertion fail with the actual value rather than swallowing the timeout).
+    /// </summary>
+    public static async Task<T?> PollForResultAsync<T>(
+        Func<Task<T?>> query,
+        Func<T?, bool> condition,
+        TimeSpan timeout,
+        TimeSpan? pollInterval = null)
+    {
+        var interval = pollInterval ?? TimeSpan.FromMilliseconds(50);
+        var deadline = DateTime.UtcNow + timeout;
+
+        while (DateTime.UtcNow < deadline)
+        {
+            var result = await query();
+            if (condition(result))
+            {
+                return result;
+            }
+            await Task.Delay(interval);
+        }
+
+        // Return final result even if condition not met (let assertion fail with actual value).
+        return await query();
+    }
+
+    /// <summary>Polls <paramref name="condition"/> until it returns true or <paramref name="timeout"/> elapses.</summary>
+    public static async Task PollUntilAsync(
+        Func<Task<bool>> condition,
+        TimeSpan timeout,
+        TimeSpan? pollInterval = null)
+    {
+        var interval = pollInterval ?? TimeSpan.FromMilliseconds(50);
+        var deadline = DateTime.UtcNow + timeout;
+
+        while (DateTime.UtcNow < deadline)
+        {
+            if (await condition())
+            {
+                return;
+            }
+            await Task.Delay(interval);
+        }
+    }
+}

--- a/tests/Couchbase.EntityFrameworkCore.IntegrationTests/Tests/CrossBucketTransactionTests.cs
+++ b/tests/Couchbase.EntityFrameworkCore.IntegrationTests/Tests/CrossBucketTransactionTests.cs
@@ -83,10 +83,20 @@ public class CrossBucketTransactionTests(BloggingFixture fixture)
             }
             finally
             {
-                // Clean up even if an assertion (or FindAsync) fails above — otherwise these
-                // documents would leak into subsequent test runs.
-                if (widgetA != null) context.Remove(widgetA);
-                if (widgetB != null) context.Remove(widgetB);
+                // Re-check with the same bounded polling rather than trusting widgetA/widgetB
+                // from the try block: if the poll above timed out (or an assertion threw before
+                // they were assigned), the documents can still exist on the server and must not
+                // be skipped here, or they'd leak into subsequent test runs.
+                var cleanupA = await PollForResultAsync(
+                    () => context.WidgetsA.FindAsync(id).AsTask(),
+                    result => result != null,
+                    TimeSpan.FromSeconds(5));
+                var cleanupB = await PollForResultAsync(
+                    () => context.WidgetsB.FindAsync(id).AsTask(),
+                    result => result != null,
+                    TimeSpan.FromSeconds(5));
+                if (cleanupA != null) context.Remove(cleanupA);
+                if (cleanupB != null) context.Remove(cleanupB);
                 await context.SaveChangesAsync();
             }
         }
@@ -171,9 +181,21 @@ public class CrossBucketTransactionTests(BloggingFixture fixture)
         {
             await using var cleanupScope = provider.CreateAsyncScope();
             var cleanupContext = cleanupScope.ServiceProvider.GetRequiredService<SpanningContext>();
-            var leftoverA = await cleanupContext.WidgetsA.FindAsync(newId);
+
+            // Poll (briefly) rather than a single immediate read: if the transaction
+            // unexpectedly persisted data, or the test failed partway through, a momentarily
+            // stale KV read here could miss a leftover document and leak it into later runs.
+            // Short timeout because the common case is a genuinely absent document (the
+            // transaction correctly rolled back), where this always runs to the full timeout.
+            var leftoverA = await PollForResultAsync(
+                () => cleanupContext.WidgetsA.FindAsync(newId).AsTask(),
+                result => result != null,
+                TimeSpan.FromSeconds(2));
             if (leftoverA != null) cleanupContext.Remove(leftoverA);
-            var widgetB = await cleanupContext.WidgetsB.FindAsync(conflictingId);
+            var widgetB = await PollForResultAsync(
+                () => cleanupContext.WidgetsB.FindAsync(conflictingId).AsTask(),
+                result => result != null,
+                TimeSpan.FromSeconds(2));
             if (widgetB != null) cleanupContext.Remove(widgetB);
             await cleanupContext.SaveChangesAsync();
         }

--- a/tests/Couchbase.EntityFrameworkCore.IntegrationTests/Tests/CrossBucketTransactionTests.cs
+++ b/tests/Couchbase.EntityFrameworkCore.IntegrationTests/Tests/CrossBucketTransactionTests.cs
@@ -64,8 +64,17 @@ public class CrossBucketTransactionTests(BloggingFixture fixture)
             TxWidgetB? widgetB = null;
             try
             {
-                widgetA = await context.WidgetsA.FindAsync(id);
-                widgetB = await context.WidgetsB.FindAsync(id);
+                // KV reads aren't governed by QueryScanConsistency.RequestPlus (that only affects
+                // N1QL), so a get immediately after CommitAsync can momentarily still return null.
+                // Poll with a bounded timeout, matching TransactionTests' pattern.
+                widgetA = await PollForResultAsync(
+                    () => context.WidgetsA.FindAsync(id).AsTask(),
+                    result => result != null,
+                    TimeSpan.FromSeconds(5));
+                widgetB = await PollForResultAsync(
+                    () => context.WidgetsB.FindAsync(id).AsTask(),
+                    result => result != null,
+                    TimeSpan.FromSeconds(5));
 
                 Assert.NotNull(widgetA);
                 Assert.NotNull(widgetB);
@@ -170,6 +179,29 @@ public class CrossBucketTransactionTests(BloggingFixture fixture)
         }
     }
 
+    private static async Task<T?> PollForResultAsync<T>(
+        Func<Task<T?>> query,
+        Func<T?, bool> condition,
+        TimeSpan timeout,
+        TimeSpan? pollInterval = null)
+    {
+        var interval = pollInterval ?? TimeSpan.FromMilliseconds(50);
+        var deadline = DateTime.UtcNow + timeout;
+
+        while (DateTime.UtcNow < deadline)
+        {
+            var result = await query();
+            if (condition(result))
+            {
+                return result;
+            }
+            await Task.Delay(interval);
+        }
+
+        // Return final result even if condition not met (let assertion fail with actual value).
+        return await query();
+    }
+
     public class TxWidgetA
     {
         public int Id { get; set; }
@@ -190,8 +222,9 @@ public class CrossBucketTransactionTests(BloggingFixture fixture)
         protected override void OnModelCreating(ModelBuilder modelBuilder)
         {
             // Reuses the isolation.widget keyspace the AppHost already provisions in both buckets
-            // (see MultiBucketSingleContextTests) — distinct CLR types keep this class's ids from
-            // colliding with that test's.
+            // (see MultiBucketSingleContextTests). Document keys are derived from the primary key
+            // value alone (no type prefix), so this class's ids (6001+) are deliberately outside
+            // that test's id range (1) to avoid colliding in the shared collection.
             modelBuilder.Entity<TxWidgetA>().ToCouchbaseCollection("default", "isolation", "widget");
             modelBuilder.Entity<TxWidgetB>().ToCouchbaseCollection("secondary", "isolation", "widget");
             modelBuilder.ConfigureToCouchbase(this, true);

--- a/tests/Couchbase.EntityFrameworkCore.IntegrationTests/Tests/CrossBucketTransactionTests.cs
+++ b/tests/Couchbase.EntityFrameworkCore.IntegrationTests/Tests/CrossBucketTransactionTests.cs
@@ -32,9 +32,19 @@ public class CrossBucketTransactionTests(BloggingFixture fixture)
 
         var provider = services.BuildServiceProvider();
 
-        await using var scope = provider.CreateAsyncScope();
-        var context = scope.ServiceProvider.GetRequiredService<SpanningContext>();
-        await context.Database.EnsureCreatedAsync();
+        try
+        {
+            await using var scope = provider.CreateAsyncScope();
+            var context = scope.ServiceProvider.GetRequiredService<SpanningContext>();
+            await context.Database.EnsureCreatedAsync();
+        }
+        catch
+        {
+            // Dispose the provider (and its cluster connection) before propagating — otherwise a
+            // failure here would leak it, since the caller never receives a provider to dispose.
+            await provider.DisposeAsync();
+            throw;
+        }
 
         return provider;
     }
@@ -67,11 +77,11 @@ public class CrossBucketTransactionTests(BloggingFixture fixture)
                 // KV reads aren't governed by QueryScanConsistency.RequestPlus (that only affects
                 // N1QL), so a get immediately after CommitAsync can momentarily still return null.
                 // Poll with a bounded timeout, matching TransactionTests' pattern.
-                widgetA = await PollForResultAsync(
+                widgetA = await PollingHelper.PollForResultAsync(
                     () => context.WidgetsA.FindAsync(id).AsTask(),
                     result => result != null,
                     TimeSpan.FromSeconds(5));
-                widgetB = await PollForResultAsync(
+                widgetB = await PollingHelper.PollForResultAsync(
                     () => context.WidgetsB.FindAsync(id).AsTask(),
                     result => result != null,
                     TimeSpan.FromSeconds(5));
@@ -87,11 +97,11 @@ public class CrossBucketTransactionTests(BloggingFixture fixture)
                 // from the try block: if the poll above timed out (or an assertion threw before
                 // they were assigned), the documents can still exist on the server and must not
                 // be skipped here, or they'd leak into subsequent test runs.
-                var cleanupA = await PollForResultAsync(
+                var cleanupA = await PollingHelper.PollForResultAsync(
                     () => context.WidgetsA.FindAsync(id).AsTask(),
                     result => result != null,
                     TimeSpan.FromSeconds(5));
-                var cleanupB = await PollForResultAsync(
+                var cleanupB = await PollingHelper.PollForResultAsync(
                     () => context.WidgetsB.FindAsync(id).AsTask(),
                     result => result != null,
                     TimeSpan.FromSeconds(5));
@@ -108,27 +118,51 @@ public class CrossBucketTransactionTests(BloggingFixture fixture)
         await using var provider = await BuildProviderAsync();
         const int id = 6002;
 
-        await using (var scope = provider.CreateAsyncScope())
+        try
         {
-            var context = scope.ServiceProvider.GetRequiredService<SpanningContext>();
-            await using var transaction = await context.Database.BeginCouchbaseTransactionAsync(DurabilityLevel.None);
+            await using (var scope = provider.CreateAsyncScope())
+            {
+                var context = scope.ServiceProvider.GetRequiredService<SpanningContext>();
+                await using var transaction = await context.Database.BeginCouchbaseTransactionAsync(DurabilityLevel.None);
 
-            context.Add(new TxWidgetA { Id = id, Name = "widget-a-rolled-back" });
-            context.Add(new TxWidgetB { Id = id, Name = "widget-b-rolled-back" });
-            await context.SaveChangesAsync();
+                context.Add(new TxWidgetA { Id = id, Name = "widget-a-rolled-back" });
+                context.Add(new TxWidgetB { Id = id, Name = "widget-b-rolled-back" });
+                await context.SaveChangesAsync();
 
-            await transaction.RollbackAsync();
+                await transaction.RollbackAsync();
+            }
+
+            // Verify from a fresh, untracked context — FindAsync on the same context that added
+            // these entities would return them straight from the change tracker (still State=Added)
+            // without ever touching the server, masking whether the rollback actually took effect.
+            // Rollback here never touched the server either (CouchbaseDbTransaction.Rollback just
+            // discards the buffered ops), so no polling for eventual consistency is needed.
+            await using var verifyScope = provider.CreateAsyncScope();
+            var verifyContext = verifyScope.ServiceProvider.GetRequiredService<SpanningContext>();
+            Assert.Null(await verifyContext.WidgetsA.FindAsync(id));
+            Assert.Null(await verifyContext.WidgetsB.FindAsync(id));
         }
-
-        // Verify from a fresh, untracked context — FindAsync on the same context that added
-        // these entities would return them straight from the change tracker (still State=Added)
-        // without ever touching the server, masking whether the rollback actually took effect.
-        // Rollback here never touched the server either (CouchbaseDbTransaction.Rollback just
-        // discards the buffered ops), so no polling for eventual consistency is needed.
-        await using var verifyScope = provider.CreateAsyncScope();
-        var verifyContext = verifyScope.ServiceProvider.GetRequiredService<SpanningContext>();
-        Assert.Null(await verifyContext.WidgetsA.FindAsync(id));
-        Assert.Null(await verifyContext.WidgetsB.FindAsync(id));
+        finally
+        {
+            // If rollback regressed (exactly what this test guards against) or an assertion
+            // above failed, the documents could actually be persisted — clean them up so they
+            // don't leak into later test runs and make other integration tests flaky. Poll
+            // (briefly) rather than a single immediate read per the same reasoning as the other
+            // cleanup blocks in this file.
+            await using var cleanupScope = provider.CreateAsyncScope();
+            var cleanupContext = cleanupScope.ServiceProvider.GetRequiredService<SpanningContext>();
+            var leftoverA = await PollingHelper.PollForResultAsync(
+                () => cleanupContext.WidgetsA.FindAsync(id).AsTask(),
+                result => result != null,
+                TimeSpan.FromSeconds(2));
+            if (leftoverA != null) cleanupContext.Remove(leftoverA);
+            var leftoverB = await PollingHelper.PollForResultAsync(
+                () => cleanupContext.WidgetsB.FindAsync(id).AsTask(),
+                result => result != null,
+                TimeSpan.FromSeconds(2));
+            if (leftoverB != null) cleanupContext.Remove(leftoverB);
+            await cleanupContext.SaveChangesAsync();
+        }
     }
 
     [Fact]
@@ -169,8 +203,15 @@ public class CrossBucketTransactionTests(BloggingFixture fixture)
             var verifyContext = verifyScope.ServiceProvider.GetRequiredService<SpanningContext>();
 
             // The default-bucket write must not have survived the failed transaction — proving
-            // the two buckets were rolled back together, not independently.
-            Assert.Null(await verifyContext.WidgetsA.FindAsync(newId));
+            // the two buckets were rolled back together, not independently. A single immediate
+            // read risks a false pass if the document is merely momentarily stale right after
+            // the failed commit and becomes visible moments later, so poll for a short window
+            // and fail as soon as it ever appears rather than checking only once.
+            var leakedWidgetA = await PollingHelper.PollForResultAsync(
+                () => verifyContext.WidgetsA.FindAsync(newId).AsTask(),
+                result => result != null,
+                TimeSpan.FromSeconds(2));
+            Assert.Null(leakedWidgetA);
             // The secondary-bucket document must still hold its pre-existing value, not the
             // conflicting insert's value.
             var widgetB = await verifyContext.WidgetsB.FindAsync(conflictingId);
@@ -187,41 +228,18 @@ public class CrossBucketTransactionTests(BloggingFixture fixture)
             // stale KV read here could miss a leftover document and leak it into later runs.
             // Short timeout because the common case is a genuinely absent document (the
             // transaction correctly rolled back), where this always runs to the full timeout.
-            var leftoverA = await PollForResultAsync(
+            var leftoverA = await PollingHelper.PollForResultAsync(
                 () => cleanupContext.WidgetsA.FindAsync(newId).AsTask(),
                 result => result != null,
                 TimeSpan.FromSeconds(2));
             if (leftoverA != null) cleanupContext.Remove(leftoverA);
-            var widgetB = await PollForResultAsync(
+            var widgetB = await PollingHelper.PollForResultAsync(
                 () => cleanupContext.WidgetsB.FindAsync(conflictingId).AsTask(),
                 result => result != null,
                 TimeSpan.FromSeconds(2));
             if (widgetB != null) cleanupContext.Remove(widgetB);
             await cleanupContext.SaveChangesAsync();
         }
-    }
-
-    private static async Task<T?> PollForResultAsync<T>(
-        Func<Task<T?>> query,
-        Func<T?, bool> condition,
-        TimeSpan timeout,
-        TimeSpan? pollInterval = null)
-    {
-        var interval = pollInterval ?? TimeSpan.FromMilliseconds(50);
-        var deadline = DateTime.UtcNow + timeout;
-
-        while (DateTime.UtcNow < deadline)
-        {
-            var result = await query();
-            if (condition(result))
-            {
-                return result;
-            }
-            await Task.Delay(interval);
-        }
-
-        // Return final result even if condition not met (let assertion fail with actual value).
-        return await query();
     }
 
     public class TxWidgetA

--- a/tests/Couchbase.EntityFrameworkCore.IntegrationTests/Tests/CrossBucketTransactionTests.cs
+++ b/tests/Couchbase.EntityFrameworkCore.IntegrationTests/Tests/CrossBucketTransactionTests.cs
@@ -143,7 +143,8 @@ public class CrossBucketTransactionTests(BloggingFixture fixture)
             context.Add(new TxWidgetB { Id = conflictingId, Name = "conflicting-insert" });
             await context.SaveChangesAsync();
 
-            await Assert.ThrowsAnyAsync<Exception>(() => transaction.CommitAsync());
+            await Assert.ThrowsAsync<global::Couchbase.Client.Transactions.Error.TransactionFailedException>(
+                () => transaction.CommitAsync());
 
             await using var verifyScope = provider.CreateAsyncScope();
             var verifyContext = verifyScope.ServiceProvider.GetRequiredService<SpanningContext>();

--- a/tests/Couchbase.EntityFrameworkCore.IntegrationTests/Tests/CrossBucketTransactionTests.cs
+++ b/tests/Couchbase.EntityFrameworkCore.IntegrationTests/Tests/CrossBucketTransactionTests.cs
@@ -60,17 +60,26 @@ public class CrossBucketTransactionTests(BloggingFixture fixture)
         await using (var scope = provider.CreateAsyncScope())
         {
             var context = scope.ServiceProvider.GetRequiredService<SpanningContext>();
-            var widgetA = await context.WidgetsA.FindAsync(id);
-            var widgetB = await context.WidgetsB.FindAsync(id);
+            TxWidgetA? widgetA = null;
+            TxWidgetB? widgetB = null;
+            try
+            {
+                widgetA = await context.WidgetsA.FindAsync(id);
+                widgetB = await context.WidgetsB.FindAsync(id);
 
-            Assert.NotNull(widgetA);
-            Assert.NotNull(widgetB);
-            Assert.Equal("widget-a-committed", widgetA!.Name);
-            Assert.Equal("widget-b-committed", widgetB!.Name);
-
-            context.Remove(widgetA);
-            context.Remove(widgetB);
-            await context.SaveChangesAsync();
+                Assert.NotNull(widgetA);
+                Assert.NotNull(widgetB);
+                Assert.Equal("widget-a-committed", widgetA!.Name);
+                Assert.Equal("widget-b-committed", widgetB!.Name);
+            }
+            finally
+            {
+                // Clean up even if an assertion (or FindAsync) fails above — otherwise these
+                // documents would leak into subsequent test runs.
+                if (widgetA != null) context.Remove(widgetA);
+                if (widgetB != null) context.Remove(widgetB);
+                await context.SaveChangesAsync();
+            }
         }
     }
 

--- a/tests/Couchbase.EntityFrameworkCore.IntegrationTests/Tests/CrossBucketTransactionTests.cs
+++ b/tests/Couchbase.EntityFrameworkCore.IntegrationTests/Tests/CrossBucketTransactionTests.cs
@@ -1,0 +1,188 @@
+using Couchbase.EntityFrameworkCode.IntegrationTests.Fixtures;
+using Couchbase.EntityFrameworkCore.Extensions;
+using Couchbase.KeyValue;
+using Microsoft.EntityFrameworkCore;
+
+namespace Couchbase.EntityFrameworkCode.IntegrationTests.Tests;
+
+/// <summary>
+/// Multi-document Couchbase transaction coverage spanning two buckets on the same cluster.
+/// <see cref="MultiBucketSingleContextTests"/> already proves a single DbContext can write/read/
+/// query across buckets; this class proves <c>BeginCouchbaseTransactionAsync</c> gives those
+/// cross-bucket writes real all-or-nothing semantics — a commit persists both, a rollback (or a
+/// failure partway through) persists neither.
+/// </summary>
+[Collection(CouchbaseTestingCollection.Name)]
+public class CrossBucketTransactionTests(BloggingFixture fixture)
+{
+    private async Task<ServiceProvider> BuildProviderAsync()
+    {
+        var services = new ServiceCollection();
+        services.AddCouchbase<SpanningContext>(
+            new global::Couchbase.ClusterOptions()
+                .WithConnectionString(fixture.Host)
+                .WithCredentials(fixture.Username, fixture.Password),
+            o =>
+            {
+                o.Bucket = "default";
+                o.Scope = "isolation";
+                o.ScanConsistency = global::Couchbase.Query.QueryScanConsistency.RequestPlus;
+            },
+            o => o.UseCamelCaseNamingConvention());
+
+        var provider = services.BuildServiceProvider();
+
+        await using var scope = provider.CreateAsyncScope();
+        var context = scope.ServiceProvider.GetRequiredService<SpanningContext>();
+        await context.Database.EnsureCreatedAsync();
+
+        return provider;
+    }
+
+    [Fact]
+    public async Task BeginTransaction_Commit_PersistsBothBuckets()
+    {
+        await using var provider = await BuildProviderAsync();
+        const int id = 6001;
+
+        await using (var scope = provider.CreateAsyncScope())
+        {
+            var context = scope.ServiceProvider.GetRequiredService<SpanningContext>();
+            await using var transaction = await context.Database.BeginCouchbaseTransactionAsync(DurabilityLevel.None);
+
+            context.Add(new TxWidgetA { Id = id, Name = "widget-a-committed" });
+            context.Add(new TxWidgetB { Id = id, Name = "widget-b-committed" });
+            await context.SaveChangesAsync();
+
+            await transaction.CommitAsync();
+        }
+
+        await using (var scope = provider.CreateAsyncScope())
+        {
+            var context = scope.ServiceProvider.GetRequiredService<SpanningContext>();
+            var widgetA = await context.WidgetsA.FindAsync(id);
+            var widgetB = await context.WidgetsB.FindAsync(id);
+
+            Assert.NotNull(widgetA);
+            Assert.NotNull(widgetB);
+            Assert.Equal("widget-a-committed", widgetA!.Name);
+            Assert.Equal("widget-b-committed", widgetB!.Name);
+
+            context.Remove(widgetA);
+            context.Remove(widgetB);
+            await context.SaveChangesAsync();
+        }
+    }
+
+    [Fact]
+    public async Task BeginTransaction_Rollback_PersistsNeitherBucket()
+    {
+        await using var provider = await BuildProviderAsync();
+        const int id = 6002;
+
+        await using (var scope = provider.CreateAsyncScope())
+        {
+            var context = scope.ServiceProvider.GetRequiredService<SpanningContext>();
+            await using var transaction = await context.Database.BeginCouchbaseTransactionAsync(DurabilityLevel.None);
+
+            context.Add(new TxWidgetA { Id = id, Name = "widget-a-rolled-back" });
+            context.Add(new TxWidgetB { Id = id, Name = "widget-b-rolled-back" });
+            await context.SaveChangesAsync();
+
+            await transaction.RollbackAsync();
+        }
+
+        // Verify from a fresh, untracked context — FindAsync on the same context that added
+        // these entities would return them straight from the change tracker (still State=Added)
+        // without ever touching the server, masking whether the rollback actually took effect.
+        // Rollback here never touched the server either (CouchbaseDbTransaction.Rollback just
+        // discards the buffered ops), so no polling for eventual consistency is needed.
+        await using var verifyScope = provider.CreateAsyncScope();
+        var verifyContext = verifyScope.ServiceProvider.GetRequiredService<SpanningContext>();
+        Assert.Null(await verifyContext.WidgetsA.FindAsync(id));
+        Assert.Null(await verifyContext.WidgetsB.FindAsync(id));
+    }
+
+    [Fact]
+    public async Task BeginTransaction_FailureInOneBucket_RollsBackWriteToOtherBucket()
+    {
+        await using var provider = await BuildProviderAsync();
+        const int newId = 6003;
+        const int conflictingId = 6004;
+
+        // Seed a document directly (outside the transaction) so the in-transaction insert to the
+        // same key in bucket "secondary" below is guaranteed to conflict.
+        await using (var seedScope = provider.CreateAsyncScope())
+        {
+            var seedContext = seedScope.ServiceProvider.GetRequiredService<SpanningContext>();
+            seedContext.Add(new TxWidgetB { Id = conflictingId, Name = "pre-existing" });
+            await seedContext.SaveChangesAsync();
+        }
+
+        try
+        {
+            await using var scope = provider.CreateAsyncScope();
+            var context = scope.ServiceProvider.GetRequiredService<SpanningContext>();
+            await using var transaction = await context.Database.BeginCouchbaseTransactionAsync(DurabilityLevel.None);
+
+            // A genuinely new document in bucket "default"...
+            context.Add(new TxWidgetA { Id = newId, Name = "should-not-persist" });
+            // ...and an Insert of an already-existing key in bucket "secondary", which the
+            // transaction will fail to commit.
+            context.Add(new TxWidgetB { Id = conflictingId, Name = "conflicting-insert" });
+            await context.SaveChangesAsync();
+
+            await Assert.ThrowsAnyAsync<Exception>(() => transaction.CommitAsync());
+
+            await using var verifyScope = provider.CreateAsyncScope();
+            var verifyContext = verifyScope.ServiceProvider.GetRequiredService<SpanningContext>();
+
+            // The default-bucket write must not have survived the failed transaction — proving
+            // the two buckets were rolled back together, not independently.
+            Assert.Null(await verifyContext.WidgetsA.FindAsync(newId));
+            // The secondary-bucket document must still hold its pre-existing value, not the
+            // conflicting insert's value.
+            var widgetB = await verifyContext.WidgetsB.FindAsync(conflictingId);
+            Assert.NotNull(widgetB);
+            Assert.Equal("pre-existing", widgetB!.Name);
+        }
+        finally
+        {
+            await using var cleanupScope = provider.CreateAsyncScope();
+            var cleanupContext = cleanupScope.ServiceProvider.GetRequiredService<SpanningContext>();
+            var leftoverA = await cleanupContext.WidgetsA.FindAsync(newId);
+            if (leftoverA != null) cleanupContext.Remove(leftoverA);
+            var widgetB = await cleanupContext.WidgetsB.FindAsync(conflictingId);
+            if (widgetB != null) cleanupContext.Remove(widgetB);
+            await cleanupContext.SaveChangesAsync();
+        }
+    }
+
+    public class TxWidgetA
+    {
+        public int Id { get; set; }
+        public string Name { get; set; } = null!;
+    }
+
+    public class TxWidgetB
+    {
+        public int Id { get; set; }
+        public string Name { get; set; } = null!;
+    }
+
+    public sealed class SpanningContext(DbContextOptions<SpanningContext> options) : DbContext(options)
+    {
+        public DbSet<TxWidgetA> WidgetsA { get; set; } = null!;
+        public DbSet<TxWidgetB> WidgetsB { get; set; } = null!;
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            // Reuses the isolation.widget keyspace the AppHost already provisions in both buckets
+            // (see MultiBucketSingleContextTests) — distinct CLR types keep this class's ids from
+            // colliding with that test's.
+            modelBuilder.Entity<TxWidgetA>().ToCouchbaseCollection("default", "isolation", "widget");
+            modelBuilder.Entity<TxWidgetB>().ToCouchbaseCollection("secondary", "isolation", "widget");
+            modelBuilder.ConfigureToCouchbase(this, true);
+        }
+    }
+}

--- a/tests/Couchbase.EntityFrameworkCore.IntegrationTests/Tests/CrossBucketTransactionTests.cs
+++ b/tests/Couchbase.EntityFrameworkCore.IntegrationTests/Tests/CrossBucketTransactionTests.cs
@@ -135,12 +135,22 @@ public class CrossBucketTransactionTests(BloggingFixture fixture)
             // Verify from a fresh, untracked context — FindAsync on the same context that added
             // these entities would return them straight from the change tracker (still State=Added)
             // without ever touching the server, masking whether the rollback actually took effect.
-            // Rollback here never touched the server either (CouchbaseDbTransaction.Rollback just
-            // discards the buffered ops), so no polling for eventual consistency is needed.
+            // A single immediate read could still (rarely) miss a persisted document if a KV read
+            // is momentarily stale right after transaction completion, letting an atomic-rollback
+            // regression pass unnoticed — poll briefly for the document to appear, then assert it
+            // never did, rather than checking only once.
             await using var verifyScope = provider.CreateAsyncScope();
             var verifyContext = verifyScope.ServiceProvider.GetRequiredService<SpanningContext>();
-            Assert.Null(await verifyContext.WidgetsA.FindAsync(id));
-            Assert.Null(await verifyContext.WidgetsB.FindAsync(id));
+            var leakedWidgetA = await PollingHelper.PollForResultAsync(
+                () => verifyContext.WidgetsA.FindAsync(id).AsTask(),
+                result => result != null,
+                TimeSpan.FromSeconds(2));
+            Assert.Null(leakedWidgetA);
+            var leakedWidgetB = await PollingHelper.PollForResultAsync(
+                () => verifyContext.WidgetsB.FindAsync(id).AsTask(),
+                result => result != null,
+                TimeSpan.FromSeconds(2));
+            Assert.Null(leakedWidgetB);
         }
         finally
         {

--- a/tests/Couchbase.EntityFrameworkCore.IntegrationTests/Tests/CrossBucketTransactionTests.cs
+++ b/tests/Couchbase.EntityFrameworkCore.IntegrationTests/Tests/CrossBucketTransactionTests.cs
@@ -120,11 +120,13 @@ public class CrossBucketTransactionTests(BloggingFixture fixture)
         const int conflictingId = 6004;
 
         // Seed a document directly (outside the transaction) so the in-transaction insert to the
-        // same key in bucket "secondary" below is guaranteed to conflict.
+        // same key in bucket "secondary" below is guaranteed to conflict. Use Update (upsert)
+        // rather than Add (insert) so seeding is idempotent — a leftover document from a prior
+        // failed run must not make this step itself throw before the finally block can clean up.
         await using (var seedScope = provider.CreateAsyncScope())
         {
             var seedContext = seedScope.ServiceProvider.GetRequiredService<SpanningContext>();
-            seedContext.Add(new TxWidgetB { Id = conflictingId, Name = "pre-existing" });
+            seedContext.Update(new TxWidgetB { Id = conflictingId, Name = "pre-existing" });
             await seedContext.SaveChangesAsync();
         }
 

--- a/tests/Couchbase.EntityFrameworkCore.IntegrationTests/Tests/TransactionTests.cs
+++ b/tests/Couchbase.EntityFrameworkCore.IntegrationTests/Tests/TransactionTests.cs
@@ -34,7 +34,7 @@ public class TransactionTests(
             await transaction.CommitAsync();
 
             // Poll for consistency with bounded timeout
-            var savedBlog = await PollForResultAsync(
+            var savedBlog = await PollingHelper.PollForResultAsync(
                 async () =>
                 {
                     await using var verifyContext = bloggingFixture.GetDbContext();
@@ -74,7 +74,7 @@ public class TransactionTests(
             await transaction.RollbackAsync();
 
             // Poll to verify document was not persisted (should remain null)
-            await PollUntilAsync(async () =>
+            await PollingHelper.PollUntilAsync(async () =>
             {
                 await using var verifyContext = bloggingFixture.GetDbContext();
                 var notSavedBlog = await verifyContext.Blogs.FindAsync(blog.BlogId);
@@ -114,7 +114,7 @@ public class TransactionTests(
             await transaction.CommitAsync();
 
             // Poll for both blogs to be persisted
-            var (saved1, saved2) = await PollForResultAsync(
+            var (saved1, saved2) = await PollingHelper.PollForResultAsync(
                 async () =>
                 {
                     await using var verifyContext = bloggingFixture.GetDbContext();
@@ -153,7 +153,7 @@ public class TransactionTests(
         try
         {
             // Poll until blog is persisted
-            await PollUntilAsync(async () =>
+            await PollingHelper.PollUntilAsync(async () =>
             {
                 await using var checkContext = bloggingFixture.GetDbContext();
                 return await checkContext.Blogs.FindAsync(blog.BlogId) != null;
@@ -171,7 +171,7 @@ public class TransactionTests(
             await transaction.CommitAsync();
 
             // Poll for updated values
-            var updatedBlog = await PollForResultAsync(
+            var updatedBlog = await PollingHelper.PollForResultAsync(
                 async () =>
                 {
                     await using var verifyContext = bloggingFixture.GetDbContext();
@@ -207,7 +207,7 @@ public class TransactionTests(
         await context.SaveChangesAsync();
 
         // Poll until blog is persisted
-        await PollUntilAsync(async () =>
+        await PollingHelper.PollUntilAsync(async () =>
         {
             await using var checkContext = bloggingFixture.GetDbContext();
             return await checkContext.Blogs.FindAsync(blog.BlogId) != null;
@@ -223,7 +223,7 @@ public class TransactionTests(
         await transaction.CommitAsync();
 
         // Poll until deletion is confirmed
-        await PollUntilAsync(async () =>
+        await PollingHelper.PollUntilAsync(async () =>
         {
             await using var verifyContext = bloggingFixture.GetDbContext();
             return await verifyContext.Blogs.FindAsync(blog.BlogId) == null;
@@ -257,7 +257,7 @@ public class TransactionTests(
             }
 
             // Poll to verify not persisted (should remain null)
-            await PollUntilAsync(async () =>
+            await PollingHelper.PollUntilAsync(async () =>
             {
                 await using var verifyContext = bloggingFixture.GetDbContext();
                 return await verifyContext.Blogs.FindAsync(blog.BlogId) == null;
@@ -328,7 +328,7 @@ public class TransactionTests(
             await context.SaveChangesAsync();
 
             // Poll for persistence
-            var savedBlog = await PollForResultAsync(
+            var savedBlog = await PollingHelper.PollForResultAsync(
                 async () =>
                 {
                     await using var verifyContext = bloggingFixture.GetDbContext();
@@ -343,53 +343,6 @@ public class TransactionTests(
         {
             context.Remove(blog);
             await context.SaveChangesAsync();
-        }
-    }
-
-    /// <summary>
-    /// Polls for a result until the condition is met or timeout is reached.
-    /// </summary>
-    private static async Task<T?> PollForResultAsync<T>(
-        Func<Task<T?>> query,
-        Func<T?, bool> condition,
-        TimeSpan timeout,
-        TimeSpan? pollInterval = null)
-    {
-        var interval = pollInterval ?? TimeSpan.FromMilliseconds(50);
-        var deadline = DateTime.UtcNow + timeout;
-
-        while (DateTime.UtcNow < deadline)
-        {
-            var result = await query();
-            if (condition(result))
-            {
-                return result;
-            }
-            await Task.Delay(interval);
-        }
-
-        // Return final result even if condition not met (let assertion fail with actual value)
-        return await query();
-    }
-
-    /// <summary>
-    /// Polls until condition is met or timeout is reached.
-    /// </summary>
-    private static async Task PollUntilAsync(
-        Func<Task<bool>> condition,
-        TimeSpan timeout,
-        TimeSpan? pollInterval = null)
-    {
-        var interval = pollInterval ?? TimeSpan.FromMilliseconds(50);
-        var deadline = DateTime.UtcNow + timeout;
-
-        while (DateTime.UtcNow < deadline)
-        {
-            if (await condition())
-            {
-                return;
-            }
-            await Task.Delay(interval);
         }
     }
 }

--- a/tests/Couchbase.EntityFrameworkCore.IntegrationTests/Tests/TransactionTests.cs
+++ b/tests/Couchbase.EntityFrameworkCore.IntegrationTests/Tests/TransactionTests.cs
@@ -73,17 +73,16 @@ public class TransactionTests(
 
             await transaction.RollbackAsync();
 
-            // Poll to verify document was not persisted (should remain null)
-            await PollingHelper.PollUntilAsync(async () =>
-            {
-                await using var verifyContext = bloggingFixture.GetDbContext();
-                var notSavedBlog = await verifyContext.Blogs.FindAsync(blog.BlogId);
-                return notSavedBlog == null;
-            }, TimeSpan.FromSeconds(5));
-
-            await using var finalVerifyContext = bloggingFixture.GetDbContext();
-            var notSavedBlog = await finalVerifyContext.Blogs.FindAsync(blog.BlogId);
-            Assert.Null(notSavedBlog);
+            // A single immediate read (or polling until it returns null) could still be fooled by
+            // a momentarily-stale KV read that returns null even though the document actually
+            // persisted — poll briefly for it to ever appear, then assert it never did, mirroring
+            // the cross-bucket rollback/leak checks in CrossBucketTransactionTests.
+            await using var verifyContext = bloggingFixture.GetDbContext();
+            var leakedBlog = await PollingHelper.PollForResultAsync(
+                () => verifyContext.Blogs.FindAsync(blog.BlogId).AsTask(),
+                result => result != null,
+                TimeSpan.FromSeconds(2));
+            Assert.Null(leakedBlog);
         }
         finally
         {
@@ -206,33 +205,49 @@ public class TransactionTests(
         context.Blogs.Add(blog);
         await context.SaveChangesAsync();
 
-        // Poll until blog is persisted
-        await PollingHelper.PollUntilAsync(async () =>
+        try
         {
-            await using var checkContext = bloggingFixture.GetDbContext();
-            return await checkContext.Blogs.FindAsync(blog.BlogId) != null;
-        }, TimeSpan.FromSeconds(5));
+            // Poll until blog is persisted
+            await PollingHelper.PollUntilAsync(async () =>
+            {
+                await using var checkContext = bloggingFixture.GetDbContext();
+                return await checkContext.Blogs.FindAsync(blog.BlogId) != null;
+            }, TimeSpan.FromSeconds(5));
 
-        // Delete in transaction
-        await using var transaction = await context.Database.BeginCouchbaseTransactionAsync(DurabilityLevel.None);
+            // Delete in transaction
+            await using var transaction = await context.Database.BeginCouchbaseTransactionAsync(DurabilityLevel.None);
 
-        var existingBlog = await context.Blogs.FindAsync(blog.BlogId);
-        context.Blogs.Remove(existingBlog!);
-        await context.SaveChangesAsync();
+            var existingBlog = await context.Blogs.FindAsync(blog.BlogId);
+            context.Blogs.Remove(existingBlog!);
+            await context.SaveChangesAsync();
 
-        await transaction.CommitAsync();
+            await transaction.CommitAsync();
 
-        // Poll until deletion is confirmed
-        await PollingHelper.PollUntilAsync(async () =>
+            // Poll until deletion is confirmed
+            await PollingHelper.PollUntilAsync(async () =>
+            {
+                await using var verifyContext = bloggingFixture.GetDbContext();
+                return await verifyContext.Blogs.FindAsync(blog.BlogId) == null;
+            }, TimeSpan.FromSeconds(5));
+
+            // Final verification
+            await using var finalContext = bloggingFixture.GetDbContext();
+            var deletedBlog = await finalContext.Blogs.FindAsync(blog.BlogId);
+            Assert.Null(deletedBlog);
+        }
+        finally
         {
-            await using var verifyContext = bloggingFixture.GetDbContext();
-            return await verifyContext.Blogs.FindAsync(blog.BlogId) == null;
-        }, TimeSpan.FromSeconds(5));
-
-        // Final verification
-        await using var finalContext = bloggingFixture.GetDbContext();
-        var deletedBlog = await finalContext.Blogs.FindAsync(blog.BlogId);
-        Assert.Null(deletedBlog);
+            // If any step above failed before deletion was confirmed (or deletion itself
+            // regressed), the fixed BlogId (9006) could remain in the collection and make later
+            // integration test runs flaky — remove it if it's still there.
+            await using var cleanupContext = bloggingFixture.GetDbContext();
+            var persistedBlog = await cleanupContext.Blogs.FindAsync(blog.BlogId);
+            if (persistedBlog != null)
+            {
+                cleanupContext.Blogs.Remove(persistedBlog);
+                await cleanupContext.SaveChangesAsync();
+            }
+        }
     }
 
     [Fact]
@@ -256,16 +271,15 @@ public class TransactionTests(
                 // Transaction disposed without commit
             }
 
-            // Poll to verify not persisted (should remain null)
-            await PollingHelper.PollUntilAsync(async () =>
-            {
-                await using var verifyContext = bloggingFixture.GetDbContext();
-                return await verifyContext.Blogs.FindAsync(blog.BlogId) == null;
-            }, TimeSpan.FromSeconds(5));
-
-            await using var finalContext = bloggingFixture.GetDbContext();
-            var notSaved = await finalContext.Blogs.FindAsync(blog.BlogId);
-            Assert.Null(notSaved);
+            // Polling until FindAsync returns null could false-pass on a momentarily-stale KV
+            // read even if the document actually persisted — poll briefly for it to ever appear,
+            // then assert it never did, mirroring the rollback/leak checks elsewhere in this file.
+            await using var verifyContext = bloggingFixture.GetDbContext();
+            var leakedBlog = await PollingHelper.PollForResultAsync(
+                () => verifyContext.Blogs.FindAsync(blog.BlogId).AsTask(),
+                result => result != null,
+                TimeSpan.FromSeconds(2));
+            Assert.Null(leakedBlog);
         }
         finally
         {


### PR DESCRIPTION
MultiBucketSingleContextTests already proves a single DbContext can write/read/query across buckets, but nothing verified that BeginCouchbaseTransactionAsync gives those cross-bucket writes real all-or-nothing semantics. Add CrossBucketTransactionTests: commit persists both buckets, rollback persists neither, and a duplicate-key insert failure in one bucket rolls back the write already staged in the other — confirming genuine atomicity across buckets on the same cluster.