### PR TITLE
Switch release workflow to manual dispatch and update changelog for 2.0.0-beta.2

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,9 +1,19 @@
 name: Release
 
 on:
-  push:
-    tags: ['v*']
-  workflow_dispatch: {}
+  # Manual dispatch against an existing tag, rather than triggering on tag push: GitHub Actions'
+  # tag-filter glob dialect's exact handling of a quantifier (+) applied to a bracket expression
+  # ([0-9]) couldn't be confirmed from the documentation, and a release trigger silently failing
+  # to fire is a bad failure mode to risk. A sibling Couchbase repo (couchbase-jvm-clients)
+  # sidesteps this the same way: workflow_dispatch with an explicit tag input, checked out
+  # directly by name, needs no tag-matching glob at all. Create/push the tag first (git tag
+  # 2.0.0-beta.2 && git push origin 2.0.0-beta.2), then run this workflow against it.
+  workflow_dispatch:
+    inputs:
+      tag:
+        type: string
+        description: Existing tag to release, e.g. 2.0.0-beta.2 (must already be pushed)
+        required: true
 
 jobs:
   pack:
@@ -11,6 +21,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.tag }}
 
       - name: Setup .NET
         uses: actions/setup-dotnet@v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,18 +7,7 @@ and this project aims to follow [Semantic Versioning](https://semver.org/spec/v2
 
 ## [Unreleased]
 
-### Added
-
-- **One `DbContext` spanning multiple buckets (same cluster).** A single context can now map
-  different entities to different buckets on the same cluster. Give an entity an explicit keyspace
-  with `ToCouchbaseCollection(bucket, scope, collection)` or the new three-argument
-  `[CouchbaseKeyspace(bucket, scope, collection)]`; entities without an explicit bucket continue to
-  use the context's configured bucket. Reads, `Find`, N1QL queries, `SaveChanges`, and
-  `EnsureCreated` all resolve each entity's own bucket. Buckets must share one physical cluster
-  (cross-cluster queries/transactions are not possible — use `ServiceKey` with a context per
-  cluster). See [Configuration](docs/configuration.md#one-context-spanning-multiple-buckets).
-
-## [2.0.0-beta.2] - 2026-06-24
+## [2.0.0-beta.2] - 2026-07-15
 
 ### Added
 
@@ -30,6 +19,46 @@ and this project aims to follow [Semantic Versioning](https://semver.org/spec/v2
   `CouchbaseDbContextOptionsBuilder.ServiceKey`. Falls back to the previous per-context
   cluster-ownership behavior when no application cluster is registered. See
   [Configuration](docs/configuration.md#multiple-buckets-and-clusters).
+- **One `DbContext` spanning multiple buckets (same cluster).** A single context can now map
+  different entities to different buckets on the same cluster. Give an entity an explicit keyspace
+  with `ToCouchbaseCollection(bucket, scope, collection)` or the new three-argument
+  `[CouchbaseKeyspace(bucket, scope, collection)]`; entities without an explicit bucket continue to
+  use the context's configured bucket. Reads, `Find`, N1QL queries, `SaveChanges`, and
+  `EnsureCreated` all resolve each entity's own bucket. Buckets must share one physical cluster
+  (cross-cluster queries/transactions are not possible — use `ServiceKey` with a context per
+  cluster). Multi-document transactions spanning two buckets on the same cluster are supported and
+  covered by dedicated tests: a commit persists both buckets, and a rollback (or a failure partway
+  through) leaves neither bucket changed. See
+  [Configuration](docs/configuration.md#one-context-spanning-multiple-buckets).
+- **`OwnsOne` can now read genuinely nested JSON objects**, not just the flat `owner_property`
+  columns from EF Core's standard relational table-splitting. Real-world documents (including
+  Couchbase's own `travel-sample` dataset) that store an owned reference as an actual nested JSON
+  object — e.g. `{"geo": {"lat": ..., "lon": ...}}` rather than `{"geo_lat": ..., "geo_lon": ...}`
+  — now populate correctly. This is additive: the existing flat-column round trip for documents
+  the provider itself writes is unaffected.
+- **`CancellationToken` support on the write path.** Tokens passed to `SaveChangesAsync` now flow
+  through to the underlying Couchbase KV/query calls and are honored for real cancellation instead
+  of being accepted but ignored.
+
+### Changed
+
+- **`SaveChangesAsync` write path parallelized.** Independent document writes within a single
+  `SaveChangesAsync` call now execute concurrently (bounded concurrency) instead of one at a time,
+  significantly reducing write latency for multi-entity change sets against a real cluster.
+  Transactional writes remain sequential (ordered within the transaction), as required for
+  correctness.
+
+### Fixed
+
+- **Whole numbers formatted as JSON decimals** (e.g. `"rating": 4.0`) in `int`/`long` properties no
+  longer throw `FormatException` — real-world Couchbase documents (not just ones this provider
+  wrote) can store an integral value with a decimal point, and both the built-in JSON conversion
+  path and the provider's owned-type materializer now tolerate it.
+- **`OwnsMany` items were always tracked as `Added` on load**, causing every `SaveChangesAsync` —
+  even with no actual changes — to issue a spurious rewrite of the owner whenever it had an
+  `OwnsMany` navigation. Collection-owned entries are no longer judged by their (meaningless, for
+  this materialization path) `EntityState`; genuine changes are still reliably detected via the
+  existing collection-snapshot comparison.
 
 ## [2.0.0-beta.1] - 2026-06-23
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,11 +26,25 @@ gate before merging anything that touches provider internals.
 
 ## Cutting a release
 
-`.github/workflows/release.yml` runs on a `v*` tag push or manual dispatch (`workflow_dispatch`).
-It builds and strong-name-signs `Couchbase.EntityFrameworkCore`, validates the public API surface
-against the last released version (`PackageValidationBaselineVersion` in the `.csproj`), and
-uploads the resulting `.nupkg` as a workflow artifact. It does **not** publish to NuGet.org —
-download the artifact and run `dotnet nuget push` yourself once you're satisfied with it.
+`.github/workflows/release.yml` runs on manual dispatch (`workflow_dispatch`) against an existing
+tag — it does **not** trigger automatically on tag push. (GitHub Actions' tag-filter glob syntax
+combines `+`/`*` quantifiers with bracket expressions like `[0-9]` in ways that couldn't be
+confirmed from the documentation, and a release trigger silently failing to fire is a bad failure
+mode to risk — a sibling Couchbase repo, `couchbase-jvm-clients`, sidesteps the same problem the
+same way.) To cut a release:
+
+```sh
+git tag 2.0.0-beta.2
+git push origin 2.0.0-beta.2   # substitute your remote name for the upstream repo if not "origin"
+gh workflow run release.yml --repo couchbaselabs/couchbase-efcore-provider -f tag=2.0.0-beta.2
+```
+
+(Or via the GitHub UI: Actions → Release → Run workflow, entering the tag name.) The workflow
+checks out that tag, builds and strong-name-signs `Couchbase.EntityFrameworkCore`, validates the
+public API surface against the last released version (`PackageValidationBaselineVersion` in the
+`.csproj`), and uploads the resulting `.nupkg` as a workflow artifact. It does **not** publish to
+NuGet.org — download the artifact and run `dotnet nuget push` yourself once you're satisfied with
+it.
 
 ### One-time setup: the `SIGNING_KEY` secret
 
@@ -63,13 +77,7 @@ key on every `InternalsVisibleTo` target, and the test assemblies are never sign
 mutually exclusive. This only matters for the release workflow, which packs the main library
 standalone and never builds the test projects against the signed output.
 
-### Known gap: API-compat baseline is currently out of date
+### After a release ships
 
-Running `-p:ValidateApiCompat=true` today (`release.yml` always does) will fail: real,
-already-shipped breaking changes from prior work (the `CancellationToken` threading on
-`ICouchbaseClientWrapper`, and new constructor/factory parameters on `CouchbaseQueryEnumerable`
-from the multi-bucket DI work) were never reconciled with `CompatibilitySuppressions.xml` or a
-bumped `PackageValidationBaselineVersion`. This needs a deliberate decision — accept them as
-intentional pre-GA breaks (regenerate suppressions with
-`-p:ApiCompatGenerateSuppressionFile=true`) or bump the baseline version — before a release can
-actually ship through this workflow. See the project's GA backlog notes for current status.
+Bump `PackageValidationBaselineVersion` in the main `.csproj` to the version that just shipped, so
+the *next* release's `ValidateApiCompat` run compares against it instead of an older baseline.


### PR DESCRIPTION
release.yml no longer triggers on tag push at all — it's manual dispatch only
(`workflow_dispatch` with a required `tag` input), checking out that tag directly
(`ref: ${{ inputs.tag }}`). An earlier version of this PR tried a `push.tags` glob
matching bare semver tags (no "v" prefix, matching this repo's existing convention:
1.0.0, 2.0.0-beta.1, etc.), but GitHub Actions' documented behavior for a `+`
quantifier applied to a bracket expression like `[0-9]` couldn't be confirmed, and a
release trigger silently failing to fire is a bad failure mode to risk. Switched to
the same pattern a sibling Couchbase repo (couchbase-jvm-clients) already uses for
its own release workflow: manual dispatch against an explicit, already-pushed tag,
which needs no tag-matching glob at all. See CONTRIBUTING.md for the updated release
steps.

CHANGELOG.md's [2.0.0-beta.2] entry was drafted back on 2026-06-24 and only covered
the multi-bucket feature; a lot has shipped since then that was undocumented
(OwnsOne nested-JSON support, the OwnsMany always-tracked-as-Added fix, write-path
parallelization, CancellationToken threading on the write path, and the int/decimal
JSON conversion fix). Consolidated it all into one accurate entry for what's
actually shipping.