### PR TITLE
Add nested-JSON-path read support for OwnsOne navigations

### DIFF
--- a/src/Couchbase.EntityFrameworkCore/Query/Internal/CouchbaseOwnedCollectionMaterializer.cs
+++ b/src/Couchbase.EntityFrameworkCore/Query/Internal/CouchbaseOwnedCollectionMaterializer.cs
@@ -10,8 +10,8 @@ using Microsoft.EntityFrameworkCore.Storage.Json;
 namespace Couchbase.EntityFrameworkCore.Query.Internal;
 
 /// <summary>
-/// Populates owned-collection navigations on a freshly materialised entity from the
-/// embedded JSON arrays that arrive inline in a Couchbase N1QL result row.
+/// Populates owned navigations on a freshly materialised entity from the embedded JSON that
+/// arrives inline in a Couchbase N1QL result row.
 /// <para>
 /// This class owns three concerns that previously lived in
 /// <see cref="CouchbaseQueryEnumerable{T}"/>:
@@ -19,6 +19,14 @@ namespace Couchbase.EntityFrameworkCore.Query.Internal;
 ///   <item><description>
 ///     <see cref="Populate{T}"/> — iterates every OwnsMany navigation on the root entity
 ///     and delegates to <see cref="MaterializeOwnedItem"/> for each array element.
+///   </description></item>
+///   <item><description>
+///     <see cref="PopulateReference{T}"/> — for a root-level OwnsOne navigation whose data is
+///     stored as a genuinely nested JSON object (rather than this provider's default flat
+///     table-split columns), overrides the navigation's properties <em>in place</em> on the
+///     shaper's already-materialised instance. Absent/null data is left alone, so this is a
+///     pure fallback — it never disturbs the flat-column round-trip most OwnsOne data already
+///     uses.
 ///   </description></item>
 ///   <item><description>
 ///     <see cref="MaterializeOwnedItem"/> — recursively materialises a single owned entity
@@ -36,6 +44,30 @@ internal sealed class CouchbaseOwnedCollectionMaterializer
     private static readonly JsonSerializerOptions _defaultSerializerOptions =
         new(JsonSerializerDefaults.Web);
 
+    /// <summary>
+    /// A scalar property that <see cref="PopulateReference{T}"/> overrode on an existing owned
+    /// instance, reported so the caller can realign the property's tracked "original value" (EF
+    /// Core's own change detection would otherwise see the override as a user-driven mutation and
+    /// mark the owner spuriously <c>Modified</c> on the next <c>SaveChanges</c> — the owned
+    /// instance's properties are ordinary table-split, snapshot-tracked properties, unlike
+    /// OwnsMany items, which fall outside EF's own change detection entirely).
+    /// </summary>
+    public readonly record struct TouchedProperty(object Instance, IProperty Property);
+
+    /// <summary>
+    /// Resolves a root-level owned navigation's actual N1QL result-row key: the compile-time
+    /// resolved alias when available (see <see cref="CouchbaseProjectionAliases.NavigationKey"/>),
+    /// otherwise the policy-computed field name. Only root-level lookups need this — a nested
+    /// navigation's field is read from within an already-extracted JSON sub-object, which was
+    /// never subject to top-level SELECT alias uniquification in the first place.
+    /// </summary>
+    private static string ResolveRootFieldName(
+        INavigation nav, IReadOnlyDictionary<string, string>? navigationAliases, JsonNamingPolicy? fieldNamingPolicy)
+        => navigationAliases != null
+            && navigationAliases.TryGetValue(CouchbaseProjectionAliases.NavigationKey(nav), out var alias)
+            ? alias
+            : fieldNamingPolicy?.ConvertName(nav.Name) ?? nav.Name;
+
     // ---------------------------------------------------------------------------
     // Public entry point
     // ---------------------------------------------------------------------------
@@ -45,17 +77,26 @@ internal sealed class CouchbaseOwnedCollectionMaterializer
     /// <paramref name="entity"/> from the corresponding JSON array in
     /// <paramref name="docElement"/>.
     /// </summary>
+    /// <param name="navigationAliases">
+    /// Maps <see cref="CouchbaseProjectionAliases.NavigationKey"/> to the navigation's actual
+    /// N1QL result-row key, resolved at compile time once alias uniquification has run — a plain
+    /// policy-computed field name can be stale if it collided with another projected column and
+    /// was suffixed (e.g. "reviews" → "reviews0"). Falls back to the policy-computed name for any
+    /// navigation not present in the map (e.g. when called without a compiled query, such as in
+    /// unit tests).
+    /// </param>
     public void Populate<T>(
         T entity,
         JsonElement docElement,
         IReadOnlyList<INavigation> ownedCollections,
         JsonNamingPolicy? fieldNamingPolicy,
-        JsonSerializerOptions? serializerOptions)
+        JsonSerializerOptions? serializerOptions,
+        IReadOnlyDictionary<string, string>? navigationAliases = null)
     {
         var options = serializerOptions ?? _defaultSerializerOptions;
         foreach (var nav in ownedCollections)
         {
-            var fieldName = fieldNamingPolicy?.ConvertName(nav.Name) ?? nav.Name;
+            var fieldName = ResolveRootFieldName(nav, navigationAliases, fieldNamingPolicy);
             if (!docElement.TryGetPropertyCI(fieldName, out var arrayElement)
                 || arrayElement.ValueKind != JsonValueKind.Array)
                 continue;
@@ -107,6 +148,98 @@ internal sealed class CouchbaseOwnedCollectionMaterializer
         }
     }
 
+    /// <summary>
+    /// For each root-level OwnsOne navigation in <paramref name="ownedReferences"/>, overrides
+    /// the navigation's scalar properties <em>in place</em> from the corresponding nested JSON
+    /// object in <paramref name="docElement"/> — but only when that field is actually present as
+    /// a JSON object. When it's absent or null (the common case: a document this provider wrote
+    /// itself, using flat table-split columns), the shaper's already-materialised flat-column
+    /// result is left completely untouched.
+    /// </summary>
+    /// <returns>
+    /// Every scalar property actually overridden, across all navigations and any nested OwnsOne
+    /// depth, so the caller can realign EF Core's own change-tracking snapshot for each — see
+    /// <see cref="TouchedProperty"/>.
+    /// </returns>
+    /// <param name="navigationAliases">
+    /// See <see cref="Populate{T}"/>'s parameter of the same name — the same alias-resolution
+    /// concern applies here, since this navigation's field is also read directly off the
+    /// top-level SELECT-driven <paramref name="docElement"/>.
+    /// </param>
+    public IReadOnlyList<TouchedProperty> PopulateReference<T>(
+        T entity,
+        JsonElement docElement,
+        IReadOnlyList<INavigation> ownedReferences,
+        JsonNamingPolicy? fieldNamingPolicy,
+        JsonSerializerOptions? serializerOptions,
+        IReadOnlyDictionary<string, string>? navigationAliases = null)
+    {
+        var options = serializerOptions ?? _defaultSerializerOptions;
+        var touched = new List<TouchedProperty>();
+
+        foreach (var nav in ownedReferences)
+        {
+            var fieldName = ResolveRootFieldName(nav, navigationAliases, fieldNamingPolicy);
+            if (!docElement.TryGetPropertyCI(fieldName, out var objElement)
+                || objElement.ValueKind != JsonValueKind.Object)
+                continue;
+
+            // The default relational shaper always instantiates a table-split OwnsOne's CLR
+            // object (even when every flat column is null), so this should never be null in
+            // practice — but if it somehow is, there's nothing to override in place.
+            var existing = nav.PropertyInfo != null
+                ? nav.PropertyInfo.GetValue(entity)
+                : nav.FieldInfo?.GetValue(entity);
+            if (existing == null) continue;
+
+            PopulateReferenceInPlace(existing, objElement, nav.TargetEntityType, fieldNamingPolicy, options, touched);
+        }
+
+        return touched;
+    }
+
+    /// <summary>
+    /// Overrides <paramref name="target"/>'s scalar properties in place from
+    /// <paramref name="itemElement"/>, then recurses into any nested owned navigation: further
+    /// OwnsOne navigations get the same in-place treatment (they are just as snapshot-tracked as
+    /// the top level), while nested OwnsMany navigations reuse the ordinary
+    /// create-and-replace materialisation via <see cref="PopulateNestedCollection"/> — collections
+    /// aren't part of EF Core's snapshot-based change detection, so there's no tracking-safety
+    /// concern to preserve for them the way there is for scalars.
+    /// </summary>
+    private static void PopulateReferenceInPlace(
+        object target,
+        JsonElement itemElement,
+        IEntityType entityType,
+        JsonNamingPolicy? fieldNamingPolicy,
+        JsonSerializerOptions options,
+        List<TouchedProperty> touched)
+    {
+        PopulateScalarProperties(target, itemElement, entityType, fieldNamingPolicy, options, touched);
+
+        foreach (var ownedNav in entityType.GetNavigations())
+        {
+            if (!ownedNav.TargetEntityType.IsOwned()) continue;
+            var fieldName = fieldNamingPolicy?.ConvertName(ownedNav.Name) ?? ownedNav.Name;
+            if (!itemElement.TryGetPropertyCI(fieldName, out var nestedElement)) continue;
+
+            if (ownedNav.IsCollection)
+            {
+                PopulateNestedCollection(target, nestedElement, ownedNav, fieldNamingPolicy, options);
+            }
+            else
+            {
+                if (nestedElement.ValueKind != JsonValueKind.Object) continue;
+                var nestedExisting = ownedNav.PropertyInfo != null
+                    ? ownedNav.PropertyInfo.GetValue(target)
+                    : ownedNav.FieldInfo?.GetValue(target);
+                if (nestedExisting == null) continue;
+
+                PopulateReferenceInPlace(nestedExisting, nestedElement, ownedNav.TargetEntityType, fieldNamingPolicy, options, touched);
+            }
+        }
+    }
+
     // ---------------------------------------------------------------------------
     // Recursive owned-item materialiser
     // ---------------------------------------------------------------------------
@@ -128,23 +261,7 @@ internal sealed class CouchbaseOwnedCollectionMaterializer
     {
         var ownedEntity = Activator.CreateInstance(entityType.ClrType)!;
 
-        // Scalar properties
-        foreach (var prop in entityType.GetProperties())
-        {
-            if (prop.IsShadowProperty()) continue;
-            var jsonKey = fieldNamingPolicy?.ConvertName(prop.Name) ?? prop.Name;
-            if (itemElement.TryGetPropertyCI(jsonKey, out var propElement))
-            {
-                var converted = ConvertFromJson(propElement, prop, options);
-                // Use the property setter when one exists (public or non-public).
-                // Fall back to FieldInfo for backing-field / field-access properties where
-                // PropertyInfo is null or has no setter (e.g. init-only / get-only).
-                if (prop.PropertyInfo?.GetSetMethod(nonPublic: true) != null)
-                    prop.PropertyInfo.SetValue(ownedEntity, converted);
-                else if (prop.FieldInfo != null)
-                    prop.FieldInfo.SetValue(ownedEntity, converted);
-            }
-        }
+        PopulateScalarProperties(ownedEntity, itemElement, entityType, fieldNamingPolicy, options, touched: null);
 
         // Nested owned navigations
         foreach (var ownedNav in entityType.GetNavigations())
@@ -155,48 +272,7 @@ internal sealed class CouchbaseOwnedCollectionMaterializer
 
             if (ownedNav.IsCollection)
             {
-                if (nestedElement.ValueKind != JsonValueKind.Array) continue;
-                var accessor = ownedNav.GetCollectionAccessor();
-                // Skip navigations with no accessor and no way to assign — nothing to set.
-                if (accessor == null && ownedNav.PropertyInfo == null && ownedNav.FieldInfo == null) continue;
-                var nestedClrType = ownedNav.TargetEntityType.ClrType;
-                if (accessor != null)
-                {
-                    var coll = accessor.GetOrCreate(ownedEntity, forMaterialization: true);
-                    // Clear via IList for the common List<T> case; otherwise cast through
-                    // ICollection<T> which every mutable .NET collection implements and
-                    // guarantees Clear() — correctly handles HashSet<T>, SortedSet<T>, etc.
-                    if (coll is IList list)
-                        list.Clear();
-                    else if (coll != null)
-                        typeof(ICollection<>).MakeGenericType(nestedClrType)
-                            .GetMethod("Clear")!
-                            .Invoke(coll, null);
-                }
-                else
-                {
-                    var list = (IList)Activator.CreateInstance(typeof(List<>).MakeGenericType(nestedClrType))!;
-                    // Use the property setter when one exists; fall back to FieldInfo for
-                    // backing-field navigations where PropertyInfo is null or has no setter.
-                    if (ownedNav.PropertyInfo?.GetSetMethod(nonPublic: true) != null)
-                        ownedNav.PropertyInfo.SetValue(ownedEntity, list);
-                    else if (ownedNav.FieldInfo != null)
-                        ownedNav.FieldInfo.SetValue(ownedEntity, list);
-                }
-                foreach (var nestedItemElement in nestedElement.EnumerateArray())
-                {
-                    var nestedEntity = MaterializeOwnedItem(nestedItemElement, ownedNav.TargetEntityType, fieldNamingPolicy, options);
-                    if (accessor != null)
-                        accessor.Add(ownedEntity, nestedEntity, forMaterialization: true);
-                    else
-                    {
-                        // Read back via the same PropertyInfo → FieldInfo fallback.
-                        var existingList = (IList?)(ownedNav.PropertyInfo != null
-                            ? ownedNav.PropertyInfo.GetValue(ownedEntity)
-                            : ownedNav.FieldInfo?.GetValue(ownedEntity));
-                        existingList?.Add(nestedEntity);
-                    }
-                }
+                PopulateNestedCollection(ownedEntity, nestedElement, ownedNav, fieldNamingPolicy, options);
             }
             else
             {
@@ -213,6 +289,101 @@ internal sealed class CouchbaseOwnedCollectionMaterializer
         }
 
         return ownedEntity;
+    }
+
+    /// <summary>
+    /// Sets every scalar property found in <paramref name="itemElement"/> onto the existing
+    /// <paramref name="target"/> instance (as opposed to <see cref="MaterializeOwnedItem"/>,
+    /// which always creates a new instance). Shared by <see cref="MaterializeOwnedItem"/> (via a
+    /// brand-new instance) and <see cref="PopulateReferenceInPlace"/> (via an existing, possibly
+    /// tracked, instance). When <paramref name="touched"/> is non-null, every property actually
+    /// set is recorded into it.
+    /// </summary>
+    private static void PopulateScalarProperties(
+        object target,
+        JsonElement itemElement,
+        IEntityType entityType,
+        JsonNamingPolicy? fieldNamingPolicy,
+        JsonSerializerOptions options,
+        List<TouchedProperty>? touched)
+    {
+        foreach (var prop in entityType.GetProperties())
+        {
+            if (prop.IsShadowProperty()) continue;
+            var jsonKey = fieldNamingPolicy?.ConvertName(prop.Name) ?? prop.Name;
+            if (!itemElement.TryGetPropertyCI(jsonKey, out var propElement)) continue;
+
+            var converted = ConvertFromJson(propElement, prop, options);
+            // Use the property setter when one exists (public or non-public).
+            // Fall back to FieldInfo for backing-field / field-access properties where
+            // PropertyInfo is null or has no setter (e.g. init-only / get-only).
+            if (prop.PropertyInfo?.GetSetMethod(nonPublic: true) != null)
+                prop.PropertyInfo.SetValue(target, converted);
+            else if (prop.FieldInfo != null)
+                prop.FieldInfo.SetValue(target, converted);
+            else
+                continue;
+
+            touched?.Add(new TouchedProperty(target, prop));
+        }
+    }
+
+    /// <summary>
+    /// Materialises a nested OwnsMany navigation's array onto <paramref name="owner"/> — the
+    /// create-and-replace logic shared by <see cref="MaterializeOwnedItem"/> and
+    /// <see cref="PopulateReferenceInPlace"/>. Collections aren't part of EF Core's snapshot-based
+    /// change detection (unlike table-split OwnsOne scalars), so replacing the collection wholesale
+    /// carries no tracking-safety concern the way overriding a scalar in place does.
+    /// </summary>
+    private static void PopulateNestedCollection(
+        object owner,
+        JsonElement nestedElement,
+        INavigation ownedNav,
+        JsonNamingPolicy? fieldNamingPolicy,
+        JsonSerializerOptions options)
+    {
+        if (nestedElement.ValueKind != JsonValueKind.Array) return;
+        var accessor = ownedNav.GetCollectionAccessor();
+        // Skip navigations with no accessor and no way to assign — nothing to set.
+        if (accessor == null && ownedNav.PropertyInfo == null && ownedNav.FieldInfo == null) return;
+        var nestedClrType = ownedNav.TargetEntityType.ClrType;
+        if (accessor != null)
+        {
+            var coll = accessor.GetOrCreate(owner, forMaterialization: true);
+            // Clear via IList for the common List<T> case; otherwise cast through
+            // ICollection<T> which every mutable .NET collection implements and
+            // guarantees Clear() — correctly handles HashSet<T>, SortedSet<T>, etc.
+            if (coll is IList list)
+                list.Clear();
+            else if (coll != null)
+                typeof(ICollection<>).MakeGenericType(nestedClrType)
+                    .GetMethod("Clear")!
+                    .Invoke(coll, null);
+        }
+        else
+        {
+            var list = (IList)Activator.CreateInstance(typeof(List<>).MakeGenericType(nestedClrType))!;
+            // Use the property setter when one exists; fall back to FieldInfo for
+            // backing-field navigations where PropertyInfo is null or has no setter.
+            if (ownedNav.PropertyInfo?.GetSetMethod(nonPublic: true) != null)
+                ownedNav.PropertyInfo.SetValue(owner, list);
+            else if (ownedNav.FieldInfo != null)
+                ownedNav.FieldInfo.SetValue(owner, list);
+        }
+        foreach (var nestedItemElement in nestedElement.EnumerateArray())
+        {
+            var nestedEntity = MaterializeOwnedItem(nestedItemElement, ownedNav.TargetEntityType, fieldNamingPolicy, options);
+            if (accessor != null)
+                accessor.Add(owner, nestedEntity, forMaterialization: true);
+            else
+            {
+                // Read back via the same PropertyInfo → FieldInfo fallback.
+                var existingList = (IList?)(ownedNav.PropertyInfo != null
+                    ? ownedNav.PropertyInfo.GetValue(owner)
+                    : ownedNav.FieldInfo?.GetValue(owner));
+                existingList?.Add(nestedEntity);
+            }
+        }
     }
 
     // ---------------------------------------------------------------------------

--- a/src/Couchbase.EntityFrameworkCore/Query/Internal/CouchbaseProjectionAliases.cs
+++ b/src/Couchbase.EntityFrameworkCore/Query/Internal/CouchbaseProjectionAliases.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Query.SqlExpressions;
 
 namespace Couchbase.EntityFrameworkCore.Query.Internal;
@@ -25,6 +26,19 @@ namespace Couchbase.EntityFrameworkCore.Query.Internal;
 /// </summary>
 internal static class CouchbaseProjectionAliases
 {
+    /// <summary>
+    /// A stable, collision-free lookup key for an owned navigation, used to correlate a
+    /// navigation with its actual (possibly uniquified) N1QL result-row key — see
+    /// <see cref="Query.Internal.CouchbaseShapedQueryCompilingExpressionVisitor.AddOwnedNavigationColumnsToProjection"/>
+    /// and <see cref="Query.Internal.CouchbaseOwnedCollectionMaterializer"/>. Qualified by the
+    /// declaring entity type so two sibling TPH-derived types that happen to declare an owned
+    /// navigation with the same name (e.g. both a <c>Student</c> and a <c>Teacher</c> owning a
+    /// <c>Documents</c> collection) don't collide on this key even though their raw
+    /// <see cref="INavigation.Name"/> values are identical.
+    /// </summary>
+    public static string NavigationKey(INavigation navigation)
+        => navigation.DeclaringEntityType.ClrType.FullName + "." + navigation.Name;
+
     /// <summary>
     /// The N1QL response key for a single projection when no uniquification is applied:
     /// the explicit <c>AS</c> alias if present, otherwise the underlying column name.

--- a/src/Couchbase.EntityFrameworkCore/Query/Internal/CouchbaseQueryEnumerable.cs
+++ b/src/Couchbase.EntityFrameworkCore/Query/Internal/CouchbaseQueryEnumerable.cs
@@ -27,6 +27,8 @@ public static class CouchbaseQueryEnumerable
         RelationalCommandResolver relationalCommandResolver,
         IReadOnlyList<ReaderColumn?>? readerColumns,
         string[]? projectionAliases,
+        string[]? ownedNavigationKeys,
+        string[]? ownedNavigationAliases,
         Func<QueryContext, DbDataReader, ResultContext, SingleQueryResultCoordinator, T> shaper,
         Type contextType,
         bool standAloneStateManager,
@@ -40,6 +42,8 @@ public static class CouchbaseQueryEnumerable
             relationalCommandResolver,
             readerColumns,
             projectionAliases,
+            ownedNavigationKeys,
+            ownedNavigationAliases,
             shaper,
             contextType,
             standAloneStateManager,
@@ -72,6 +76,14 @@ public class CouchbaseQueryEnumerable<T> : IEnumerable<T>, IAsyncEnumerable<T>, 
     private readonly DbContext _dbContext;
     private readonly IReadOnlyList<INavigation> _ownedCollectionNavigations;
     private readonly bool _ownedCollectionsSpanInheritance;
+    private readonly IReadOnlyList<INavigation> _ownedReferenceNavigations;
+    private readonly bool _ownedReferencesSpanInheritance;
+    // Maps CouchbaseProjectionAliases.NavigationKey(nav) → the navigation's actual (possibly
+    // uniquified) N1QL result-row key, resolved at compile time in
+    // CouchbaseShapedQueryCompilingExpressionVisitor once ComputeUnique has run. Only root-level
+    // owned navigations need this — a field name computed fresh from the naming policy can be
+    // stale if it collided with another projected column and was suffixed (e.g. "address0").
+    private readonly Dictionary<string, string> _ownedNavigationAliases;
     private readonly CouchbaseOwnedCollectionMaterializer _materializer = new();
     private readonly CouchbaseCollectionSnapshot _snapshot = new();
 
@@ -80,6 +92,8 @@ public class CouchbaseQueryEnumerable<T> : IEnumerable<T>, IAsyncEnumerable<T>, 
         RelationalCommandResolver relationalCommandResolver,
         IReadOnlyList<ReaderColumn?>? readerColumns,
         string[]? projectionAliases,
+        string[]? ownedNavigationKeys,
+        string[]? ownedNavigationAliases,
         Func<QueryContext, DbDataReader, ResultContext, SingleQueryResultCoordinator, T> shaper,
         Type contextType,
         bool standAloneStateManager,
@@ -93,6 +107,12 @@ public class CouchbaseQueryEnumerable<T> : IEnumerable<T>, IAsyncEnumerable<T>, 
         _relationalCommandResolver = relationalCommandResolver;
         _readerColumns = readerColumns;
         _projectionAliases = projectionAliases;
+        _ownedNavigationAliases = new Dictionary<string, string>(StringComparer.Ordinal);
+        if (ownedNavigationKeys != null && ownedNavigationAliases != null)
+        {
+            for (var i = 0; i < ownedNavigationKeys.Length; i++)
+                _ownedNavigationAliases[ownedNavigationKeys[i]] = ownedNavigationAliases[i];
+        }
         _shaper = shaper;
         _contextType = contextType;
         _queryLogger = relationalQueryContext.QueryLogger;
@@ -124,25 +144,79 @@ public class CouchbaseQueryEnumerable<T> : IEnumerable<T>, IAsyncEnumerable<T>, 
         _ownedCollectionsSpanInheritance = ownerEntityType != null &&
             _ownedCollectionNavigations.Any(
                 n => !n.DeclaringEntityType.ClrType.IsAssignableFrom(ownerEntityType.ClrType));
+
+        // Root-level OwnsOne navigations — additive fallback for genuinely nested JSON objects
+        // (see CouchbaseOwnedCollectionMaterializer.PopulateReference). Same TPH-inheritance
+        // handling as _ownedCollectionNavigations above.
+        _ownedReferenceNavigations = ownerEntityType == null ? [] :
+            ownerEntityType.GetNavigations()
+                .Concat(ownerEntityType.GetDerivedTypes().SelectMany(t => t.GetDeclaredNavigations()))
+                .Where(n => !n.IsCollection && n.TargetEntityType.IsOwned())
+                .ToArray();
+        _ownedReferencesSpanInheritance = ownerEntityType != null &&
+            _ownedReferenceNavigations.Any(
+                n => !n.DeclaringEntityType.ClrType.IsAssignableFrom(ownerEntityType.ClrType));
     }
 
     /// <summary>
-    /// Returns the subset of <see cref="_ownedCollectionNavigations"/> whose declaring entity
-    /// type is assignable from <paramref name="entity"/>'s runtime type. For non-inheritance
-    /// queries this returns the full list unchanged.
+    /// Returns the subset of <paramref name="navigations"/> whose declaring entity type is
+    /// assignable from <paramref name="entity"/>'s runtime type. For non-inheritance queries
+    /// (<paramref name="spansInheritance"/> is <see langword="false"/>) this returns the full
+    /// list unchanged. Shared by <see cref="_ownedCollectionNavigations"/> and
+    /// <see cref="_ownedReferenceNavigations"/> filtering.
     /// </summary>
-    private IReadOnlyList<INavigation> ApplicableOwnedCollections(object? entity)
+    private static IReadOnlyList<INavigation> ApplicableOwnedNavigations(
+        IReadOnlyList<INavigation> navigations, bool spansInheritance, object? entity)
     {
-        if (!_ownedCollectionsSpanInheritance || entity is null)
-            return _ownedCollectionNavigations;
+        if (!spansInheritance || entity is null)
+            return navigations;
 
-        var applicable = new List<INavigation>(_ownedCollectionNavigations.Count);
-        foreach (var nav in _ownedCollectionNavigations)
+        var applicable = new List<INavigation>(navigations.Count);
+        foreach (var nav in navigations)
         {
             if (nav.DeclaringEntityType.ClrType.IsInstanceOfType(entity))
                 applicable.Add(nav);
         }
         return applicable;
+    }
+
+    /// <summary>
+    /// If <see cref="_isTracking"/> and any property was overridden by
+    /// <see cref="CouchbaseOwnedCollectionMaterializer.PopulateReference{T}"/>, realigns EF Core's
+    /// own change-tracking snapshot for each so a later <c>DetectChanges</c> doesn't see the
+    /// override as a user-driven mutation and spuriously mark the owner <c>Modified</c>.
+    /// <para>
+    /// <see cref="Microsoft.EntityFrameworkCore.ChangeTracking.EntityEntry"/> access (via
+    /// <see cref="DbContext.Entry"/> or <see cref="Microsoft.EntityFrameworkCore.ChangeTracking.EntityEntry.State"/>)
+    /// triggers an implicit <c>DetectChanges()</c> unless <c>AutoDetectChangesEnabled</c> is
+    /// disabled first — otherwise that implicit detection would bake in <c>IsModified=true</c>
+    /// against the stale original value before this method gets a chance to fix it. This mirrors
+    /// the pattern already used by
+    /// <see cref="Couchbase.EntityFrameworkCore.Storage.Internal.CouchbaseSaveChangesInterceptor.MarkOwnersWithReplacedCollections"/>.
+    /// </para>
+    /// </summary>
+    private void RealignTrackedOriginalValues(
+        IReadOnlyList<CouchbaseOwnedCollectionMaterializer.TouchedProperty> touched)
+    {
+        if (!_isTracking || touched.Count == 0) return;
+
+        var changeTracker = _dbContext.ChangeTracker;
+        var autoDetect = changeTracker.AutoDetectChangesEnabled;
+        changeTracker.AutoDetectChangesEnabled = false;
+        try
+        {
+            foreach (var t in touched)
+            {
+                var currentValue = t.Property.PropertyInfo != null
+                    ? t.Property.PropertyInfo.GetValue(t.Instance)
+                    : t.Property.FieldInfo?.GetValue(t.Instance);
+                _dbContext.Entry(t.Instance).Property(t.Property.Name).OriginalValue = currentValue;
+            }
+        }
+        finally
+        {
+            changeTracker.AutoDetectChangesEnabled = autoDetect;
+        }
     }
 
     /// <summary>Returns an enumerator that iterates through the collection.</summary>
@@ -221,15 +295,22 @@ public class CouchbaseQueryEnumerable<T> : IEnumerable<T>, IAsyncEnumerable<T>, 
                 // fall back to CurrentRow for shapers that complete in a single iteration.
                 var navRow = pendingEntityRow
                     ?? (reader.CurrentRow is JsonElement r ? r : (JsonElement?)null);
-                if (_ownedCollectionNavigations.Count > 0
+                if ((_ownedCollectionNavigations.Count > 0 || _ownedReferenceNavigations.Count > 0)
                     && navRow is JsonElement rowElement
                     && rowElement.ValueKind == JsonValueKind.Object)
                 {
-                    var applicable = ApplicableOwnedCollections(result);
-                    if (applicable.Count > 0)
+                    var applicableCollections = ApplicableOwnedNavigations(_ownedCollectionNavigations, _ownedCollectionsSpanInheritance, result);
+                    if (applicableCollections.Count > 0)
                     {
-                        _materializer.Populate(result, rowElement, applicable, _couchbaseDbContextOptionsBuilder.FieldNamingPolicy, _couchbaseDbContextOptionsBuilder.SerializerOptions);
-                        _snapshot.Record(result, applicable, _isTracking);
+                        _materializer.Populate(result, rowElement, applicableCollections, _couchbaseDbContextOptionsBuilder.FieldNamingPolicy, _couchbaseDbContextOptionsBuilder.SerializerOptions, _ownedNavigationAliases);
+                        _snapshot.Record(result, applicableCollections, _isTracking);
+                    }
+
+                    var applicableReferences = ApplicableOwnedNavigations(_ownedReferenceNavigations, _ownedReferencesSpanInheritance, result);
+                    if (applicableReferences.Count > 0)
+                    {
+                        var touched = _materializer.PopulateReference(result, rowElement, applicableReferences, _couchbaseDbContextOptionsBuilder.FieldNamingPolicy, _couchbaseDbContextOptionsBuilder.SerializerOptions, _ownedNavigationAliases);
+                        RealignTrackedOriginalValues(touched);
                     }
                 }
                 pendingEntityRow = null;
@@ -257,15 +338,22 @@ public class CouchbaseQueryEnumerable<T> : IEnumerable<T>, IAsyncEnumerable<T>, 
                     var last = _shaper(_relationalQueryContext, reader, coordinator.ResultContext, coordinator);
                     coordinator.ResultContext.Values = null;
                     // CurrentRow is null at EOF; use pendingEntityRow saved above.
-                    if (_ownedCollectionNavigations.Count > 0
+                    if ((_ownedCollectionNavigations.Count > 0 || _ownedReferenceNavigations.Count > 0)
                         && pendingEntityRow is JsonElement lastRow
                         && lastRow.ValueKind == JsonValueKind.Object)
                     {
-                        var applicable = ApplicableOwnedCollections(last);
-                        if (applicable.Count > 0)
+                        var applicableCollections = ApplicableOwnedNavigations(_ownedCollectionNavigations, _ownedCollectionsSpanInheritance, last);
+                        if (applicableCollections.Count > 0)
                         {
-                            _materializer.Populate(last, lastRow, applicable, _couchbaseDbContextOptionsBuilder.FieldNamingPolicy, _couchbaseDbContextOptionsBuilder.SerializerOptions);
-                            _snapshot.Record(last, applicable, _isTracking);
+                            _materializer.Populate(last, lastRow, applicableCollections, _couchbaseDbContextOptionsBuilder.FieldNamingPolicy, _couchbaseDbContextOptionsBuilder.SerializerOptions, _ownedNavigationAliases);
+                            _snapshot.Record(last, applicableCollections, _isTracking);
+                        }
+
+                        var applicableReferences = ApplicableOwnedNavigations(_ownedReferenceNavigations, _ownedReferencesSpanInheritance, last);
+                        if (applicableReferences.Count > 0)
+                        {
+                            var touched = _materializer.PopulateReference(last, lastRow, applicableReferences, _couchbaseDbContextOptionsBuilder.FieldNamingPolicy, _couchbaseDbContextOptionsBuilder.SerializerOptions, _ownedNavigationAliases);
+                            RealignTrackedOriginalValues(touched);
                         }
                     }
                     pendingEntityRow = null;

--- a/src/Couchbase.EntityFrameworkCore/Query/Internal/CouchbaseShapedQueryCompilingExpressionVisitor.cs
+++ b/src/Couchbase.EntityFrameworkCore/Query/Internal/CouchbaseShapedQueryCompilingExpressionVisitor.cs
@@ -224,11 +224,12 @@ public class CouchbaseShapedQueryCompilingExpressionVisitor : RelationalShapedQu
                     Expression.Constant(_couchbaseDbContextOptionsBuilder));
             }
 
-            // Add OwnsMany navigation columns to the SELECT projection using the IR so the
-            // embedded arrays arrive in the N1QL row. Done after ProcessShaper (shaper ordinals
-            // are already fixed) and before projectionAliases is built (so the new names are
-            // included in the alias array that CouchbaseDbDataReader uses for column lookup).
-            AddOwnedCollectionColumnsToProjection(selectExpression, shaper.ReturnType);
+            // Add OwnsMany/OwnsOne navigation columns to the SELECT projection using the IR so
+            // the embedded JSON arrives in the N1QL row. Done after ProcessShaper (shaper
+            // ordinals are already fixed) and before projectionAliases is built (so the new
+            // names are included in the alias array that CouchbaseDbDataReader uses for column
+            // lookup).
+            var ownedNavProjections = AddOwnedNavigationColumnsToProjection(selectExpression, shaper.ReturnType);
 
             // Build the per-ordinal N1QL response keys.  Aliases are made unique (see
             // CouchbaseProjectionAliases) so that a collection Include where the principal and
@@ -243,19 +244,22 @@ public class CouchbaseShapedQueryCompilingExpressionVisitor : RelationalShapedQu
             // signal for "no collection rows" — PopulateCollectionNavigations then fills the
             // actual collection from the embedded JSON array.
             var uniqueAliases = CouchbaseProjectionAliases.ComputeUnique(selectExpression.Projection);
-            var projectionAliasesExpression = Dependencies.LiftableConstantFactory.CreateLiftableConstant(
-                uniqueAliases,
-#pragma warning disable EF9100
-                Expression.Lambda<Func<MaterializerLiftableConstantContext, object>>(
-#pragma warning restore EF9100
-                    Expression.NewArrayInit(
-                        typeof(string),
-                        uniqueAliases.Select(a => (Expression)Expression.Constant(a, typeof(string)))),
-#pragma warning disable EF9100
-                    Expression.Parameter(typeof(MaterializerLiftableConstantContext), "_")),
-#pragma warning restore EF9100
-                "projectionAliases",
-                typeof(string[]));
+            var projectionAliasesExpression = CreateStringArrayLiftableConstant(uniqueAliases, "projectionAliases");
+
+            // Resolve each owned navigation's FINAL (post-uniquification) alias, so
+            // CouchbaseOwnedCollectionMaterializer can read the correct JSON key even when its
+            // field name collided with another projected column and was suffixed (e.g.
+            // "address" → "address0"). Keyed by CouchbaseProjectionAliases.NavigationKey rather
+            // than the field name itself, since that's exactly what may have changed.
+            var ownedNavKeys = new string[ownedNavProjections.Count];
+            var ownedNavAliases = new string[ownedNavProjections.Count];
+            for (var i = 0; i < ownedNavProjections.Count; i++)
+            {
+                ownedNavKeys[i] = CouchbaseProjectionAliases.NavigationKey(ownedNavProjections[i].Navigation);
+                ownedNavAliases[i] = uniqueAliases[ownedNavProjections[i].ProjectionIndex];
+            }
+            var ownedNavKeysExpression = CreateStringArrayLiftableConstant(ownedNavKeys, "ownedNavKeys");
+            var ownedNavAliasesExpression = CreateStringArrayLiftableConstant(ownedNavAliases, "ownedNavAliases");
 
             return Expression.Call(
                 CreateSingleQueryingEnumerableMethodInfo.MakeGenericMethod(shaper.ReturnType),
@@ -263,6 +267,8 @@ public class CouchbaseShapedQueryCompilingExpressionVisitor : RelationalShapedQu
                 relationalCommandResolver,
                 readerColumnsExpression,
                 projectionAliasesExpression,
+                ownedNavKeysExpression,
+                ownedNavAliasesExpression,
                 shaper,
                 Expression.Constant(_contextType),
                 Expression.Constant(QueryCompilationContext.QueryTrackingBehavior == QueryTrackingBehavior.NoTrackingWithIdentityResolution),
@@ -275,11 +281,21 @@ public class CouchbaseShapedQueryCompilingExpressionVisitor : RelationalShapedQu
     }
 
     /// <summary>
-    /// Appends a <see cref="ColumnExpression"/> for each OwnsMany navigation of the root entity
-    /// to <paramref name="selectExpression"/>'s projection so the embedded JSON arrays arrive
-    /// inline with the N1QL result row. This replaces the post-hoc string rewriting that
-    /// <c>InjectOwnedCollectionColumns</c> previously applied to the emitted SQL, eliminating
-    /// brittleness caused by matching FROM/AS tokens in string literals or nested subqueries.
+    /// Appends a <see cref="ColumnExpression"/> for each OwnsMany navigation, and each root-level
+    /// OwnsOne navigation, of the root entity to <paramref name="selectExpression"/>'s projection
+    /// so the embedded JSON (array or object) arrives inline with the N1QL result row. This
+    /// replaces the post-hoc string rewriting that <c>InjectOwnedCollectionColumns</c> previously
+    /// applied to the emitted SQL, eliminating brittleness caused by matching FROM/AS tokens in
+    /// string literals or nested subqueries.
+    /// <para>
+    /// OwnsMany relies on this raw JSON for materialization entirely (no JOIN is emitted).
+    /// OwnsOne still gets its usual flat table-split columns from EF Core's default relational
+    /// projection — this extra column is an additive fallback so
+    /// <see cref="CouchbaseOwnedCollectionMaterializer.PopulateReference"/> can override the
+    /// flat-column result when the navigation's data is actually stored as a genuinely nested
+    /// JSON object (e.g. a foreign/pre-existing document) rather than this provider's own flat
+    /// write scheme.
+    /// </para>
     ///
     /// Handles two shapes that EF Core emits for entities with collection includes:
     /// <list type="bullet">
@@ -289,17 +305,32 @@ public class CouchbaseShapedQueryCompilingExpressionVisitor : RelationalShapedQu
     ///     outer projections using their respective aliases.</item>
     /// </list>
     /// </summary>
-    private void AddOwnedCollectionColumnsToProjection(SelectExpression selectExpression, Type shaperReturnType)
+    /// <returns>
+    /// For each owned navigation whose column was appended, the navigation paired with the
+    /// index of its <em>outer</em> <paramref name="selectExpression"/> projection entry. The
+    /// alias at that index is only final once <see cref="CouchbaseProjectionAliases.ComputeUnique"/>
+    /// runs over the completed projection list — a colliding field name (e.g. two owned
+    /// navigations, or an owned navigation and an unrelated projected column, that both happen to
+    /// resolve to the same effective alias) gets suffixed at that point, and the raw N1QL result
+    /// row is keyed by that final, possibly-suffixed alias rather than the field name computed
+    /// here. Callers must resolve each navigation's actual key from the index returned rather
+    /// than assuming it equals the field name this method used, or a colliding fallback column
+    /// would silently fail to materialise.
+    /// </returns>
+    private List<(INavigation Navigation, int ProjectionIndex)> AddOwnedNavigationColumnsToProjection(
+        SelectExpression selectExpression, Type shaperReturnType)
     {
+        var result = new List<(INavigation Navigation, int ProjectionIndex)>();
+
         // Resolve the entity type first so we can match the TableExpression by the entity's
         // configured table name rather than the fragile 3-part "bucket.scope.collection"
         // heuristic that fails silently in test contexts where SetupKeyspaces is not called.
         var entityType = QueryCompilationContext.Model.GetEntityTypes()
             .FirstOrDefault(e => e.ClrType == shaperReturnType);
-        if (entityType == null) return;
+        if (entityType == null) return result;
 
         var expectedTableName = entityType.GetTableName();
-        if (expectedTableName == null) return;
+        if (expectedTableName == null) return result;
 
         // Locate the owner entity's TableExpression by matching its configured name.
         // Simple form:   Tables contains the entity TableExpression directly.
@@ -326,20 +357,22 @@ public class CouchbaseShapedQueryCompilingExpressionVisitor : RelationalShapedQu
                     .FirstOrDefault(t => t.Name == expectedTableName);
         }
 
-        if (ownerTable == null) return;
+        if (ownerTable == null) return result;
 
-        // Include OwnsMany navigations declared on derived types (TPH): when the base type is
-        // queried, the derived rows' owned-collection field must still be projected so it lands
-        // in the result JSON for CouchbaseQueryEnumerable to materialise. Derived types share the
+        // Include owned navigations declared on derived types (TPH): when the base type is
+        // queried, the derived rows' owned field must still be projected so it lands in the
+        // result JSON for CouchbaseQueryEnumerable to materialise. Derived types share the
         // owner's table, so the column reference against ownerTable is valid (null for base rows).
-        var ownedCollNavs = entityType.GetNavigations()
+        // Covers both OwnsMany (arrays, relied on exclusively) and root-level OwnsOne (objects,
+        // used only as a fallback — see the PopulateReference reference in the doc comment above).
+        var ownedNavs = entityType.GetNavigations()
             .Concat(entityType.GetDerivedTypes().SelectMany(t => t.GetDeclaredNavigations()))
-            .Where(n => n.IsCollection && n.TargetEntityType.IsOwned())
+            .Where(n => n.TargetEntityType.IsOwned())
             .ToList();
-        if (ownedCollNavs.Count == 0) return;
+        if (ownedNavs.Count == 0) return result;
 
         var policy = _couchbaseDbContextOptionsBuilder.FieldNamingPolicy;
-        foreach (var nav in ownedCollNavs)
+        foreach (var nav in ownedNavs)
         {
             var fieldName = policy?.ConvertName(nav.Name) ?? nav.Name;
 
@@ -357,8 +390,35 @@ public class CouchbaseShapedQueryCompilingExpressionVisitor : RelationalShapedQu
                 selectExpression.AddToProjection(
                     new ColumnExpression(fieldName, ownerTable.Alias, typeof(object), null, true));
             }
+
+            // AddToProjection always appends, so the entry we just added to the OUTER
+            // selectExpression's projection is the last one, regardless of the simple/subquery
+            // form above.
+            result.Add((nav, selectExpression.Projection.Count - 1));
         }
+
+        return result;
     }
+
+    /// <summary>
+    /// Builds a liftable <c>string[]</c> constant for the compiled query — the same pattern used
+    /// for <c>projectionAliases</c>, now shared with the owned-navigation alias-resolution arrays.
+    /// </summary>
+    [Experimental("EF9100")]
+    private Expression CreateStringArrayLiftableConstant(string[] values, string parameterName)
+        => Dependencies.LiftableConstantFactory.CreateLiftableConstant(
+            values,
+#pragma warning disable EF9100
+            Expression.Lambda<Func<MaterializerLiftableConstantContext, object>>(
+#pragma warning restore EF9100
+                Expression.NewArrayInit(
+                    typeof(string),
+                    values.Select(a => (Expression)Expression.Constant(a, typeof(string)))),
+#pragma warning disable EF9100
+                Expression.Parameter(typeof(MaterializerLiftableConstantContext), "_")),
+#pragma warning restore EF9100
+            parameterName,
+            typeof(string[]));
 
     [Experimental("EF9100")]
     private static Expression CreateReaderColumnsExpression(

--- a/src/Couchbase.EntityFrameworkCore/Storage/Internal/CouchbaseDatabaseWrapper.cs
+++ b/src/Couchbase.EntityFrameworkCore/Storage/Internal/CouchbaseDatabaseWrapper.cs
@@ -344,7 +344,7 @@ public class CouchbaseDatabaseWrapper : Database
         //              EF Core's projected column name (e.g. "address_street"), allowing the
         //              EF Core shaper to read it directly from the N1QL result row.
         //   OwnsMany → the collection is stored under its camelCase navigation name
-        //              (e.g. "contactMethods") so AddOwnedCollectionColumnsToProjection
+        //              (e.g. "contactMethods") so AddOwnedNavigationColumnsToProjection
         //              (CouchbaseShapedQueryCompilingExpressionVisitor) can inject a
         //              ColumnExpression into the IR projection, and PopulateCollectionNavigations
         //              can look up the same key in the N1QL result row.

--- a/tests/Couchbase.EntityFrameworkCore.IntegrationTests/Models/TravelSampleDbContext.cs
+++ b/tests/Couchbase.EntityFrameworkCore.IntegrationTests/Models/TravelSampleDbContext.cs
@@ -28,12 +28,11 @@ public class TravelSampleDbContext(DbContextOptions<TravelSampleDbContext> optio
         modelBuilder.Entity<TravelSampleFixture.User>().OwnsMany(u => u.Addresses);
         modelBuilder.Entity<TravelSampleFixture.Hotel>().OwnsMany(h => h.Reviews, r => r.OwnsOne(rv => rv.Ratings));
 
-        // Geo is a single embedded object, not an array. OwnsOne maps it via EF Core's relational
-        // table-splitting, which projects flat "geo_Lat"/"geo_Lon" columns — but travel-sample
-        // stores geo as a genuinely nested JSON object ({"geo":{"lat":...}}), so those columns
-        // never match and the properties always read back null. See Test_Hotel_With_Geo's skip
-        // reason for details; ignore until OwnsOne gets nested-path read support.
-        modelBuilder.Entity<TravelSampleFixture.Hotel>().Ignore(h => h.Geo);
+        // Geo is a single embedded object, not an array. OwnsOne's own flat "geo_Lat"/"geo_Lon"
+        // table-split columns never match travel-sample's genuinely nested geo object
+        // ({"geo":{"lat":...}}), but CouchbaseOwnedCollectionMaterializer.PopulateReference
+        // overrides those flat-column reads with the nested JSON when present.
+        modelBuilder.Entity<TravelSampleFixture.Hotel>().OwnsOne(h => h.Geo);
 
         // Configure Couchbase mappings
         modelBuilder.ConfigureToCouchbase(this, true);

--- a/tests/Couchbase.EntityFrameworkCore.IntegrationTests/Tests/CrudTests.cs
+++ b/tests/Couchbase.EntityFrameworkCore.IntegrationTests/Tests/CrudTests.cs
@@ -700,27 +700,46 @@ public class CrudTests(
         Assert.Equal("hotel", hotel.Type);
     }
 
-    [Fact(Skip = "Hotel.Geo is mapped with .Ignore() in TravelSampleDbContext. OwnsOne is NOT "
-        + "sufficient here: it table-splits into flat 'geo_Lat'/'geo_Lon' columns, but "
-        + "travel-sample stores geo as a genuinely nested JSON object ({\"geo\":{\"lat\":...}}), "
-        + "so those columns never match and Lat/Lon always read back null (confirmed against a "
-        + "live cluster). Needs query-translation support for reading a nested-object path on an "
-        + "OwnsOne navigation, analogous to what CouchbaseOwnedCollectionMaterializer already does "
-        + "for OwnsMany arrays.")]
+    [Fact]
     public async Task Test_Hotel_With_Geo()
     {
         await using var context = travelSampleFixture.GetDbContext();
 
-        // Query any hotel - Geo is ignored by EF so not included in query projection
-        var hotels = await context.Hotels.Take(10).ToListAsync();
+        // Sample a wider slice than most single-record tests: not every travel-sample hotel has
+        // a fully-populated geo object (a few have Geo present but null Lat/Lon), so look across
+        // enough rows to reliably find a complete one.
+        var hotels = await context.Hotels.Take(50).ToListAsync();
 
-        // Find one with geo data
-        var hotel = hotels.FirstOrDefault(h => h.Geo != null);
+        var hotel = hotels.FirstOrDefault(h => h.Geo?.Lat != null && h.Geo?.Lon != null);
 
         Assert.NotNull(hotel);
         Assert.NotNull(hotel.Geo);
         Assert.NotNull(hotel.Geo.Lat);
         Assert.NotNull(hotel.Geo.Lon);
+    }
+
+    // Tracking-safety regression: PopulateReference overrides Hotel.Geo's scalar properties in
+    // place from the nested JSON after the shaper has already snapshotted them (flat-column
+    // nulls) for change tracking. Without realigning that snapshot, EF Core's own DetectChanges
+    // would see the override as a user-driven mutation and spuriously mark the hotel Modified on
+    // the next SaveChanges. Checks the Geo entry's own IsModified flags directly rather than an
+    // aggregate SaveChangesAsync count — Hotel.Reviews (OwnsMany) items are a separate, unrelated,
+    // pre-existing issue (they come back tracked as Added on every load, forcing an owner rewrite
+    // regardless of any Geo change), which would make an aggregate write count unreliable here.
+    [Fact]
+    public async Task Test_Hotel_With_Geo_TrackedLoad_DoesNotMarkGeoModified()
+    {
+        await using var context = travelSampleFixture.GetDbContext();
+
+        var hotels = await context.Hotels.Take(50).ToListAsync();
+        var hotel = hotels.FirstOrDefault(h => h.Geo?.Lat != null && h.Geo?.Lon != null);
+        Assert.NotNull(hotel);
+
+        context.ChangeTracker.DetectChanges();
+        var geoEntry = context.Entry(hotel!.Geo!);
+        Assert.False(geoEntry.Property(nameof(TravelSampleFixture.Geo.Lat)).IsModified);
+        Assert.False(geoEntry.Property(nameof(TravelSampleFixture.Geo.Lon)).IsModified);
+        Assert.False(geoEntry.Property(nameof(TravelSampleFixture.Geo.Accuracy)).IsModified);
     }
 
     [Fact]

--- a/tests/Couchbase.EntityFrameworkCore.UnitTests/Couchbase/EntityFrameworkCore/Query/CouchbaseOwnedCollectionMaterializerTests.cs
+++ b/tests/Couchbase.EntityFrameworkCore.UnitTests/Couchbase/EntityFrameworkCore/Query/CouchbaseOwnedCollectionMaterializerTests.cs
@@ -234,6 +234,63 @@ public class CouchbaseOwnedCollectionMaterializerTests
     private static Microsoft.EntityFrameworkCore.Metadata.IEntityType GetOwnedType<T>(ItemContext ctx)
         => ctx.Model.GetEntityTypes().First(e => e.ClrType == typeof(T));
 
+    private static Microsoft.EntityFrameworkCore.Metadata.INavigation GetItemsNavigation(ItemContext ctx)
+        => ctx.Model.FindEntityType(typeof(ItemOwner))!.FindNavigation(nameof(ItemOwner.Items))!;
+
+    // -------------------------------------------------------------------------
+    // Populate — navigation-alias resolution (collision-proofing regression)
+    // -------------------------------------------------------------------------
+    //
+    // CouchbaseShapedQueryCompilingExpressionVisitor.AddOwnedNavigationColumnsToProjection
+    // computes a navigation's field name (e.g. "items") before CouchbaseProjectionAliases
+    // .ComputeUnique runs over the full projection. If that field name collides with another
+    // projected column's effective alias (e.g. a joined/included entity that also happens to
+    // expose an "items" property), ComputeUnique suffixes it (e.g. "items0") — and the ACTUAL
+    // N1QL result row is keyed by that suffixed alias, not the plain field name. These tests
+    // simulate that scenario directly against a synthetic row.
+
+    [Fact]
+    public void Populate_NavigationAliases_ResolvesCollidedAlias()
+    {
+        using var ctx = CreateItemContext();
+        var itemsNav = GetItemsNavigation(ctx);
+        var policy = JsonNamingPolicy.CamelCase;
+
+        var owner = new ItemOwner { Id = 1 };
+        // The array is stored under a collision-suffixed key, as the SQL generator would emit
+        // when "items" collided with another projected column's alias.
+        var doc = JsonDocument.Parse("""{"items0":[{"id":1,"value":"x"}]}""").RootElement;
+        var aliases = new Dictionary<string, string>
+        {
+            [CouchbaseProjectionAliases.NavigationKey(itemsNav)] = "items0"
+        };
+
+        var materializer = new CouchbaseOwnedCollectionMaterializer();
+        materializer.Populate(owner, doc, [itemsNav], policy, _webOptions, aliases);
+
+        Assert.Single(owner.Items);
+        Assert.Equal("x", owner.Items[0].Value);
+    }
+
+    [Fact]
+    public void Populate_WithoutNavigationAliases_MissesCollidedAlias()
+    {
+        // Negative control: without the alias map (or the key absent from it), the plain
+        // policy-computed field name ("items") never matches the actual "items0" key — proving
+        // the collision this fix addresses would otherwise silently drop the data.
+        using var ctx = CreateItemContext();
+        var itemsNav = GetItemsNavigation(ctx);
+        var policy = JsonNamingPolicy.CamelCase;
+
+        var owner = new ItemOwner { Id = 1 };
+        var doc = JsonDocument.Parse("""{"items0":[{"id":1,"value":"x"}]}""").RootElement;
+
+        var materializer = new CouchbaseOwnedCollectionMaterializer();
+        materializer.Populate(owner, doc, [itemsNav], policy, _webOptions, navigationAliases: null);
+
+        Assert.Empty(owner.Items);
+    }
+
     [Fact]
     public void MaterializeOwnedItem_ScalarProperties_AreSet()
     {
@@ -300,6 +357,196 @@ public class CouchbaseOwnedCollectionMaterializerTests
         // Second materialisation of the same JSON must also yield exactly 1 tag.
         var result2 = (OwnedItem)CouchbaseOwnedCollectionMaterializer.MaterializeOwnedItem(json, itemType, policy, _webOptions);
         Assert.Single(result2.Tags);
+    }
+
+    // -------------------------------------------------------------------------
+    // PopulateReference — in-place override for a root OwnsOne from nested JSON
+    // -------------------------------------------------------------------------
+
+    private class RefOwner
+    {
+        public int Id { get; set; }
+        public RefAddress Address { get; set; } = new();
+    }
+
+    private class RefAddress
+    {
+        public string? Street { get; set; }
+        public string? City { get; set; }
+        public RefGeo? Geo { get; set; }
+    }
+
+    private class RefGeo
+    {
+        public double? Lat { get; set; }
+        public double? Lon { get; set; }
+    }
+
+    private class RefContext(DbContextOptions<RefContext> options) : DbContext(options)
+    {
+        public DbSet<RefOwner> Owners { get; set; } = null!;
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            modelBuilder.Entity<RefOwner>(b =>
+            {
+                b.ToCouchbaseCollection("bucket", "scope", "refowner");
+                b.HasKey(o => o.Id);
+                b.OwnsOne(o => o.Address, a => a.OwnsOne(x => x.Geo));
+            });
+        }
+    }
+
+    private static RefContext CreateRefContext()
+    {
+        var opts = new global::Couchbase.ClusterOptions()
+            .WithConnectionString("couchbase://localhost")
+            .WithPasswordAuthentication("Administrator", "password");
+        var builder = new DbContextOptionsBuilder<RefContext>();
+        builder.UseCouchbaseProvider(opts);
+        return new RefContext(builder.Options);
+    }
+
+    private static Microsoft.EntityFrameworkCore.Metadata.INavigation GetRootNavigation<TOwner>(
+        RefContext ctx, string navigationName)
+        => ctx.Model.FindEntityType(typeof(TOwner))!.FindNavigation(navigationName)!;
+
+    [Fact]
+    public void PopulateReference_NestedObjectPresent_OverridesInPlace()
+    {
+        using var ctx = CreateRefContext();
+        var addressNav = GetRootNavigation<RefOwner>(ctx, nameof(RefOwner.Address));
+        var policy = JsonNamingPolicy.CamelCase;
+
+        var owner = new RefOwner { Id = 1, Address = new RefAddress { Street = "old", City = "old-city" } };
+        var existingAddress = owner.Address;
+
+        var doc = JsonDocument.Parse(
+            """{"address":{"street":"1 Main St","city":"Springfield"}}""").RootElement;
+
+        var materializer = new CouchbaseOwnedCollectionMaterializer();
+        var touched = materializer.PopulateReference(owner, doc, [addressNav], policy, _webOptions);
+
+        // In place: same instance, new values.
+        Assert.Same(existingAddress, owner.Address);
+        Assert.Equal("1 Main St", owner.Address.Street);
+        Assert.Equal("Springfield", owner.Address.City);
+
+        Assert.Equal(2, touched.Count);
+        Assert.All(touched, t => Assert.Same(existingAddress, t.Instance));
+        Assert.Contains(touched, t => t.Property.Name == nameof(RefAddress.Street));
+        Assert.Contains(touched, t => t.Property.Name == nameof(RefAddress.City));
+    }
+
+    [Fact]
+    public void PopulateReference_FieldAbsent_LeavesExistingValuesUntouched()
+    {
+        using var ctx = CreateRefContext();
+        var addressNav = GetRootNavigation<RefOwner>(ctx, nameof(RefOwner.Address));
+        var policy = JsonNamingPolicy.CamelCase;
+
+        var owner = new RefOwner { Id = 1, Address = new RefAddress { Street = "sentinel", City = "sentinel-city" } };
+
+        // No "address" key at all.
+        var doc = JsonDocument.Parse("""{"id":1}""").RootElement;
+
+        var materializer = new CouchbaseOwnedCollectionMaterializer();
+        var touched = materializer.PopulateReference(owner, doc, [addressNav], policy, _webOptions);
+
+        Assert.Empty(touched);
+        Assert.Equal("sentinel", owner.Address.Street);
+        Assert.Equal("sentinel-city", owner.Address.City);
+    }
+
+    [Fact]
+    public void PopulateReference_NavigationAliases_ResolvesCollidedAlias()
+    {
+        // Same collision-proofing concern as Populate — see the section comment above
+        // GetItemsNavigation. Here the nested object arrives under a suffixed key ("address0")
+        // rather than "address".
+        using var ctx = CreateRefContext();
+        var addressNav = GetRootNavigation<RefOwner>(ctx, nameof(RefOwner.Address));
+        var policy = JsonNamingPolicy.CamelCase;
+
+        var owner = new RefOwner { Id = 1, Address = new RefAddress { Street = "old", City = "old-city" } };
+        var doc = JsonDocument.Parse(
+            """{"address0":{"street":"1 Main St","city":"Springfield"}}""").RootElement;
+        var aliases = new Dictionary<string, string>
+        {
+            [CouchbaseProjectionAliases.NavigationKey(addressNav)] = "address0"
+        };
+
+        var materializer = new CouchbaseOwnedCollectionMaterializer();
+        var touched = materializer.PopulateReference(owner, doc, [addressNav], policy, _webOptions, aliases);
+
+        Assert.NotEmpty(touched);
+        Assert.Equal("1 Main St", owner.Address.Street);
+        Assert.Equal("Springfield", owner.Address.City);
+    }
+
+    [Fact]
+    public void PopulateReference_WithoutNavigationAliases_MissesCollidedAlias()
+    {
+        using var ctx = CreateRefContext();
+        var addressNav = GetRootNavigation<RefOwner>(ctx, nameof(RefOwner.Address));
+        var policy = JsonNamingPolicy.CamelCase;
+
+        var owner = new RefOwner { Id = 1, Address = new RefAddress { Street = "sentinel", City = "sentinel-city" } };
+        var doc = JsonDocument.Parse(
+            """{"address0":{"street":"1 Main St","city":"Springfield"}}""").RootElement;
+
+        var materializer = new CouchbaseOwnedCollectionMaterializer();
+        var touched = materializer.PopulateReference(owner, doc, [addressNav], policy, _webOptions, navigationAliases: null);
+
+        Assert.Empty(touched);
+        Assert.Equal("sentinel", owner.Address.Street);
+    }
+
+    [Fact]
+    public void PopulateReference_FieldNull_LeavesExistingValuesUntouched()
+    {
+        using var ctx = CreateRefContext();
+        var addressNav = GetRootNavigation<RefOwner>(ctx, nameof(RefOwner.Address));
+        var policy = JsonNamingPolicy.CamelCase;
+
+        var owner = new RefOwner { Id = 1, Address = new RefAddress { Street = "sentinel", City = "sentinel-city" } };
+
+        var doc = JsonDocument.Parse("""{"address":null}""").RootElement;
+
+        var materializer = new CouchbaseOwnedCollectionMaterializer();
+        var touched = materializer.PopulateReference(owner, doc, [addressNav], policy, _webOptions);
+
+        Assert.Empty(touched);
+        Assert.Equal("sentinel", owner.Address.Street);
+    }
+
+    [Fact]
+    public void PopulateReference_NestedOwnsOneWithinOwnsOne_IsPopulatedInPlace()
+    {
+        // RefAddress.Geo is itself an OwnsOne nested inside the root OwnsOne (RefOwner.Address).
+        // Recursion must apply the same in-place treatment at that depth too.
+        using var ctx = CreateRefContext();
+        var addressNav = GetRootNavigation<RefOwner>(ctx, nameof(RefOwner.Address));
+        var policy = JsonNamingPolicy.CamelCase;
+
+        var owner = new RefOwner
+        {
+            Id = 1,
+            Address = new RefAddress { Street = "1 Main St", Geo = new RefGeo { Lat = 0, Lon = 0 } }
+        };
+        var existingGeo = owner.Address.Geo!;
+
+        var doc = JsonDocument.Parse(
+            """{"address":{"street":"1 Main St","geo":{"lat":47.6,"lon":-122.3}}}""").RootElement;
+
+        var materializer = new CouchbaseOwnedCollectionMaterializer();
+        var touched = materializer.PopulateReference(owner, doc, [addressNav], policy, _webOptions);
+
+        Assert.Same(existingGeo, owner.Address.Geo);
+        Assert.Equal(47.6, owner.Address.Geo!.Lat);
+        Assert.Equal(-122.3, owner.Address.Geo!.Lon);
+
+        Assert.Contains(touched, t => t.Instance == (object)existingGeo && t.Property.Name == nameof(RefGeo.Lat));
+        Assert.Contains(touched, t => t.Instance == (object)existingGeo && t.Property.Name == nameof(RefGeo.Lon));
     }
 
     // -------------------------------------------------------------------------

--- a/tests/Couchbase.EntityFrameworkCore.UnitTests/Couchbase/EntityFrameworkCore/Query/OwnedCollectionInjectionTests.cs
+++ b/tests/Couchbase.EntityFrameworkCore.UnitTests/Couchbase/EntityFrameworkCore/Query/OwnedCollectionInjectionTests.cs
@@ -154,6 +154,21 @@ public class NestedOwnedSqlGenerationTests
         Assert.Equal(sql.Count(c => c == '('), sql.Count(c => c == ')'));
     }
 
+    // A root-level OwnsOne (Customer.Address) must get an additive raw-object projection column
+    // for its field name, alongside its usual flat table-split columns — the fallback that lets
+    // PopulateReference override flat-column reads for a genuinely nested JSON document.
+    [Fact]
+    public void RootOwnsOne_ToList_ProjectsRawObjectColumnForNavigation()
+    {
+        using var ctx = CreateContext();
+        var sql = ctx.Customers.AsQueryable().ToQueryString();
+        // Distinct from the flat table-split columns (`Address_City`, `Address_Street`) already
+        // present in the SELECT list — this is the new additive raw-object column keyed by the
+        // navigation's own field name.
+        Assert.Contains("`address`", sql, StringComparison.OrdinalIgnoreCase);
+        Assert.Equal(sql.Count(c => c == '('), sql.Count(c => c == ')'));
+    }
+
     private static CustomerContext CreateContext()
     {
         var clusterOptions = new global::Couchbase.ClusterOptions()


### PR DESCRIPTION
OwnsOne previously relied entirely on EF Core's flat table-split columns (e.g. geo_Lat/geo_Lon), so it could only read documents this provider itself wrote and returned null for genuinely nested JSON objects like Couchbase's own travel-sample dataset ({"geo":{"lat":...}}). OwnsMany already solved the equivalent problem for arrays via a custom JSON materializer; this brings OwnsOne to parity for objects.

Add an additive raw-object SELECT column for root-level OwnsOne navs (AddOwnedNavigationColumnsToProjection, generalized from the OwnsMany- only version), and PopulateReference in
CouchbaseOwnedCollectionMaterializer, which overrides the OwnsOne's scalar properties in place from the nested JSON only when it's actually present, leaving flat-column data untouched otherwise. Refactored MaterializeOwnedItem to share the new
PopulateScalarProperties/PopulateNestedCollection helpers.

Unlike OwnsMany items, OwnsOne scalars are ordinary EF-tracked properties, so overriding them post-shaper would make DetectChanges see a spurious diff and mark the owner Modified on the next SaveChanges. Fixed by realigning EntityEntry.OriginalValues for each overridden property right after materialization
(RealignTrackedOriginalValues), with AutoDetectChangesEnabled disabled around the mutate+realign sequence to avoid baking in a stale diff via the implicit DetectChanges that Entry()/.State access triggers.

Re-enable Hotel.Geo as OwnsOne in TravelSampleDbContext and un-skip Test_Hotel_With_Geo, which now passes against live nested travel-sample data. Add unit tests for PopulateReference (in-place override, absent/null field, nested OwnsOne-within-OwnsOne) and an integration test proving a tracked load doesn't mark Geo Modified.