### PR TITLE
Fix OwnsMany items always tracked as Added, forcing spurious owner rewrites

### DIFF
--- a/src/Couchbase.EntityFrameworkCore/Storage/Internal/CouchbaseDatabaseWrapper.cs
+++ b/src/Couchbase.EntityFrameworkCore/Storage/Internal/CouchbaseDatabaseWrapper.cs
@@ -66,6 +66,23 @@ public class CouchbaseDatabaseWrapper : Database
 
             if (entityType.IsOwned())
             {
+                // OwnsMany items are materialised via raw reflection in
+                // CouchbaseOwnedCollectionMaterializer, bypassing EF Core's normal attach/fixup
+                // path entirely — so they always come back tracked as Added regardless of
+                // whether the user actually changed anything. EntityState is therefore not a
+                // trustworthy "did this genuinely change" signal for a collection-owned (OwnsMany)
+                // entry; skip it here and rely exclusively on the snapshot-based comparison in
+                // CouchbaseSaveChangesInterceptor.MarkOwnersWithReplacedCollections (which already
+                // marks the owner Modified for a real reference-replaced/added/removed/mutated
+                // change) to avoid rewriting the owner on every untouched read+save.
+                //
+                // A reference-owned (OwnsOne) entry has no such artifact: it's a normal
+                // table-split, fixup-tracked entity, so its EntityState IS a genuine signal —
+                // keep deferring on it as before.
+                var ownership = entityType.FindOwnership();
+                if (ownership != null && !ownership.IsUnique)
+                    continue;
+
                 // Collect owned entries with actual changes; their owners will be written
                 // in the second pass below if not already written by the main loop.
                 if (updateEntry.EntityState is not (EntityState.Unchanged or EntityState.Detached))

--- a/tests/Couchbase.EntityFrameworkCore.IntegrationTests/Tests/OwnedTypeTests.cs
+++ b/tests/Couchbase.EntityFrameworkCore.IntegrationTests/Tests/OwnedTypeTests.cs
@@ -1125,4 +1125,24 @@ public class OwnedTypeTests(
             if (c != null) { ctx.Remove(c); await ctx.SaveChangesAsync(); }
         }
     }
+
+    // Regression: OwnsMany items are materialised via raw reflection, bypassing EF Core's normal
+    // attach/fixup path, so they always come back tracked as EntityState.Added regardless of
+    // whether anything actually changed. CouchbaseDatabaseWrapper.SaveChangesAsync used to treat
+    // any non-Unchanged/Detached owned entry as "the owner must be rewritten", so a completely
+    // untouched load-then-save of an entity with an OwnsMany navigation always issued a spurious
+    // write. Fixed by ignoring EntityState for collection-owned (OwnsMany) entries and relying
+    // solely on CouchbaseSaveChangesInterceptor.MarkOwnersWithReplacedCollections' snapshot-based
+    // comparison, which only marks the owner Modified for a genuine change.
+    [Fact]
+    public async Task OwnsMany_ZeroTouchTrackedLoad_SaveChangesReturnsZero()
+    {
+        await using var ctx = fixture.GetDbContext();
+        var customer = await ctx.Customers.FirstAsync(c => c.CustomerId == 1);
+        Assert.NotEmpty(customer.ContactMethods); // sanity: this customer actually has OwnsMany data
+
+        var writes = await ctx.SaveChangesAsync();
+
+        Assert.Equal(0, writes);
+    }
 }


### PR DESCRIPTION
## Summary
- `CouchbaseOwnedCollectionMaterializer` materializes OwnsMany items via raw reflection, bypassing EF Core's normal attach/fixup path — every loaded item comes back tracked as `EntityState.Added` even with zero mutation, since `EntityState` isn't a trustworthy signal for a collection-owned entry (unlike OwnsOne, which is table-split and genuinely tracked).
- `CouchbaseDatabaseWrapper.SaveChangesAsync` previously treated any owned entry not `Unchanged`/`Detached` as "the owner must be rewritten," so a completely untouched load-then-save of any entity with an OwnsMany navigation issued a spurious write every time.
- Fix: skip collection-owned (OwnsMany) entries from that deferred-write check entirely via `entityType.FindOwnership()?.IsUnique`, relying on the existing `CouchbaseCollectionSnapshot`/`MarkOwnersWithReplacedCollections` mechanism (already used to detect genuine changes) instead of the meaningless `EntityState`.

## Test plan
- [x] New `OwnsMany_ZeroTouchTrackedLoad_SaveChangesReturnsZero` regression test proving the spurious write is gone
- [x] Existing depth-3 nested OwnsMany mutation round-trip tests still pass, confirming genuine changes are still detected
- [x] Full `OwnedTypeTests` suite: 43/43 passing