### PR TITLE
Fix ApiCompat baseline restore in release workflow, remove CS1998 war…

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,8 +51,15 @@ jobs:
           umask 077
           printf '%s' "$SIGNING_KEY" | base64 --decode > src/Couchbase.EntityFrameworkCore/Couchbase.snk
 
+      # -p:ValidateApiCompat=true must be passed here too, not just at pack time: when
+      # EnablePackageValidation is on, the SDK adds an implicit download of the baseline package
+      # (PackageValidationBaselineVersion) as a restore-time item, so it lands in the NuGet cache
+      # for the later --no-restore pack step to compare against. Restoring without this flag
+      # leaves that baseline package missing, and Pack fails with a FileNotFoundException looking
+      # for it in ~/.nuget/packages — confirmed by reproducing this exact failure locally against a
+      # clean NuGet cache (this bug was masked in earlier local testing by an already-warm cache).
       - name: Restore
-        run: dotnet restore src/Couchbase.EntityFrameworkCore/Couchbase.EntityFrameworkCore.csproj
+        run: dotnet restore src/Couchbase.EntityFrameworkCore/Couchbase.EntityFrameworkCore.csproj -p:ValidateApiCompat=true
 
       - name: Build (signed)
         run: >

--- a/src/Couchbase.EntityFrameworkCore/Storage/Internal/CouchbaseDbDataReader.cs
+++ b/src/Couchbase.EntityFrameworkCore/Storage/Internal/CouchbaseDbDataReader.cs
@@ -715,10 +715,8 @@ public class CouchbaseDbDataReader<T> : DbDataReader
     /// <summary>
     /// Asynchronously determines whether the field at the specified ordinal is null.
     /// </summary>
-    public override async Task<bool> IsDBNullAsync(int ordinal, CancellationToken cancellationToken)
-    {
-        return IsDBNull(ordinal);
-    }
+    public override Task<bool> IsDBNullAsync(int ordinal, CancellationToken cancellationToken)
+        => Task.FromResult(IsDBNull(ordinal));
 
     /// <summary>Gets the boolean value of the field at the specified ordinal.</summary>
     public override bool GetBoolean(int ordinal)


### PR DESCRIPTION
…ning

The release workflow's Pack step failed on a clean runner: ValidateApiCompat was only passed at pack time, but the SDK needs it at restore time too, since that's when it adds the implicit download of the baseline package into the NuGet cache. Without it, the later --no-restore pack step couldn't find the baseline to compare against. Reproduced locally by clearing the cached baseline package, then confirmed the fix (passing -p:ValidateApiCompat=true on Restore too) resolves it.

Also drops the unnecessary async on IsDBNullAsync, matching the existing Task.FromResult pattern used elsewhere in the file for synchronous-only overrides.