### PR TITLE
Suppress ManyServiceProvidersCreatedWarning in integration tests

### DIFF
--- a/tests/Couchbase.EntityFrameworkCore.IntegrationTests/Fixtures/CouchbaseFixture.cs
+++ b/tests/Couchbase.EntityFrameworkCore.IntegrationTests/Fixtures/CouchbaseFixture.cs
@@ -1,6 +1,7 @@
 using Aspire.Hosting;
 using Couchbase.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.Extensions.Logging;
 
 namespace Couchbase.EntityFrameworkCode.IntegrationTests.Fixtures;
@@ -27,20 +28,40 @@ public abstract class CouchbaseFixture<T> : IDisposable, IAsyncDisposable, IAsyn
 
     public abstract Task LoadDataAsync();
 
+    // GetDbContext() calls CreateDbContextOptions on every invocation — often many times per
+    // test, across hundreds of tests sharing this fixture instance via ICollectionFixture<>.
+    // Building a fresh ILoggerFactory per call was suspected to force EF Core's internal
+    // ServiceProviderCache to treat each call as a distinct configuration (the
+    // ManyServiceProvidersCreatedWarning scenario) — confirmed NOT the case here (this
+    // ILoggerFactory feeds the Couchbase SDK's own client logging via ClusterOptions.WithLogging,
+    // which is unrelated to EF Core's own UseLoggerFactory/CoreOptionsExtension hash; verified via
+    // reflection that CouchbaseOptionsExtension/CoreOptionsExtension/NamingConventionsOptionsExtension
+    // all hash identically regardless of logger-factory identity). Still cached per fixture
+    // instance as a harmless improvement — no reason to rebuild it on every call, since its
+    // configuration (ScopeName, log file path) never changes after construction.
+    private ILoggerFactory? _loggerFactory;
+
     protected DbContextOptions<TContext> CreateDbContextOptions<TContext>() where TContext : DbContext
     {
-        var loggerFactory = LoggerFactory.Create(builder =>
+        _loggerFactory ??= LoggerFactory.Create(builder =>
         {
             builder.AddFilter(level => level >= LogLevel.Debug);
             builder.AddFile("Logs/" + ScopeName + "-{Date}.txt", LogLevel.Debug);
         });
 
         var optionsBuilder = new DbContextOptionsBuilder<TContext>();
+        // The full integration suite legitimately spans many distinct bucket/scope/DI-container
+        // combinations across ~250 tests by design (multi-bucket and DI-isolation tests each
+        // need their own internal service provider to prove real isolation) — this crosses EF
+        // Core's own ">20 internal service providers" heuristic, which defaults to throwing.
+        // Suppress it here: it's the officially documented way to acknowledge "yes, this many
+        // providers is expected" (see the warning's own message), not a sign of a real leak.
+        optionsBuilder.ConfigureWarnings(w => w.Ignore(CoreEventId.ManyServiceProvidersCreatedWarning));
         optionsBuilder.UseCouchbase(
             new ClusterOptions()
                 .WithConnectionString(Host)
                 .WithPasswordAuthentication(Username, Password)
-                .WithLogging(loggerFactory),
+                .WithLogging(_loggerFactory),
             couchbaseDbContextOptions =>
             {
                 couchbaseDbContextOptions.Bucket = BucketName;
@@ -79,18 +100,21 @@ public abstract class CouchbaseFixture<T> : IDisposable, IAsyncDisposable, IAsyn
 
     async Task IAsyncLifetime.DisposeAsync()
     {
+        _loggerFactory?.Dispose();
         await _app.DisposeAsync();
         await _appHost.DisposeAsync();
     }
 
     public void Dispose()
     {
+        _loggerFactory?.Dispose();
         _app.Dispose();
         _appHost.Dispose();
     }
 
     public async ValueTask DisposeAsync()
     {
+        _loggerFactory?.Dispose();
         await _app.DisposeAsync();
         await _appHost.DisposeAsync();
     }

--- a/tests/Couchbase.EntityFrameworkCore.IntegrationTests/Tests/CrossBucketTransactionTests.cs
+++ b/tests/Couchbase.EntityFrameworkCore.IntegrationTests/Tests/CrossBucketTransactionTests.cs
@@ -2,6 +2,7 @@ using Couchbase.EntityFrameworkCode.IntegrationTests.Fixtures;
 using Couchbase.EntityFrameworkCore.Extensions;
 using Couchbase.KeyValue;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
 
 namespace Couchbase.EntityFrameworkCode.IntegrationTests.Tests;
 
@@ -28,7 +29,13 @@ public class CrossBucketTransactionTests(BloggingFixture fixture)
                 o.Scope = "isolation";
                 o.ScanConsistency = global::Couchbase.Query.QueryScanConsistency.RequestPlus;
             },
-            o => o.UseCamelCaseNamingConvention());
+            o => o.UseCamelCaseNamingConvention()
+                // Each test builds its own ServiceCollection/ServiceProvider, and the full suite
+                // legitimately accumulates many distinct DbContextOptions configurations across
+                // ~250 tests (multi-bucket/DI-isolation tests need their own internal service
+                // provider by design) — crosses EF Core's own ">20 providers" heuristic. Suppress
+                // the resulting warning, the officially documented way to acknowledge it's expected.
+                .ConfigureWarnings(w => w.Ignore(CoreEventId.ManyServiceProvidersCreatedWarning)));
 
         var provider = services.BuildServiceProvider();
 

--- a/tests/Couchbase.EntityFrameworkCore.IntegrationTests/Tests/DependencyInjectionTests.cs
+++ b/tests/Couchbase.EntityFrameworkCore.IntegrationTests/Tests/DependencyInjectionTests.cs
@@ -3,6 +3,7 @@ using Couchbase.EntityFrameworkCode.IntegrationTests.Models;
 using Couchbase.EntityFrameworkCore.Extensions;
 using Couchbase.Extensions.DependencyInjection;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.Extensions.Logging;
 using Xunit.Abstractions;
 
@@ -38,7 +39,8 @@ public class DependencyInjectionTests(
                 couchbaseDbContextOptions.Bucket = "default";
                 couchbaseDbContextOptions.Scope = "blogs";
             },
-            options => options.UseCamelCaseNamingConvention());
+            options => options.UseCamelCaseNamingConvention()
+                .ConfigureWarnings(w => w.Ignore(CoreEventId.ManyServiceProvidersCreatedWarning)));
 
         services.AddCouchbase<TravelSampleDbContext>(new ClusterOptions()
                 .WithConnectionString(travelSampleFixture.Host)
@@ -49,7 +51,8 @@ public class DependencyInjectionTests(
                 configuration.Bucket = "travel-sample";
                 configuration.Scope = "inventory";
             },
-            options => options.UseCamelCaseNamingConvention());
+            options => options.UseCamelCaseNamingConvention()
+                .ConfigureWarnings(w => w.Ignore(CoreEventId.ManyServiceProvidersCreatedWarning)));
 
         services.AddKeyedCouchbase("mine", options =>
         {

--- a/tests/Couchbase.EntityFrameworkCore.IntegrationTests/Tests/KeyspaceMappingIntegrationTests.cs
+++ b/tests/Couchbase.EntityFrameworkCore.IntegrationTests/Tests/KeyspaceMappingIntegrationTests.cs
@@ -3,6 +3,7 @@ using Couchbase.EntityFrameworkCore;
 using Couchbase.EntityFrameworkCore.Extensions;
 using Couchbase.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.Extensions.Logging;
 using Xunit;
 
@@ -480,6 +481,7 @@ public class KeyspaceMappingIntegrationTests
                 couchbaseDbContextOptions.Bucket = _fixture.BucketName;
                 couchbaseDbContextOptions.Scope = _fixture.ScopeName;
             });
+        optionsBuilder.ConfigureWarnings(w => w.Ignore(CoreEventId.ManyServiceProvidersCreatedWarning));
 
         return (TContext)Activator.CreateInstance(typeof(TContext), optionsBuilder.Options)!;
     }
@@ -502,6 +504,7 @@ public class KeyspaceMappingIntegrationTests
                 couchbaseDbContextOptions.Bucket = null!;
                 couchbaseDbContextOptions.Scope = _fixture.ScopeName;
             });
+        optionsBuilder.ConfigureWarnings(w => w.Ignore(CoreEventId.ManyServiceProvidersCreatedWarning));
 
         return (TContext)Activator.CreateInstance(typeof(TContext), optionsBuilder.Options)!;
     }
@@ -524,6 +527,7 @@ public class KeyspaceMappingIntegrationTests
                 couchbaseDbContextOptions.Bucket = "";
                 couchbaseDbContextOptions.Scope = _fixture.ScopeName;
             });
+        optionsBuilder.ConfigureWarnings(w => w.Ignore(CoreEventId.ManyServiceProvidersCreatedWarning));
 
         return (TContext)Activator.CreateInstance(typeof(TContext), optionsBuilder.Options)!;
     }
@@ -546,6 +550,7 @@ public class KeyspaceMappingIntegrationTests
                 couchbaseDbContextOptions.Bucket = _fixture.BucketName;
                 couchbaseDbContextOptions.Scope = null!;
             });
+        optionsBuilder.ConfigureWarnings(w => w.Ignore(CoreEventId.ManyServiceProvidersCreatedWarning));
 
         return (TContext)Activator.CreateInstance(typeof(TContext), optionsBuilder.Options)!;
     }
@@ -568,6 +573,7 @@ public class KeyspaceMappingIntegrationTests
                 couchbaseDbContextOptions.Bucket = _fixture.BucketName;
                 couchbaseDbContextOptions.Scope = "";
             });
+        optionsBuilder.ConfigureWarnings(w => w.Ignore(CoreEventId.ManyServiceProvidersCreatedWarning));
 
         return (TContext)Activator.CreateInstance(typeof(TContext), optionsBuilder.Options)!;
     }

--- a/tests/Couchbase.EntityFrameworkCore.IntegrationTests/Tests/MultiBucketDependencyInjectionTests.cs
+++ b/tests/Couchbase.EntityFrameworkCore.IntegrationTests/Tests/MultiBucketDependencyInjectionTests.cs
@@ -3,6 +3,7 @@ using Couchbase.EntityFrameworkCore.Extensions;
 using Couchbase.EntityFrameworkCore.Infrastructure;
 using Couchbase.Extensions.DependencyInjection;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.Extensions.DependencyInjection;
 using Xunit;
@@ -26,11 +27,11 @@ public class MultiBucketDependencyInjectionTests(BloggingFixture fixture)
         services.AddCouchbase<PrimaryWidgetContext>(
             NewClusterOptions(),
             o => ConfigureBucket(o, "default"),
-            o => o.UseCamelCaseNamingConvention());
+            o => { o.UseCamelCaseNamingConvention(); SuppressManyProvidersWarning(o); });
         services.AddCouchbase<SecondaryWidgetContext>(
             NewClusterOptions(),
             o => ConfigureBucket(o, "secondary"),
-            o => o.UseCamelCaseNamingConvention());
+            o => { o.UseCamelCaseNamingConvention(); SuppressManyProvidersWarning(o); });
 
         await using var provider = services.BuildServiceProvider();
 
@@ -80,12 +81,14 @@ public class MultiBucketDependencyInjectionTests(BloggingFixture fixture)
             new global::Couchbase.ClusterOptions()
                 .WithConnectionString(fixture.Host)
                 .WithCredentials(fixture.Username, fixture.Password),
-            o => ConfigureBucket(o, "default"));
+            o => ConfigureBucket(o, "default"),
+            SuppressManyProvidersWarning);
         services.AddCouchbase<SecondaryWidgetContext>(
             new global::Couchbase.ClusterOptions()
                 .WithConnectionString("couchbase://cluster-b.invalid")
                 .WithCredentials("user", "password"),
-            o => ConfigureBucket(o, "default"));
+            o => ConfigureBucket(o, "default"),
+            SuppressManyProvidersWarning);
 
         using var provider = services.BuildServiceProvider();
         using var scope = provider.CreateScope();
@@ -116,9 +119,11 @@ public class MultiBucketDependencyInjectionTests(BloggingFixture fixture)
         // Distinct scope so this test gets its own EF internal service-provider cache key
         // (EF caches internal providers process-wide by connection string/bucket/scope/key).
         services.AddCouchbase<PrimaryWidgetContext>(NewClusterOptions(),
-            o => ConfigureBucket(o, "default", "clustershared"), o => o.UseCamelCaseNamingConvention());
+            o => ConfigureBucket(o, "default", "clustershared"),
+            o => { o.UseCamelCaseNamingConvention(); SuppressManyProvidersWarning(o); });
         services.AddCouchbase<SecondaryWidgetContext>(NewClusterOptions(),
-            o => ConfigureBucket(o, "secondary", "clustershared"), o => o.UseCamelCaseNamingConvention());
+            o => ConfigureBucket(o, "secondary", "clustershared"),
+            o => { o.UseCamelCaseNamingConvention(); SuppressManyProvidersWarning(o); });
 
         await using var provider = services.BuildServiceProvider();
 
@@ -154,10 +159,10 @@ public class MultiBucketDependencyInjectionTests(BloggingFixture fixture)
         });
         services.AddCouchbase<PrimaryWidgetContext>(NewClusterOptions(),
             o => { ConfigureBucket(o, "default"); o.ServiceKey = "clusterA"; },
-            o => o.UseCamelCaseNamingConvention());
+            o => { o.UseCamelCaseNamingConvention(); SuppressManyProvidersWarning(o); });
         services.AddCouchbase<SecondaryWidgetContext>(NewClusterOptions(),
             o => { ConfigureBucket(o, "secondary"); o.ServiceKey = "clusterB"; },
-            o => o.UseCamelCaseNamingConvention());
+            o => { o.UseCamelCaseNamingConvention(); SuppressManyProvidersWarning(o); });
 
         await using var provider = services.BuildServiceProvider();
 
@@ -185,6 +190,13 @@ public class MultiBucketDependencyInjectionTests(BloggingFixture fixture)
         // Read-after-write consistency so the FindAsync below sees the just-written document.
         options.ScanConsistency = global::Couchbase.Query.QueryScanConsistency.RequestPlus;
     }
+
+    // This class deliberately registers many distinct bucket/scope/cluster/ServiceKey
+    // combinations across its tests to prove real DI isolation — legitimately crossing EF Core's
+    // own ">20 internal service providers" heuristic across the full test suite. Suppress the
+    // resulting warning per-context; it's the officially documented way to acknowledge it's expected.
+    private static void SuppressManyProvidersWarning(DbContextOptionsBuilder options)
+        => options.ConfigureWarnings(w => w.Ignore(CoreEventId.ManyServiceProvidersCreatedWarning));
 
     public class Widget
     {

--- a/tests/Couchbase.EntityFrameworkCore.IntegrationTests/Tests/MultiBucketSingleContextTests.cs
+++ b/tests/Couchbase.EntityFrameworkCore.IntegrationTests/Tests/MultiBucketSingleContextTests.cs
@@ -1,6 +1,7 @@
 using Couchbase.EntityFrameworkCode.IntegrationTests.Fixtures;
 using Couchbase.EntityFrameworkCore.Extensions;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
 
 namespace Couchbase.EntityFrameworkCode.IntegrationTests.Tests;
 
@@ -29,7 +30,8 @@ public class MultiBucketSingleContextTests(BloggingFixture fixture)
                 // Read-after-write consistency so the reads below see the just-written docs.
                 o.ScanConsistency = global::Couchbase.Query.QueryScanConsistency.RequestPlus;
             },
-            o => o.UseCamelCaseNamingConvention());
+            o => o.UseCamelCaseNamingConvention()
+                .ConfigureWarnings(w => w.Ignore(CoreEventId.ManyServiceProvidersCreatedWarning)));
 
         await using var provider = services.BuildServiceProvider();
 

--- a/tests/Couchbase.EntityFrameworkCore.IntegrationTests/Tests/SequenceValueGenerationTests.cs
+++ b/tests/Couchbase.EntityFrameworkCore.IntegrationTests/Tests/SequenceValueGenerationTests.cs
@@ -3,6 +3,7 @@ using Couchbase.EntityFrameworkCore;
 using Couchbase.EntityFrameworkCore.Extensions;
 using Couchbase.EntityFrameworkCore.ValueGeneration;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.ValueGeneration;
 using Microsoft.Extensions.Logging;
@@ -125,6 +126,7 @@ public class SequenceValueGenerationTests : IAsyncLifetime
                 couchbaseDbContextOptions.Scope = _fixture.ScopeName;
             });
         optionsBuilder.UseCamelCaseNamingConvention();
+        optionsBuilder.ConfigureWarnings(w => w.Ignore(CoreEventId.ManyServiceProvidersCreatedWarning));
 
         return new SequenceTestDbContext(optionsBuilder.Options, SequenceName);
     }
@@ -333,6 +335,7 @@ public class SequenceValueGenerationTests : IAsyncLifetime
                 couchbaseDbContextOptions.Bucket = _fixture.BucketName;
                 couchbaseDbContextOptions.Scope = _fixture.ScopeName;
             });
+        optionsBuilder.ConfigureWarnings(w => w.Ignore(CoreEventId.ManyServiceProvidersCreatedWarning));
 
         await using var testContext = new AutoCreateSequenceDbContext(optionsBuilder.Options);
 
@@ -384,6 +387,7 @@ public class SequenceValueGenerationTests : IAsyncLifetime
                 couchbaseDbContextOptions.Bucket = _fixture.BucketName;
                 couchbaseDbContextOptions.Scope = _fixture.ScopeName;
             });
+        optionsBuilder.ConfigureWarnings(w => w.Ignore(CoreEventId.ManyServiceProvidersCreatedWarning));
 
         await using var context = new EnsureCreatedSequenceDbContext(optionsBuilder.Options);
 
@@ -444,6 +448,7 @@ public class SequenceValueGenerationTests : IAsyncLifetime
                 couchbaseDbContextOptions.Bucket = _fixture.BucketName;
                 couchbaseDbContextOptions.Scope = _fixture.ScopeName;
             });
+        optionsBuilder.ConfigureWarnings(w => w.Ignore(CoreEventId.ManyServiceProvidersCreatedWarning));
 
         await using var context = new E2EAutoCreateSequenceDbContext(optionsBuilder.Options);
 


### PR DESCRIPTION
The full integration suite legitimately creates >20 distinct EF Core internal service providers across ~250 tests, since several test classes (CrossBucketTransactionTests, MultiBucketDependencyInjectionTests, MultiBucketSingleContextTests, DependencyInjectionTests, SequenceValueGenerationTests, KeyspaceMappingIntegrationTests) deliberately vary bucket/scope/ServiceKey/connection-string per test to prove real DI/multi-bucket isolation. This crossed EF Core's diagnostic threshold and intermittently threw in CrossBucketTransactionTests when the whole suite ran in one process. Suppress the warning at every ad-hoc DbContextOptions configuration site, plus the shared CouchbaseFixture, via ConfigureWarnings(w => w.Ignore(CoreEventId.ManyServiceProvidersCreatedWarning)).

Also cache CouchbaseFixture's ILoggerFactory per fixture instance instead of rebuilding it on every GetDbContext() call, as a minor cleanup (confirmed via reflection this was not the actual cause, since ClusterOptions.WithLogging is unrelated to EF Core's own service-provider cache key).