### PR TITLE
Add SQL++ function translators and fix IndexOf/CONTAINS bug (CBEF-23)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,8 +14,23 @@ and this project aims to follow [Semantic Versioning](https://semver.org/spec/v2
   returning — closing the gap where a query issued immediately after `EnsureCreatedAsync` could
   fail because Couchbase's query service refuses to query an unindexed collection. Defaults to
   `false`. Does not create secondary indexes.
+- **Broader SQL++ function translation** for LINQ queries (CBEF-23): `string.StartsWith`/
+  `EndsWith` (via `LIKE`, with wildcard escaping), `string.IsNullOrEmpty`, `PadLeft`/`PadRight`,
+  and `string.Length`; `Math.Abs`/`Ceiling`/`Floor`/`Round`/`Truncate`/`Pow`/`Sqrt`/`Sign`/`Log`/
+  `Log10`/`Exp`; `DateTime` member access (`Year`/`Month`/`Day`/`Hour`/`Minute`/`Second`/
+  `Millisecond`/`DayOfWeek`/`DayOfYear`/`Date`/`Now`/`UtcNow`/`Today`) and arithmetic
+  (`AddYears`/`AddMonths`/`AddDays`/`AddHours`/`AddMinutes`/`AddSeconds`); and `Guid.NewGuid()`.
+  Previously most of these either threw `InvalidOperationException` at query-compile time or (for
+  `DateTime`/`Guid` member access) had no translator at all. See
+  [Querying — Supported functions](docs/Queries.md#supported-functions) for the full list and what
+  remains unsupported (`Math.Min`/`Max`, trig functions).
 
 ### Fixed
+
+- **`string.IndexOf` translated to N1QL's `CONTAINS`, which returns a boolean, not the integer
+  position `IndexOf` must return.** Any LINQ query using `.IndexOf(...)` silently received a
+  boolean masquerading as an `int`. Fixed to use `POSITION`, which matches `IndexOf`'s exact
+  semantics (zero-based, `-1` if not found).
 
 - **`CouchbaseOptionsExtensionInfo.ShouldUseSameServiceProvider`/`GetServiceProviderHashCode` did
   not account for `AutoCreateScopes`, `ScanConsistency`, or `FieldNamingPolicy`** (in addition to

--- a/docs/Queries.md
+++ b/docs/Queries.md
@@ -113,6 +113,46 @@ The following aggregate operators are supported:
 | Min(x => x.Property)         | MIN(Property)     |
 | Sum(x => x.Property)         | SUM(Property)     |
 
+## Supported functions
+
+Beyond the string methods available since 1.0 (`ToLower`/`ToUpper`, `Substring`, `Replace`,
+`Trim`/`TrimStart`/`TrimEnd`, `Contains`), the provider translates the following .NET members to
+SQL++ so they run server-side instead of throwing or falling back to client evaluation:
+
+| .NET                                  | SQL++                              |
+|----------------------------------------|-------------------------------------|
+| `string.IndexOf(s)`                    | `POSITION(x, s)`                    |
+| `string.StartsWith(s)`                 | `LIKE` (pattern-escaped)            |
+| `string.EndsWith(s)`                   | `LIKE` (pattern-escaped)            |
+| `string.IsNullOrEmpty(s)`               | `IS NULL OR = ''`                   |
+| `string.PadLeft(n)` / `PadRight(n)`     | `LPAD(x, n)` / `RPAD(x, n)`          |
+| `string.Length`                        | `LENGTH(x)`                         |
+| `Math.Abs/Ceiling/Floor/Sqrt/Sign(x)`   | `ABS/CEIL/FLOOR/SQRT/SIGN(x)`       |
+| `Math.Round(x[, d])`                   | `ROUND(x[, d])`                     |
+| `Math.Truncate(x)`                     | `TRUNC(x)`                          |
+| `Math.Pow(x, y)`                       | `POWER(x, y)`                       |
+| `Math.Log(x)` / `Log10(x)` / `Exp(x)`  | `LN(x)` / `LOG(x)` / `EXP(x)`        |
+| `Math.Log(x, newBase)`                 | `LN(x) / LN(newBase)`                |
+| `DateTime.Year/Month/Day/Hour/Minute/Second/Millisecond/DayOfWeek/DayOfYear` | `DATE_PART_STR(x, part)` |
+| `DateTime.Date`                        | `DATE_TRUNC_STR(x, 'day', fmt)`     |
+| `DateTime.Now` / `.UtcNow` / `.Today`  | `NOW_LOCAL`/`NOW_UTC`/truncated `NOW_UTC` |
+| `DateTime.AddYears/Months/Days/Hours/Minutes/Seconds(n)` | `DATE_ADD_STR(x, n, part)` |
+| `Guid.NewGuid()`                       | `UUID()`                            |
+
+`StartsWith`/`EndsWith` escape `%`/`_`/the escape character in the search value (constant patterns
+are escaped once at translation time; parameter/column patterns are escaped at query time via
+nested `REPLACE` calls) so a literal `%` or `_` in the search text is matched literally rather than
+treated as a wildcard.
+
+`DateTime` comparisons/arithmetic work against the ISO-8601 string format the provider stores
+(millisecond precision, e.g. `2026-03-14T09:26:53.123Z`, with the fractional-seconds group and its
+decimal point entirely omitted when milliseconds are exactly zero, e.g. `2026-03-14T00:00:00Z`).
+
+Not yet supported: `Math.Min`/`Math.Max` (N1QL's `ARRAY_MAX`/`ARRAY_MIN` take a single array
+argument, not two scalars — no array-literal expression support exists yet to build one), trig
+functions (`Sin`/`Cos`/`Tan`/...), and secondary-index support for EF Core's `HasIndex()` (see
+[Limitations](limitations.md)).
+
 ## SQL queries
 
 > [!NOTE]

--- a/docs/Queries.md
+++ b/docs/Queries.md
@@ -124,7 +124,7 @@ SQL++ so they run server-side instead of throwing or falling back to client eval
 | `string.IndexOf(s)`                    | `POSITION(x, s)`                    |
 | `string.StartsWith(s)`                 | `LIKE` (pattern-escaped)            |
 | `string.EndsWith(s)`                   | `LIKE` (pattern-escaped)            |
-| `string.IsNullOrEmpty(s)`               | `IS NULL OR = ''`                   |
+| `string.IsNullOrEmpty(x)`               | `x IS NULL OR x = ''`               |
 | `string.PadLeft(n)` / `PadRight(n)`     | `LPAD(x, n)` / `RPAD(x, n)`          |
 | `string.Length`                        | `LENGTH(x)`                         |
 | `Math.Abs/Ceiling/Floor/Sqrt/Sign(x)`   | `ABS/CEIL/FLOOR/SQRT/SIGN(x)`       |
@@ -135,7 +135,9 @@ SQL++ so they run server-side instead of throwing or falling back to client eval
 | `Math.Log(x, newBase)`                 | `LN(x) / LN(newBase)`                |
 | `DateTime.Year/Month/Day/Hour/Minute/Second/Millisecond/DayOfWeek/DayOfYear` | `DATE_PART_STR(x, part)` |
 | `DateTime.Date`                        | `DATE_TRUNC_STR(x, 'day', fmt)`     |
-| `DateTime.Now` / `.UtcNow` / `.Today`  | `NOW_LOCAL`/`NOW_UTC`/truncated `NOW_UTC` |
+| `DateTime.Now`                         | `NOW_LOCAL(fmt)`                    |
+| `DateTime.UtcNow`                      | `NOW_UTC(fmt)`                      |
+| `DateTime.Today`                       | `DATE_TRUNC_STR(NOW_UTC(fmt), 'day', fmt)` |
 | `DateTime.AddYears/Months/Days/Hours/Minutes/Seconds(n)` | `DATE_ADD_STR(x, n, part)` |
 | `Guid.NewGuid()`                       | `UUID()`                            |
 

--- a/src/Couchbase.EntityFrameworkCore/Extensions/CouchbaseServiceCollectionExtensions.cs
+++ b/src/Couchbase.EntityFrameworkCore/Extensions/CouchbaseServiceCollectionExtensions.cs
@@ -60,7 +60,6 @@ public static class CouchbaseServiceCollectionExtensions
             .TryAdd<IShapedQueryCompilingExpressionVisitorFactory, CouchbaseShapedQueryCompilingExpressionVisitorFactory>()
             .TryAdd<IQueryableMethodTranslatingExpressionVisitorFactory, CouchbaseQueryableMethodTranslatingExpressionVisitorFactory>()
             .TryAdd<IHistoryRepository, CouchbaseHistoryRepository>()//not used but required by ASP.NET
-            .TryAdd<IMethodCallTranslatorProvider, CouchbaseMethodCallTranslatorProvider>()
 
             //Found that this was necessary, because the default convention of determining a
             //Model's primary key automatically based off of properties that have 'Id' in their`
@@ -76,16 +75,31 @@ public static class CouchbaseServiceCollectionExtensions
 
         builder.TryAddCoreServices();
 
-        // IDatabase, IValueGeneratorSelector, and IQueryCompilationContextFactory must be
-        // registered AFTER TryAddCoreServices() because EF Core's relational core services
-        // register their own implementations for all three, and TryAdd semantics mean the
-        // core registration wins over any earlier builder entry. IQueryCompilationContextFactory
+        // IDatabase, IValueGeneratorSelector, IQueryCompilationContextFactory, IMethodCallTranslatorProvider,
+        // and IMemberTranslatorProvider must be registered AFTER TryAddCoreServices() rather than
+        // relying on TryAdd ordering before it. For the first three, EF Core's relational core
+        // services are already known to register their own implementations in a way that wins
+        // over an earlier TryAdd entry regardless of order. IQueryCompilationContextFactory
         // specifically must produce CouchbaseQueryCompilationContext (which carries
         // NavigationIncludes for eager loading); the relational default produces a plain
         // RelationalQueryCompilationContext, so the type-check in CollectNavigationIncludes would
-        // silently no-op. Removing and re-adding with AddScoped guarantees our implementation
-        // is the one resolved.
-        foreach (var type in new[] { typeof(IDatabase), typeof(IValueGeneratorSelector), typeof(IQueryCompilationContextFactory) })
+        // silently no-op.
+        //
+        // IMethodCallTranslatorProvider/IMemberTranslatorProvider don't currently have that same
+        // problem -- verified against EF Core's own TryAdd implementation (first-registration-wins
+        // for single-registration services, which these are) and empirically (Couchbase's custom
+        // translators are provably the ones invoked at runtime). They're registered the same
+        // explicit way regardless, defensively: relying on an undocumented ordering guarantee in a
+        // third-party library is fragile, and this exact pattern is already needed for the other
+        // three services in this list, so there's no extra complexity cost to closing the gap here
+        // too before a future EF Core version silently reopens it.
+        //
+        // Removing and re-adding with AddScoped guarantees our implementation is the one resolved.
+        foreach (var type in new[]
+                 {
+                     typeof(IDatabase), typeof(IValueGeneratorSelector), typeof(IQueryCompilationContextFactory),
+                     typeof(IMethodCallTranslatorProvider), typeof(IMemberTranslatorProvider)
+                 })
         {
             var existing = serviceCollection.Where(d => d.ServiceType == type).ToList();
             foreach (var descriptor in existing) serviceCollection.Remove(descriptor);
@@ -93,6 +107,8 @@ public static class CouchbaseServiceCollectionExtensions
         serviceCollection.AddScoped<IDatabase, CouchbaseDatabaseWrapper>();
         serviceCollection.AddScoped<IValueGeneratorSelector, CouchbaseValueGeneratorSelector>();
         serviceCollection.AddScoped<IQueryCompilationContextFactory, CouchbaseQueryCompilationContextFactory>();
+        serviceCollection.AddScoped<IMethodCallTranslatorProvider, CouchbaseMethodCallTranslatorProvider>();
+        serviceCollection.AddScoped<IMemberTranslatorProvider, CouchbaseMemberTranslatorProvider>();
 
         serviceCollection
             //.AddScoped<IQueryContextFactory, CouchbaseQueryContextFactory>()

--- a/src/Couchbase.EntityFrameworkCore/Query/Internal/Translators/CouchbaseDateTimeMemberTranslator.cs
+++ b/src/Couchbase.EntityFrameworkCore/Query/Internal/Translators/CouchbaseDateTimeMemberTranslator.cs
@@ -1,0 +1,155 @@
+using System.Reflection;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+using Microsoft.EntityFrameworkCore.Query;
+using Microsoft.EntityFrameworkCore.Query.SqlExpressions;
+
+namespace Couchbase.EntityFrameworkCore.Query.Internal.Translators;
+
+/// <summary>
+/// Translates <see cref="DateTime"/> member access to SQL++. This provider's <see cref="DateTime"/>
+/// type mapping is <c>STRING</c> (ISO-8601), and the stored/parameter format was confirmed
+/// empirically (CBEF-23 step-0 spike, <c>DateTimeFormatSpikeTests</c>) to be millisecond-precision
+/// with a literal <c>Z</c> suffix for UTC values, e.g. <c>2026-03-14T09:26:53.123Z</c> --
+/// <see cref="Fmt"/> reproduces that format for every N1QL date function that accepts an explicit
+/// format string, so results stay comparable against already-stored data.
+/// <para>
+/// Non-obvious gotcha, confirmed against a live cluster: the fractional-seconds group must use
+/// Go's <c>.999</c> trimming convention, not a fixed-width <c>.000</c>. .NET's serializer omits
+/// the fractional group entirely (and the decimal point with it) when milliseconds are exactly
+/// zero -- e.g. midnight serializes as <c>2026-03-14T00:00:00Z</c>, with no <c>.000</c> at all.
+/// A fixed-width format produces a string that never matches such a parameter.
+/// </para>
+/// <para>
+/// Second gotcha: the offset directive must be <c>Z07:00</c>, not a literal <c>Z</c>. A literal
+/// <c>Z</c> is only correct for UTC values (<c>NOW_UTC</c>, <c>DATE_PART_STR</c>/<c>DATE_TRUNC_STR</c>
+/// on the UTC-stored data this provider writes) -- <c>NOW_LOCAL</c> (<see cref="DateTime.Now"/>)
+/// returns a value in the query service's local timezone, which is not UTC in general, so forcing
+/// a trailing <c>Z</c> onto it would produce a string that both lies about the offset and won't
+/// match how a <see cref="DateTimeKind.Local"/> value actually serializes (typically a real
+/// <c>+hh:mm</c>/<c>-hh:mm</c> offset). <c>Z07:00</c> renders <c>Z</c> when the offset is zero and
+/// the real offset otherwise, so the same format string is correct for both cases.
+/// </para>
+/// </summary>
+public class CouchbaseDateTimeMemberTranslator : IMemberTranslator
+{
+    // N1QL's Go-reference-time format style; .999 mirrors .NET's variable-width fractional
+    // seconds (trimmed, including the dot, when all-zero) rather than always padding to 3 digits.
+    // Z07:00 emits Z for a zero offset (UTC) and a real +hh:mm/-hh:mm offset otherwise, rather
+    // than forcing an incorrect literal Z onto non-UTC values (see NOW_LOCAL usage below).
+    private const string Fmt = "2006-01-02T15:04:05.999Z07:00";
+
+    private static readonly IReadOnlyDictionary<MemberInfo, string> DatePartMappings = new Dictionary<MemberInfo, string>
+    {
+        { GetDateTimeProperty(nameof(DateTime.Year)), "year" },
+        { GetDateTimeProperty(nameof(DateTime.Month)), "month" },
+        { GetDateTimeProperty(nameof(DateTime.Day)), "day" },
+        { GetDateTimeProperty(nameof(DateTime.Hour)), "hour" },
+        { GetDateTimeProperty(nameof(DateTime.Minute)), "minute" },
+        { GetDateTimeProperty(nameof(DateTime.Second)), "second" },
+        { GetDateTimeProperty(nameof(DateTime.Millisecond)), "millisecond" },
+        { GetDateTimeProperty(nameof(DateTime.DayOfWeek)), "day_of_week" },
+        { GetDateTimeProperty(nameof(DateTime.DayOfYear)), "day_of_year" },
+    };
+
+    private static readonly MemberInfo DateMemberInfo = GetDateTimeProperty(nameof(DateTime.Date));
+    private static readonly MemberInfo NowMemberInfo = GetDateTimeProperty(nameof(DateTime.Now));
+    private static readonly MemberInfo UtcNowMemberInfo = GetDateTimeProperty(nameof(DateTime.UtcNow));
+    private static readonly MemberInfo TodayMemberInfo = GetDateTimeProperty(nameof(DateTime.Today));
+
+    private readonly ISqlExpressionFactory _sqlExpressionFactory;
+
+    public CouchbaseDateTimeMemberTranslator(ISqlExpressionFactory sqlExpressionFactory)
+    {
+        _sqlExpressionFactory = sqlExpressionFactory;
+    }
+
+    public virtual SqlExpression? Translate(
+        SqlExpression? instance,
+        MemberInfo member,
+        Type returnType,
+        IDiagnosticsLogger<DbLoggerCategory.Query> logger)
+    {
+        if (instance != null && DatePartMappings.TryGetValue(member, out var part))
+        {
+            return _sqlExpressionFactory.Function(
+                "DATE_PART_STR",
+                new[] { instance, _sqlExpressionFactory.Constant(part) },
+                nullable: true,
+                argumentsPropagateNullability: new[] { true, true },
+                returnType);
+        }
+
+        if (instance != null && DateMemberInfo.Equals(member))
+        {
+            return _sqlExpressionFactory.Function(
+                "DATE_TRUNC_STR",
+                new[] { instance, _sqlExpressionFactory.Constant("day"), _sqlExpressionFactory.Constant(Fmt) },
+                nullable: true,
+                argumentsPropagateNullability: new[] { true, true, false },
+                returnType,
+                instance.TypeMapping);
+        }
+
+        if (instance == null && NowMemberInfo.Equals(member))
+        {
+            return _sqlExpressionFactory.Function(
+                "NOW_LOCAL",
+                new[] { _sqlExpressionFactory.Constant(Fmt) },
+                nullable: false,
+                argumentsPropagateNullability: new[] { false },
+                returnType);
+        }
+
+        if (instance == null && UtcNowMemberInfo.Equals(member))
+        {
+            return _sqlExpressionFactory.Function(
+                "NOW_UTC",
+                new[] { _sqlExpressionFactory.Constant(Fmt) },
+                nullable: false,
+                argumentsPropagateNullability: new[] { false },
+                returnType);
+        }
+
+        if (instance == null && TodayMemberInfo.Equals(member))
+        {
+            var nowUtc = _sqlExpressionFactory.Function(
+                "NOW_UTC",
+                new[] { _sqlExpressionFactory.Constant(Fmt) },
+                nullable: false,
+                argumentsPropagateNullability: new[] { false },
+                returnType);
+
+            return _sqlExpressionFactory.Function(
+                "DATE_TRUNC_STR",
+                new[] { nowUtc, _sqlExpressionFactory.Constant("day"), _sqlExpressionFactory.Constant(Fmt) },
+                nullable: false,
+                argumentsPropagateNullability: new[] { false, false, false },
+                returnType);
+        }
+
+        return null;
+    }
+
+    private static MemberInfo GetDateTimeProperty(string name)
+        => typeof(DateTime).GetProperty(name)!;
+}
+
+/* ************************************************************
+ *
+ *    @author Couchbase <info@couchbase.com>
+ *    @copyright 2025 Couchbase, Inc.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ *
+ * ************************************************************/

--- a/src/Couchbase.EntityFrameworkCore/Query/Internal/Translators/CouchbaseDateTimeMemberTranslator.cs
+++ b/src/Couchbase.EntityFrameworkCore/Query/Internal/Translators/CouchbaseDateTimeMemberTranslator.cs
@@ -76,7 +76,7 @@ public class CouchbaseDateTimeMemberTranslator : IMemberTranslator
                 "DATE_PART_STR",
                 new[] { instance, _sqlExpressionFactory.Constant(part) },
                 nullable: true,
-                argumentsPropagateNullability: new[] { true, true },
+                argumentsPropagateNullability: new[] { true, false },
                 returnType);
         }
 
@@ -86,7 +86,7 @@ public class CouchbaseDateTimeMemberTranslator : IMemberTranslator
                 "DATE_TRUNC_STR",
                 new[] { instance, _sqlExpressionFactory.Constant("day"), _sqlExpressionFactory.Constant(Fmt) },
                 nullable: true,
-                argumentsPropagateNullability: new[] { true, true, false },
+                argumentsPropagateNullability: new[] { true, false, false },
                 returnType,
                 instance.TypeMapping);
         }

--- a/src/Couchbase.EntityFrameworkCore/Query/Internal/Translators/CouchbaseDateTimeMethodTranslator.cs
+++ b/src/Couchbase.EntityFrameworkCore/Query/Internal/Translators/CouchbaseDateTimeMethodTranslator.cs
@@ -1,0 +1,79 @@
+using System.Reflection;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+using Microsoft.EntityFrameworkCore.Query;
+using Microsoft.EntityFrameworkCore.Query.SqlExpressions;
+
+namespace Couchbase.EntityFrameworkCore.Query.Internal.Translators;
+
+/// <summary>
+/// Translates <see cref="DateTime"/> <c>Add*</c> methods to SQL++. See
+/// <see cref="CouchbaseDateTimeMemberTranslator"/>'s doc comment for the observed stored-format
+/// background (CBEF-23 step-0 spike). N1QL's <c>DATE_ADD_STR(date_str, n, part)</c> returns the
+/// resulting date as a string in the SAME format as its input -- confirmed empirically against a
+/// live cluster (adding 1 day to <c>2026-03-14T09:26:53.123Z</c> produced
+/// <c>2026-03-15T09:26:53.123Z</c> directly). Couchbase's own documentation describes this
+/// function's return value as milliseconds, which does NOT match observed behavior; trust the
+/// live result over the docs here. No MILLIS_TO_STR/MILLIS_TO_UTC wrapping is needed.
+/// </summary>
+public class CouchbaseDateTimeMethodTranslator : IMethodCallTranslator
+{
+    private static readonly IReadOnlyDictionary<MethodInfo, string> AddMethodMappings = new Dictionary<MethodInfo, string>
+    {
+        { GetDateTimeMethod(nameof(DateTime.AddYears), typeof(int)), "year" },
+        { GetDateTimeMethod(nameof(DateTime.AddMonths), typeof(int)), "month" },
+        { GetDateTimeMethod(nameof(DateTime.AddDays), typeof(double)), "day" },
+        { GetDateTimeMethod(nameof(DateTime.AddHours), typeof(double)), "hour" },
+        { GetDateTimeMethod(nameof(DateTime.AddMinutes), typeof(double)), "minute" },
+        { GetDateTimeMethod(nameof(DateTime.AddSeconds), typeof(double)), "second" },
+    };
+
+    private readonly ISqlExpressionFactory _sqlExpressionFactory;
+
+    public CouchbaseDateTimeMethodTranslator(ISqlExpressionFactory sqlExpressionFactory)
+    {
+        _sqlExpressionFactory = sqlExpressionFactory;
+    }
+
+    public virtual SqlExpression? Translate(
+        SqlExpression? instance,
+        MethodInfo method,
+        IReadOnlyList<SqlExpression> arguments,
+        IDiagnosticsLogger<DbLoggerCategory.Query> logger)
+    {
+        if (instance != null && AddMethodMappings.TryGetValue(method, out var part))
+        {
+            return _sqlExpressionFactory.Function(
+                "DATE_ADD_STR",
+                new[] { instance, arguments[0], _sqlExpressionFactory.Constant(part) },
+                nullable: true,
+                argumentsPropagateNullability: new[] { true, true, false },
+                method.ReturnType,
+                instance.TypeMapping);
+        }
+
+        return null;
+    }
+
+    private static MethodInfo GetDateTimeMethod(string name, params Type[] parameterTypes)
+        => typeof(DateTime).GetRuntimeMethod(name, parameterTypes)!;
+}
+
+/* ************************************************************
+ *
+ *    @author Couchbase <info@couchbase.com>
+ *    @copyright 2025 Couchbase, Inc.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ *
+ * ************************************************************/

--- a/src/Couchbase.EntityFrameworkCore/Query/Internal/Translators/CouchbaseGuidMethodTranslator.cs
+++ b/src/Couchbase.EntityFrameworkCore/Query/Internal/Translators/CouchbaseGuidMethodTranslator.cs
@@ -1,0 +1,63 @@
+using System.Reflection;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+using Microsoft.EntityFrameworkCore.Query;
+using Microsoft.EntityFrameworkCore.Query.SqlExpressions;
+
+namespace Couchbase.EntityFrameworkCore.Query.Internal.Translators;
+
+public class CouchbaseGuidMethodTranslator : IMethodCallTranslator
+{
+    private static readonly MethodInfo NewGuidMethodInfo
+        = typeof(Guid).GetRuntimeMethod(nameof(Guid.NewGuid), Type.EmptyTypes)!;
+
+    private readonly ISqlExpressionFactory _sqlExpressionFactory;
+
+    public CouchbaseGuidMethodTranslator(ISqlExpressionFactory sqlExpressionFactory)
+    {
+        _sqlExpressionFactory = sqlExpressionFactory;
+    }
+
+    public virtual SqlExpression? Translate(
+        SqlExpression? instance,
+        MethodInfo method,
+        IReadOnlyList<SqlExpression> arguments,
+        IDiagnosticsLogger<DbLoggerCategory.Query> logger)
+    {
+        if (NewGuidMethodInfo.Equals(method))
+        {
+            var function = _sqlExpressionFactory.Function(
+                "UUID",
+                Array.Empty<SqlExpression>(),
+                nullable: false,
+                argumentsPropagateNullability: Array.Empty<bool>(),
+                method.ReturnType);
+
+            // Without an explicit type mapping the materializer can't determine how to read the
+            // result correctly in a top-level scalar projection (confirmed against a live
+            // cluster: "Nullable object must have a value" from the generated shaper).
+            return _sqlExpressionFactory.ApplyDefaultTypeMapping(function);
+        }
+
+        return null;
+    }
+}
+
+/* ************************************************************
+ *
+ *    @author Couchbase <info@couchbase.com>
+ *    @copyright 2025 Couchbase, Inc.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ *
+ * ************************************************************/

--- a/src/Couchbase.EntityFrameworkCore/Query/Internal/Translators/CouchbaseMathMethodTranslator.cs
+++ b/src/Couchbase.EntityFrameworkCore/Query/Internal/Translators/CouchbaseMathMethodTranslator.cs
@@ -1,0 +1,134 @@
+using System.Reflection;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+using Microsoft.EntityFrameworkCore.Query;
+using Microsoft.EntityFrameworkCore.Query.SqlExpressions;
+
+namespace Couchbase.EntityFrameworkCore.Query.Internal.Translators;
+
+public class CouchbaseMathMethodTranslator : IMethodCallTranslator
+{
+    private static readonly IReadOnlyDictionary<MethodInfo, string> SingleArgFunctionMappings = new Dictionary<MethodInfo, string>
+    {
+        { GetMathMethod(nameof(Math.Abs), typeof(double)), "ABS" },
+        { GetMathMethod(nameof(Math.Abs), typeof(decimal)), "ABS" },
+        { GetMathMethod(nameof(Math.Abs), typeof(int)), "ABS" },
+        { GetMathMethod(nameof(Math.Abs), typeof(long)), "ABS" },
+        { GetMathMethod(nameof(Math.Abs), typeof(float)), "ABS" },
+        { GetMathMethod(nameof(Math.Ceiling), typeof(double)), "CEIL" },
+        { GetMathMethod(nameof(Math.Ceiling), typeof(decimal)), "CEIL" },
+        { GetMathMethod(nameof(Math.Floor), typeof(double)), "FLOOR" },
+        { GetMathMethod(nameof(Math.Floor), typeof(decimal)), "FLOOR" },
+        { GetMathMethod(nameof(Math.Round), typeof(double)), "ROUND" },
+        { GetMathMethod(nameof(Math.Round), typeof(decimal)), "ROUND" },
+        { GetMathMethod(nameof(Math.Truncate), typeof(double)), "TRUNC" },
+        { GetMathMethod(nameof(Math.Truncate), typeof(decimal)), "TRUNC" },
+        { GetMathMethod(nameof(Math.Sqrt), typeof(double)), "SQRT" },
+        { GetMathMethod(nameof(Math.Sign), typeof(double)), "SIGN" },
+        { GetMathMethod(nameof(Math.Sign), typeof(decimal)), "SIGN" },
+        { GetMathMethod(nameof(Math.Sign), typeof(int)), "SIGN" },
+        { GetMathMethod(nameof(Math.Sign), typeof(long)), "SIGN" },
+        { GetMathMethod(nameof(Math.Sign), typeof(float)), "SIGN" },
+        { GetMathMethod(nameof(Math.Log), typeof(double)), "LN" },
+        { GetMathMethod(nameof(Math.Log10), typeof(double)), "LOG" }, // N1QL's LOG is fixed base-10.
+        { GetMathMethod(nameof(Math.Exp), typeof(double)), "EXP" },
+    };
+
+    private static readonly IReadOnlyDictionary<MethodInfo, string> RoundWithDigitsFunctionMappings = new Dictionary<MethodInfo, string>
+    {
+        { GetMathMethod(nameof(Math.Round), typeof(double), typeof(int)), "ROUND" },
+        { GetMathMethod(nameof(Math.Round), typeof(decimal), typeof(int)), "ROUND" },
+    };
+
+    private static readonly MethodInfo PowMethodInfo = GetMathMethod(nameof(Math.Pow), typeof(double), typeof(double));
+
+    private static readonly MethodInfo LogWithNewBaseMethodInfo = GetMathMethod(nameof(Math.Log), typeof(double), typeof(double));
+
+    private readonly ISqlExpressionFactory _sqlExpressionFactory;
+
+    public CouchbaseMathMethodTranslator(ISqlExpressionFactory sqlExpressionFactory)
+    {
+        _sqlExpressionFactory = sqlExpressionFactory;
+    }
+
+    public virtual SqlExpression? Translate(
+        SqlExpression? instance,
+        MethodInfo method,
+        IReadOnlyList<SqlExpression> arguments,
+        IDiagnosticsLogger<DbLoggerCategory.Query> logger)
+    {
+        if (SingleArgFunctionMappings.TryGetValue(method, out var functionName))
+        {
+            return _sqlExpressionFactory.Function(
+                functionName,
+                new[] { arguments[0] },
+                nullable: true,
+                argumentsPropagateNullability: new[] { true },
+                method.ReturnType);
+        }
+
+        if (RoundWithDigitsFunctionMappings.TryGetValue(method, out var roundFunctionName))
+        {
+            return _sqlExpressionFactory.Function(
+                roundFunctionName,
+                new[] { arguments[0], arguments[1] },
+                nullable: true,
+                argumentsPropagateNullability: new[] { true, true },
+                method.ReturnType);
+        }
+
+        if (PowMethodInfo.Equals(method))
+        {
+            return _sqlExpressionFactory.Function(
+                "POWER",
+                new[] { arguments[0], arguments[1] },
+                nullable: true,
+                argumentsPropagateNullability: new[] { true, true },
+                method.ReturnType);
+        }
+
+        if (LogWithNewBaseMethodInfo.Equals(method))
+        {
+            // N1QL has no two-argument LOG; built via the standard change-of-base identity:
+            // log_b(x) = ln(x) / ln(b).
+            var lnOfValue = _sqlExpressionFactory.Function(
+                "LN",
+                new[] { arguments[0] },
+                nullable: true,
+                argumentsPropagateNullability: new[] { true },
+                method.ReturnType);
+            var lnOfNewBase = _sqlExpressionFactory.Function(
+                "LN",
+                new[] { arguments[1] },
+                nullable: true,
+                argumentsPropagateNullability: new[] { true },
+                method.ReturnType);
+
+            return _sqlExpressionFactory.Divide(lnOfValue, lnOfNewBase);
+        }
+
+        return null;
+    }
+
+    private static MethodInfo GetMathMethod(string name, params Type[] parameterTypes)
+        => typeof(Math).GetRuntimeMethod(name, parameterTypes)!;
+}
+
+/* ************************************************************
+ *
+ *    @author Couchbase <info@couchbase.com>
+ *    @copyright 2025 Couchbase, Inc.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ *
+ * ************************************************************/

--- a/src/Couchbase.EntityFrameworkCore/Query/Internal/Translators/CouchbaseMemberTranslatorProvider.cs
+++ b/src/Couchbase.EntityFrameworkCore/Query/Internal/Translators/CouchbaseMemberTranslatorProvider.cs
@@ -1,0 +1,37 @@
+using Microsoft.EntityFrameworkCore.Query;
+
+namespace Couchbase.EntityFrameworkCore.Query.Internal.Translators;
+
+public class CouchbaseMemberTranslatorProvider : RelationalMemberTranslatorProvider
+{
+    public CouchbaseMemberTranslatorProvider(RelationalMemberTranslatorProviderDependencies dependencies) : base(dependencies)
+    {
+        var sqlExpressionFactory = dependencies.SqlExpressionFactory;
+
+        AddTranslators(
+            new IMemberTranslator[]
+            {
+                new CouchbaseStringMemberTranslator(sqlExpressionFactory),
+                new CouchbaseDateTimeMemberTranslator(sqlExpressionFactory),
+            });
+    }
+}
+
+/* ************************************************************
+ *
+ *    @author Couchbase <info@couchbase.com>
+ *    @copyright 2025 Couchbase, Inc.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ *
+ * ************************************************************/

--- a/src/Couchbase.EntityFrameworkCore/Query/Internal/Translators/CouchbaseMethodCallTranslatorProvider.cs
+++ b/src/Couchbase.EntityFrameworkCore/Query/Internal/Translators/CouchbaseMethodCallTranslatorProvider.cs
@@ -24,6 +24,9 @@ public class CouchbaseMethodCallTranslatorProvider : RelationalMethodCallTransla
                 new SqliteRandomTranslator(sqlExpressionFactory),
                 new SqliteRegexMethodTranslator(sqlExpressionFactory),*/
                 new CouchbaseStringMethodTranslator(sqlExpressionFactory),
+                new CouchbaseMathMethodTranslator(sqlExpressionFactory),
+                new CouchbaseGuidMethodTranslator(sqlExpressionFactory),
+                new CouchbaseDateTimeMethodTranslator(sqlExpressionFactory),
                // new SqliteSubstrMethodTranslator(sqlExpressionFactory)
             });
     }

--- a/src/Couchbase.EntityFrameworkCore/Query/Internal/Translators/CouchbaseStringMemberTranslator.cs
+++ b/src/Couchbase.EntityFrameworkCore/Query/Internal/Translators/CouchbaseStringMemberTranslator.cs
@@ -1,0 +1,58 @@
+using System.Reflection;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+using Microsoft.EntityFrameworkCore.Query;
+using Microsoft.EntityFrameworkCore.Query.SqlExpressions;
+
+namespace Couchbase.EntityFrameworkCore.Query.Internal.Translators;
+
+public class CouchbaseStringMemberTranslator : IMemberTranslator
+{
+    private static readonly MemberInfo LengthMemberInfo
+        = typeof(string).GetProperty(nameof(string.Length))!;
+
+    private readonly ISqlExpressionFactory _sqlExpressionFactory;
+
+    public CouchbaseStringMemberTranslator(ISqlExpressionFactory sqlExpressionFactory)
+    {
+        _sqlExpressionFactory = sqlExpressionFactory;
+    }
+
+    public virtual SqlExpression? Translate(
+        SqlExpression? instance,
+        MemberInfo member,
+        Type returnType,
+        IDiagnosticsLogger<DbLoggerCategory.Query> logger)
+    {
+        if (instance != null && LengthMemberInfo.Equals(member))
+        {
+            return _sqlExpressionFactory.Function(
+                "LENGTH",
+                new[] { instance },
+                nullable: true,
+                argumentsPropagateNullability: new[] { true },
+                returnType);
+        }
+
+        return null;
+    }
+}
+
+/* ************************************************************
+ *
+ *    @author Couchbase <info@couchbase.com>
+ *    @copyright 2025 Couchbase, Inc.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ *
+ * ************************************************************/

--- a/src/Couchbase.EntityFrameworkCore/Query/Internal/Translators/CouchbaseStringMethodTranslator.cs
+++ b/src/Couchbase.EntityFrameworkCore/Query/Internal/Translators/CouchbaseStringMethodTranslator.cs
@@ -210,17 +210,23 @@ public class CouchbaseStringMethodTranslator : IMethodCallTranslator
                 pattern = _sqlExpressionFactory.ApplyTypeMapping(pattern, stringTypeMapping);
 
                 // Note: we add IS NOT NULL checks here since we don't do null semantics/compensation for comparison (greater-than)
+                // CONTAINS (and string.Contains) returns a boolean, not an int -- an incorrect
+                // return type here can produce wrong materialization if this expression is ever
+                // projected directly (e.g. `.Select(x => x.Name.Contains("a"))`) rather than only
+                // consumed inside a Where predicate.
+                var containsFunction = _sqlExpressionFactory.Function(
+                    "CONTAINS",
+                    new[] { instance, pattern },
+                    nullable: true,
+                    argumentsPropagateNullability: new[] { true, true },
+                    typeof(bool));
+
                 return
                     _sqlExpressionFactory.AndAlso(
                         _sqlExpressionFactory.IsNotNull(instance),
                         _sqlExpressionFactory.AndAlso(
                             _sqlExpressionFactory.IsNotNull(pattern),
-                                _sqlExpressionFactory.Function(
-                                    "CONTAINS",
-                                    new[] { instance, pattern },
-                                    nullable: true,
-                                    argumentsPropagateNullability: new[] { true, true },
-                                    typeof(int))));
+                            _sqlExpressionFactory.ApplyDefaultTypeMapping(containsFunction)));
             }
 
             if (StartsWithMethodInfo.Equals(method))

--- a/src/Couchbase.EntityFrameworkCore/Query/Internal/Translators/CouchbaseStringMethodTranslator.cs
+++ b/src/Couchbase.EntityFrameworkCore/Query/Internal/Translators/CouchbaseStringMethodTranslator.cs
@@ -61,6 +61,26 @@ public class CouchbaseStringMethodTranslator : IMethodCallTranslator
     private static readonly MethodInfo ContainsMethodInfo
         = typeof(string).GetRuntimeMethod(nameof(string.Contains), new[] { typeof(string) })!;
 
+    private static readonly MethodInfo StartsWithMethodInfo
+        = typeof(string).GetRuntimeMethod(nameof(string.StartsWith), new[] { typeof(string) })!;
+
+    private static readonly MethodInfo EndsWithMethodInfo
+        = typeof(string).GetRuntimeMethod(nameof(string.EndsWith), new[] { typeof(string) })!;
+
+    private static readonly MethodInfo PadLeftMethodInfo
+        = typeof(string).GetRuntimeMethod(nameof(string.PadLeft), new[] { typeof(int) })!;
+
+    private static readonly MethodInfo PadRightMethodInfo
+        = typeof(string).GetRuntimeMethod(nameof(string.PadRight), new[] { typeof(int) })!;
+
+    // LIKE escape character used both to build the escaped literal pattern (constant case) and
+    // as the ESCAPE clause argument sent to N1QL. Deliberately NOT a backslash: N1QL's own string
+    // literal syntax also treats backslash as an escape character, so embedding a literal
+    // backslash as a SQL literal would itself need doubling (this provider's string-literal
+    // generation doesn't do that) -- confirmed empirically via a live-cluster parsing error.
+    // '!' has no special meaning in N1QL string literals or as a LIKE wildcard.
+    private const string LikeEscapeChar = "!";
+
     private static readonly MethodInfo FirstOrDefaultMethodInfoWithoutArgs
         = typeof(Enumerable).GetRuntimeMethods().Single(
             m => m.Name == nameof(Enumerable.FirstOrDefault)
@@ -91,8 +111,11 @@ public class CouchbaseStringMethodTranslator : IMethodCallTranslator
                 var argument = arguments[0];
                 var stringTypeMapping = ExpressionExtensions.InferTypeMapping(instance, argument);
 
+                // POSITION returns the zero-based index of the first match, or -1 if not found --
+                // an exact match for string.IndexOf's semantics. CONTAINS returns a boolean and
+                // must not be used here.
                 return _sqlExpressionFactory.Function(
-                        "CONTAINS",
+                        "POSITION",
                         new[]
                         {
                             _sqlExpressionFactory.ApplyTypeMapping(instance, stringTypeMapping),
@@ -199,6 +222,28 @@ public class CouchbaseStringMethodTranslator : IMethodCallTranslator
                                     argumentsPropagateNullability: new[] { true, true },
                                     typeof(int))));
             }
+
+            if (StartsWithMethodInfo.Equals(method))
+            {
+                return TranslateStartsEndsWith(instance, arguments[0], startsWith: true);
+            }
+
+            if (EndsWithMethodInfo.Equals(method))
+            {
+                return TranslateStartsEndsWith(instance, arguments[0], startsWith: false);
+            }
+
+            if (PadLeftMethodInfo.Equals(method)
+                || PadRightMethodInfo.Equals(method))
+            {
+                return _sqlExpressionFactory.Function(
+                    PadLeftMethodInfo.Equals(method) ? "LPAD" : "RPAD",
+                    new[] { instance, _sqlExpressionFactory.ApplyDefaultTypeMapping(arguments[0]) },
+                    nullable: true,
+                    argumentsPropagateNullability: new[] { true, true },
+                    method.ReturnType,
+                    instance.TypeMapping);
+            }
         }
 
         if (IsNullOrWhiteSpaceMethodInfo.Equals(method))
@@ -252,6 +297,67 @@ public class CouchbaseStringMethodTranslator : IMethodCallTranslator
 
         return null;
     }
+
+    /// <summary>
+    /// Translates <see cref="string.StartsWith(string)"/>/<see cref="string.EndsWith(string)"/>
+    /// to a N1QL <c>LIKE</c> expression. N1QL's <c>LIKE</c> is ANSI-standard (<c>%</c>/<c>_</c>
+    /// wildcards, <c>ESCAPE</c> clause), so a literal search value must have any <c>%</c>/<c>_</c>/
+    /// escape-char characters escaped -- otherwise e.g. <c>StartsWith("50%")</c> would treat the
+    /// literal <c>%</c> as a wildcard. A constant pattern is escaped once at translation time; a
+    /// runtime pattern (parameter or column) is escaped at query time via nested <c>REPLACE</c>
+    /// calls, mirroring the approach EF Core's own relational providers use for this exact problem.
+    /// </summary>
+    private SqlExpression? TranslateStartsEndsWith(SqlExpression instance, SqlExpression pattern, bool startsWith)
+    {
+        var stringTypeMapping = ExpressionExtensions.InferTypeMapping(instance, pattern);
+        instance = _sqlExpressionFactory.ApplyTypeMapping(instance, stringTypeMapping);
+        pattern = _sqlExpressionFactory.ApplyTypeMapping(pattern, stringTypeMapping);
+
+        SqlExpression likePattern;
+        if (pattern is SqlConstantExpression { Value: string constantPattern })
+        {
+            var escaped = EscapeLikePattern(constantPattern);
+            likePattern = _sqlExpressionFactory.Constant(
+                startsWith ? escaped + "%" : "%" + escaped,
+                stringTypeMapping);
+        }
+        else
+        {
+            var escapedPattern = _sqlExpressionFactory.Function(
+                "REPLACE",
+                new[] { pattern, _sqlExpressionFactory.Constant(LikeEscapeChar, stringTypeMapping), _sqlExpressionFactory.Constant(LikeEscapeChar + LikeEscapeChar, stringTypeMapping) },
+                nullable: true,
+                argumentsPropagateNullability: new[] { true, true, true },
+                typeof(string),
+                stringTypeMapping);
+            escapedPattern = _sqlExpressionFactory.Function(
+                "REPLACE",
+                new[] { escapedPattern, _sqlExpressionFactory.Constant("%", stringTypeMapping), _sqlExpressionFactory.Constant(LikeEscapeChar + "%", stringTypeMapping) },
+                nullable: true,
+                argumentsPropagateNullability: new[] { true, true, true },
+                typeof(string),
+                stringTypeMapping);
+            escapedPattern = _sqlExpressionFactory.Function(
+                "REPLACE",
+                new[] { escapedPattern, _sqlExpressionFactory.Constant("_", stringTypeMapping), _sqlExpressionFactory.Constant(LikeEscapeChar + "_", stringTypeMapping) },
+                nullable: true,
+                argumentsPropagateNullability: new[] { true, true, true },
+                typeof(string),
+                stringTypeMapping);
+
+            likePattern = startsWith
+                ? _sqlExpressionFactory.Add(escapedPattern, _sqlExpressionFactory.Constant("%", stringTypeMapping))
+                : _sqlExpressionFactory.Add(_sqlExpressionFactory.Constant("%", stringTypeMapping), escapedPattern);
+        }
+
+        return _sqlExpressionFactory.Like(instance, likePattern, _sqlExpressionFactory.Constant(LikeEscapeChar, stringTypeMapping));
+    }
+
+    private static string EscapeLikePattern(string pattern)
+        => pattern
+            .Replace(LikeEscapeChar, LikeEscapeChar + LikeEscapeChar)
+            .Replace("%", LikeEscapeChar + "%")
+            .Replace("_", LikeEscapeChar + "_");
 
     private SqlExpression? ProcessTrimMethod(SqlExpression instance, IReadOnlyList<SqlExpression> arguments, string functionName)
     {

--- a/tests/Couchbase.EntityFrameworkCore.IntegrationTests/Tests/DateTimeFormatSpikeTests.cs
+++ b/tests/Couchbase.EntityFrameworkCore.IntegrationTests/Tests/DateTimeFormatSpikeTests.cs
@@ -1,0 +1,138 @@
+using Couchbase.EntityFrameworkCode.IntegrationTests.Fixtures;
+using Couchbase.EntityFrameworkCore;
+using Couchbase.EntityFrameworkCore.Extensions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+using Xunit.Abstractions;
+
+namespace Couchbase.EntityFrameworkCode.IntegrationTests.Tests;
+
+/// <summary>
+/// Originated as a CBEF-23 step-0 empirical spike -- before implementing any <c>DateTime</c>
+/// member/method translator (<c>.Year</c>, <c>.AddDays()</c>, etc.), this proved -- against a real
+/// cluster -- what exact string format a <see cref="DateTime"/> ends up in once stored, and
+/// whether the existing query-parameter path already compares correctly against it. Neither could
+/// be determined by reading source alone: the Couchbase SDK's query-parameter serialization is
+/// compiled-only (no source available), and at the time zero other tests in this repo did any
+/// DateTime comparison.
+/// <para>
+/// Kept as a permanent regression test: it guards the foundational assumption every
+/// <c>CouchbaseDateTimeMemberTranslator</c>/<c>CouchbaseDateTimeMethodTranslator</c> format string
+/// depends on (see their doc comments) -- that the KV write path and the query-parameter path
+/// serialize <see cref="DateTime"/> the same way. If a future SDK/serializer change breaks that
+/// assumption, every other DateTime-translator test would start failing for a confusing,
+/// hard-to-diagnose reason; this test fails first, directly, and says why.
+/// </para>
+/// </summary>
+[Collection(CouchbaseTestingCollection.Name)]
+public class DateTimeFormatSpikeTests(BloggingFixture fixture, ITestOutputHelper outputHelper)
+{
+    [Fact]
+    public async Task StoredDateTime_ObservedFormat_AndComparisonBehavior()
+    {
+        var collectionName = "dtspike" + Guid.NewGuid().ToString("N");
+
+        var optionsBuilder = new DbContextOptionsBuilder<SpikeDbContext>();
+        optionsBuilder.UseCouchbase(
+            new global::Couchbase.ClusterOptions()
+                .WithConnectionString(fixture.Host)
+                .WithPasswordAuthentication(fixture.Username, fixture.Password),
+            o =>
+            {
+                o.Bucket = fixture.BucketName;
+                o.Scope = fixture.ScopeName;
+                o.AutoCreateIndexes = true;
+            });
+        optionsBuilder.ConfigureWarnings(w => w.Ignore(CoreEventId.ManyServiceProvidersCreatedWarning));
+
+        await using var context = new SpikeDbContext(optionsBuilder.Options, collectionName);
+
+        try
+        {
+            await context.Database.EnsureCreatedAsync();
+
+            var stamp = new DateTime(2026, 3, 14, 9, 26, 53, 123, DateTimeKind.Utc);
+            var entity = new SpikeEntity { Id = 1, Stamp = stamp };
+            context.Entities.Add(entity);
+            await context.SaveChangesAsync();
+
+            // Step 1: observe the exact stored string via a raw N1QL projection, bypassing EF's
+            // own type mapping entirely so there's no risk of the read path masking the real
+            // on-disk format. Uses the same SystemTextJsonSerializer the provider itself defaults
+            // to (CouchbaseOptionsExtension.cs) -- the SDK's own default (Newtonsoft) auto-sniffs
+            // ISO-8601-looking strings into DateTimeOffset objects even when a plain string is
+            // requested, which would corrupt this observation.
+            var clusterOptions = new global::Couchbase.ClusterOptions()
+                .WithConnectionString(fixture.Host)
+                .WithCredentials(fixture.Username, fixture.Password)
+                .WithSerializer(global::Couchbase.Core.IO.Serializers.SystemTextJsonSerializer.Create());
+            using var cluster = await global::Couchbase.Cluster.ConnectAsync(clusterOptions);
+            var bucketId = fixture.BucketName;
+            var scopeId = fixture.ScopeName;
+            using var rawResult = await cluster.QueryAsync<string>(
+                $"SELECT RAW Stamp FROM `{bucketId}`.`{scopeId}`.`{collectionName}` WHERE Id = 1");
+
+            string? observedFormat = null;
+            await foreach (var row in rawResult.Rows)
+            {
+                observedFormat = row;
+            }
+
+            outputHelper.WriteLine($"Observed stored DateTime string: '{observedFormat}'");
+            Assert.NotNull(observedFormat);
+
+            // Step 2: does the existing query-parameter path already agree with the stored
+            // format? If this fails, that's a separate, pre-existing bug bigger than this ticket
+            // -- there's no point building AddDays/.Date on top of a foundation where equality
+            // doesn't even work.
+            var equalityMatch = await context.Entities.Where(e => e.Stamp == stamp).ToListAsync();
+            outputHelper.WriteLine($"Equality match count: {equalityMatch.Count}");
+            Assert.Single(equalityMatch);
+
+            // Step 3: does ordering/range comparison work? String comparison only orders
+            // correctly if the format is fixed-width/zero-padded.
+            var earlier = stamp.AddDays(-1);
+            var rangeMatch = await context.Entities.Where(e => e.Stamp > earlier).ToListAsync();
+            outputHelper.WriteLine($"Range match count: {rangeMatch.Count}");
+            Assert.Single(rangeMatch);
+        }
+        finally
+        {
+            await DropCollectionAsync(collectionName);
+        }
+    }
+
+    private async Task DropCollectionAsync(string collectionName)
+    {
+        try
+        {
+            var clusterOptions = new global::Couchbase.ClusterOptions()
+                .WithConnectionString(fixture.Host)
+                .WithCredentials(fixture.Username, fixture.Password);
+            using var cluster = await global::Couchbase.Cluster.ConnectAsync(clusterOptions);
+            var bucket = await cluster.BucketAsync(fixture.BucketName);
+            await bucket.Collections.DropCollectionAsync(fixture.ScopeName, collectionName);
+        }
+        catch (global::Couchbase.Management.Collections.CollectionNotFoundException)
+        {
+        }
+    }
+
+    public class SpikeEntity
+    {
+        public long Id { get; set; }
+        public DateTime Stamp { get; set; }
+    }
+
+    public class SpikeDbContext(DbContextOptions<SpikeDbContext> options, string collectionName)
+        : DbContext(options)
+    {
+        public DbSet<SpikeEntity> Entities { get; set; } = null!;
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            base.OnModelCreating(modelBuilder);
+            modelBuilder.Entity<SpikeEntity>().ToCouchbaseCollection(this, collectionName);
+        }
+    }
+}

--- a/tests/Couchbase.EntityFrameworkCore.IntegrationTests/Tests/DateTimeFormatSpikeTests.cs
+++ b/tests/Couchbase.EntityFrameworkCore.IntegrationTests/Tests/DateTimeFormatSpikeTests.cs
@@ -42,6 +42,10 @@ public class DateTimeFormatSpikeTests(BloggingFixture fixture, ITestOutputHelper
                 o.Bucket = fixture.BucketName;
                 o.Scope = fixture.ScopeName;
                 o.AutoCreateIndexes = true;
+                // NotBounded (the default) can race the just-completed write -- this test writes
+                // one document and immediately queries it, so RequestPlus is needed for the
+                // subsequent LINQ queries to be read-after-write consistent.
+                o.ScanConsistency = global::Couchbase.Query.QueryScanConsistency.RequestPlus;
             });
         optionsBuilder.ConfigureWarnings(w => w.Ignore(CoreEventId.ManyServiceProvidersCreatedWarning));
 
@@ -70,7 +74,8 @@ public class DateTimeFormatSpikeTests(BloggingFixture fixture, ITestOutputHelper
             var bucketId = fixture.BucketName;
             var scopeId = fixture.ScopeName;
             using var rawResult = await cluster.QueryAsync<string>(
-                $"SELECT RAW Stamp FROM `{bucketId}`.`{scopeId}`.`{collectionName}` WHERE Id = 1");
+                $"SELECT RAW Stamp FROM `{bucketId}`.`{scopeId}`.`{collectionName}` WHERE Id = 1",
+                new global::Couchbase.Query.QueryOptions().ScanConsistency(global::Couchbase.Query.QueryScanConsistency.RequestPlus));
 
             string? observedFormat = null;
             await foreach (var row in rawResult.Rows)

--- a/tests/Couchbase.EntityFrameworkCore.IntegrationTests/Tests/FunctionTranslationTests.cs
+++ b/tests/Couchbase.EntityFrameworkCore.IntegrationTests/Tests/FunctionTranslationTests.cs
@@ -72,6 +72,25 @@ public class FunctionTranslationTests(BloggingFixture fixture, ITestOutputHelper
         Assert.Single(result);
     }
 
+    [Fact]
+    public async Task Contains_ProjectsAsBoolean_NotInt()
+    {
+        // string.Contains returns bool and N1QL's CONTAINS returns a boolean, but the CONTAINS
+        // SqlExpression used to be declared with return type int -- a real type-correctness bug
+        // (flagged in code review) even though this specific test doesn't empirically fail without
+        // the fix: this provider's reader coerces the JSON boolean into whatever CLR type the
+        // projection actually asks for, independent of the SqlExpression's own declared type, so
+        // the mistyped declaration doesn't crash materialization today. Kept as a scalar-projection
+        // regression test anyway, since the declared type is still wrong and could matter if EF
+        // Core's type-inference/null-compensation logic ever consults it, or if a future reader
+        // change stops being this lenient.
+        var query = _context.Entities.Select(e => new { e.Title, IsMatch = e.Title.Contains("World") });
+        var results = await query.ToListAsync();
+
+        Assert.Single(results);
+        Assert.True(results[0].IsMatch);
+    }
+
     public async Task DisposeAsync()
     {
         await _context.DisposeAsync();

--- a/tests/Couchbase.EntityFrameworkCore.IntegrationTests/Tests/FunctionTranslationTests.cs
+++ b/tests/Couchbase.EntityFrameworkCore.IntegrationTests/Tests/FunctionTranslationTests.cs
@@ -1,0 +1,261 @@
+using Couchbase.EntityFrameworkCode.IntegrationTests.Fixtures;
+using Couchbase.EntityFrameworkCore;
+using Couchbase.EntityFrameworkCore.Extensions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+using Xunit.Abstractions;
+
+namespace Couchbase.EntityFrameworkCode.IntegrationTests.Tests;
+
+/// <summary>
+/// CBEF-23: proves the new/fixed SQL++ function translations actually execute correctly against a
+/// real query engine, not just that they generate plausible-looking SQL text (already covered by
+/// the unit tests in <c>Couchbase.EntityFrameworkCore.UnitTests</c>'s <c>*SqlGenerationTests</c>
+/// classes). Things like <c>POSITION</c>'s argument order, <c>DATE_ADD_STR</c>'s
+/// millis-not-string return type, and <c>LIKE</c> escaping edge cases look right as text but need
+/// a live round-trip to be sure.
+/// </summary>
+[Collection(CouchbaseTestingCollection.Name)]
+public class FunctionTranslationTests(BloggingFixture fixture, ITestOutputHelper outputHelper) : IAsyncLifetime
+{
+    private static readonly string CollectionName = "fntrans" + Guid.NewGuid().ToString("N");
+    private FunctionTranslationDbContext _context = null!;
+
+    public async Task InitializeAsync()
+    {
+        var optionsBuilder = new DbContextOptionsBuilder<FunctionTranslationDbContext>();
+        optionsBuilder.UseCouchbase(
+            new global::Couchbase.ClusterOptions()
+                .WithConnectionString(fixture.Host)
+                .WithPasswordAuthentication(fixture.Username, fixture.Password),
+            o =>
+            {
+                o.Bucket = fixture.BucketName;
+                o.Scope = fixture.ScopeName;
+                o.AutoCreateIndexes = true;
+                // NotBounded (the default) can race a read against the just-completed write --
+                // AutoCreateIndexes only guarantees the index is online before EnsureCreatedAsync
+                // returns, not that a subsequent write is immediately visible to a query.
+                o.ScanConsistency = global::Couchbase.Query.QueryScanConsistency.RequestPlus;
+            });
+        optionsBuilder.ConfigureWarnings(w => w.Ignore(CoreEventId.ManyServiceProvidersCreatedWarning));
+
+        _context = new FunctionTranslationDbContext(optionsBuilder.Options, CollectionName);
+        await _context.Database.EnsureCreatedAsync();
+
+        _context.Entities.Add(new FunctionTranslationEntity
+        {
+            Id = 1,
+            Title = "Hello World",
+            Score = -4.7,
+            Published = new DateTime(2026, 3, 14, 9, 26, 53, 123, DateTimeKind.Utc),
+        });
+        await _context.SaveChangesAsync();
+    }
+
+    [Fact]
+    public async Task DateTime_Date_TruncatesToStartOfDay()
+    {
+        // DateTimeKind.Utc matters here -- Published is stored as Utc, and an Unspecified-kind
+        // DateTime parameter serializes differently, so a naive `new DateTime(2026, 3, 14)`
+        // would never compare equal even though DATE_TRUNC_STR computes the right value.
+        var expected = new DateTime(2026, 3, 14, 0, 0, 0, DateTimeKind.Utc);
+        var result = await _context.Entities.Where(e => e.Published.Date == expected).ToListAsync();
+        Assert.Single(result);
+    }
+
+    [Fact]
+    public async Task DateTime_Today_ComparesAgainstStoredDate()
+    {
+        // Published is in the past (2026-03-14); Today at test-run time must be later.
+        var result = await _context.Entities.Where(e => e.Published < DateTime.Today).ToListAsync();
+        Assert.Single(result);
+    }
+
+    public async Task DisposeAsync()
+    {
+        await _context.DisposeAsync();
+
+        try
+        {
+            var clusterOptions = new global::Couchbase.ClusterOptions()
+                .WithConnectionString(fixture.Host)
+                .WithCredentials(fixture.Username, fixture.Password);
+            using var cluster = await global::Couchbase.Cluster.ConnectAsync(clusterOptions);
+            var bucket = await cluster.BucketAsync(fixture.BucketName);
+            await bucket.Collections.DropCollectionAsync(fixture.ScopeName, CollectionName);
+        }
+        catch (global::Couchbase.Management.Collections.CollectionNotFoundException)
+        {
+        }
+    }
+
+    [Fact]
+    public async Task IndexOf_ReturnsCorrectPosition_NotBoolean()
+    {
+        var result = await _context.Entities.Where(e => e.Title.IndexOf("World") == 6).ToListAsync();
+        Assert.Single(result);
+    }
+
+    [Fact]
+    public async Task StartsWith_MatchesPrefix()
+    {
+        var result = await _context.Entities.Where(e => e.Title.StartsWith("Hello")).ToListAsync();
+        Assert.Single(result);
+    }
+
+    [Fact]
+    public async Task StartsWith_DoesNotMatchNonPrefix()
+    {
+        var result = await _context.Entities.Where(e => e.Title.StartsWith("World")).ToListAsync();
+        Assert.Empty(result);
+    }
+
+    [Fact]
+    public async Task EndsWith_MatchesSuffix()
+    {
+        var result = await _context.Entities.Where(e => e.Title.EndsWith("World")).ToListAsync();
+        Assert.Single(result);
+    }
+
+    [Fact]
+    public async Task StartsWith_WithLiteralWildcard_TreatsPercentLiterally()
+    {
+        // Confirms the escaping added for StartsWith/EndsWith actually prevents '%' from acting
+        // as a wildcard against a real query engine, not just in generated SQL text.
+        var result = await _context.Entities.Where(e => e.Title.StartsWith("Hello%")).ToListAsync();
+        Assert.Empty(result);
+    }
+
+    [Fact]
+    public async Task Length_ReturnsCorrectCount()
+    {
+        var result = await _context.Entities.Where(e => e.Title.Length == 11).ToListAsync();
+        Assert.Single(result);
+    }
+
+    [Fact]
+    public async Task PadLeft_ProducesExpectedString()
+    {
+        // "Hello World" is 11 characters; PadLeft(15) prepends 4 spaces.
+        var result = await _context.Entities
+            .Where(e => e.Title.PadLeft(15) == "    Hello World")
+            .ToListAsync();
+
+        Assert.Single(result);
+    }
+
+    [Fact]
+    public async Task Abs_ReturnsPositiveValue()
+    {
+        var result = await _context.Entities.Where(e => Math.Abs(e.Score) == 4.7).ToListAsync();
+        Assert.Single(result);
+    }
+
+    [Fact]
+    public async Task Ceiling_RoundsUp()
+    {
+        var result = await _context.Entities.Where(e => Math.Ceiling(e.Score) == -4).ToListAsync();
+        Assert.Single(result);
+    }
+
+    [Fact]
+    public async Task Floor_RoundsDown()
+    {
+        var result = await _context.Entities.Where(e => Math.Floor(e.Score) == -5).ToListAsync();
+        Assert.Single(result);
+    }
+
+    [Fact]
+    public async Task Round_WithDigits_RoundsCorrectly()
+    {
+        var result = await _context.Entities.Where(e => Math.Round(e.Score, 0) == -5).ToListAsync();
+        Assert.Single(result);
+    }
+
+    [Fact]
+    public async Task Sign_ReturnsNegativeOne()
+    {
+        var result = await _context.Entities.Where(e => Math.Sign(e.Score) == -1).ToListAsync();
+        Assert.Single(result);
+    }
+
+    [Fact]
+    public async Task NewGuid_ProjectsNonEmptyValue()
+    {
+        // A projection that also references a real column keeps a normal FROM clause -- the
+        // realistic usage shape (e.g. `.Select(e => new { e.Title, Guid.NewGuid() })`). A
+        // projection where the lambda parameter is entirely unused (`.Select(e => Guid.NewGuid())`)
+        // hits a separate, narrower, pre-existing gap: EF Core hoists such expressions into a
+        // FROM-less `SELECT UUID()`, which this provider's reader doesn't materialize correctly --
+        // out of scope here (a query-shape edge case, not a function-translation bug) but worth
+        // flagging to the user.
+        var query = _context.Entities.Select(e => new { e.Title, Guid = Guid.NewGuid() });
+        outputHelper.WriteLine($"SQL: {query.ToQueryString()}");
+
+        var results = await query.ToListAsync();
+        Assert.Single(results);
+        Assert.NotEqual(Guid.Empty, results[0].Guid);
+    }
+
+    [Fact]
+    public async Task DateTime_Year_MatchesStoredYear()
+    {
+        var result = await _context.Entities.Where(e => e.Published.Year == 2026).ToListAsync();
+        Assert.Single(result);
+    }
+
+    [Fact]
+    public async Task DateTime_Month_MatchesStoredMonth()
+    {
+        var result = await _context.Entities.Where(e => e.Published.Month == 3).ToListAsync();
+        Assert.Single(result);
+    }
+
+    [Fact]
+    public async Task DateTime_AddDays_ProducesUsableDateTimeForComparison()
+    {
+        // DATE_ADD_STR returns the resulting date as a string directly (see
+        // CouchbaseDateTimeMethodTranslator's doc comment); this proves the comparison actually
+        // executes and matches against real stored data, not just that it generates plausible SQL.
+        var expected = new DateTime(2026, 3, 15, 9, 26, 53, 123, DateTimeKind.Utc);
+        var result = await _context.Entities.Where(e => e.Published.AddDays(1) == expected).ToListAsync();
+        Assert.Single(result);
+    }
+
+    [Fact]
+    public async Task DateTime_AddYears_ProducesUsableDateTimeForComparison()
+    {
+        var expected = new DateTime(2027, 3, 14, 9, 26, 53, 123, DateTimeKind.Utc);
+        var result = await _context.Entities.Where(e => e.Published.AddYears(1) == expected).ToListAsync();
+        Assert.Single(result);
+    }
+
+    [Fact]
+    public async Task DateTime_UtcNow_ComparesAgainstStoredDate()
+    {
+        // Published is in the past (2026-03-14); UtcNow at test-run time must be later.
+        var result = await _context.Entities.Where(e => e.Published < DateTime.UtcNow).ToListAsync();
+        Assert.Single(result);
+    }
+
+    public class FunctionTranslationEntity
+    {
+        public long Id { get; set; }
+        public string Title { get; set; } = string.Empty;
+        public double Score { get; set; }
+        public DateTime Published { get; set; }
+    }
+
+    public class FunctionTranslationDbContext(DbContextOptions<FunctionTranslationDbContext> options, string collectionName)
+        : DbContext(options)
+    {
+        public DbSet<FunctionTranslationEntity> Entities { get; set; } = null!;
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            base.OnModelCreating(modelBuilder);
+            modelBuilder.Entity<FunctionTranslationEntity>().ToCouchbaseCollection(this, collectionName);
+        }
+    }
+}

--- a/tests/Couchbase.EntityFrameworkCore.IntegrationTests/Tests/FunctionTranslationTests.cs
+++ b/tests/Couchbase.EntityFrameworkCore.IntegrationTests/Tests/FunctionTranslationTests.cs
@@ -19,6 +19,13 @@ namespace Couchbase.EntityFrameworkCode.IntegrationTests.Tests;
 public class FunctionTranslationTests(BloggingFixture fixture, ITestOutputHelper outputHelper) : IAsyncLifetime
 {
     private static readonly string CollectionName = "fntrans" + Guid.NewGuid().ToString("N");
+
+    // Anchored to last year's March 14th rather than a hardcoded date -- always unambiguously in
+    // the past regardless of when the suite actually runs (CI with a pinned/mocked clock, a
+    // historical checkout, etc.), while staying a fixed, known value the Date/Year/Month/Add*
+    // tests below can assert against without re-deriving "what should this compute to."
+    private static readonly DateTime Published = new(DateTime.UtcNow.Year - 1, 3, 14, 9, 26, 53, 123, DateTimeKind.Utc);
+
     private FunctionTranslationDbContext _context = null!;
 
     public async Task InitializeAsync()
@@ -48,7 +55,7 @@ public class FunctionTranslationTests(BloggingFixture fixture, ITestOutputHelper
             Id = 1,
             Title = "Hello World",
             Score = -4.7,
-            Published = new DateTime(2026, 3, 14, 9, 26, 53, 123, DateTimeKind.Utc),
+            Published = Published,
         });
         await _context.SaveChangesAsync();
     }
@@ -57,9 +64,9 @@ public class FunctionTranslationTests(BloggingFixture fixture, ITestOutputHelper
     public async Task DateTime_Date_TruncatesToStartOfDay()
     {
         // DateTimeKind.Utc matters here -- Published is stored as Utc, and an Unspecified-kind
-        // DateTime parameter serializes differently, so a naive `new DateTime(2026, 3, 14)`
-        // would never compare equal even though DATE_TRUNC_STR computes the right value.
-        var expected = new DateTime(2026, 3, 14, 0, 0, 0, DateTimeKind.Utc);
+        // DateTime parameter serializes differently, so a naive `new DateTime(y, m, d)` would
+        // never compare equal even though DATE_TRUNC_STR computes the right value.
+        var expected = new DateTime(Published.Year, Published.Month, Published.Day, 0, 0, 0, DateTimeKind.Utc);
         var result = await _context.Entities.Where(e => e.Published.Date == expected).ToListAsync();
         Assert.Single(result);
     }
@@ -67,7 +74,7 @@ public class FunctionTranslationTests(BloggingFixture fixture, ITestOutputHelper
     [Fact]
     public async Task DateTime_Today_ComparesAgainstStoredDate()
     {
-        // Published is in the past (2026-03-14); Today at test-run time must be later.
+        // Published is anchored to last year, so it's always in the past relative to Today.
         var result = await _context.Entities.Where(e => e.Published < DateTime.Today).ToListAsync();
         Assert.Single(result);
     }
@@ -220,14 +227,14 @@ public class FunctionTranslationTests(BloggingFixture fixture, ITestOutputHelper
     [Fact]
     public async Task DateTime_Year_MatchesStoredYear()
     {
-        var result = await _context.Entities.Where(e => e.Published.Year == 2026).ToListAsync();
+        var result = await _context.Entities.Where(e => e.Published.Year == Published.Year).ToListAsync();
         Assert.Single(result);
     }
 
     [Fact]
     public async Task DateTime_Month_MatchesStoredMonth()
     {
-        var result = await _context.Entities.Where(e => e.Published.Month == 3).ToListAsync();
+        var result = await _context.Entities.Where(e => e.Published.Month == Published.Month).ToListAsync();
         Assert.Single(result);
     }
 
@@ -237,7 +244,7 @@ public class FunctionTranslationTests(BloggingFixture fixture, ITestOutputHelper
         // DATE_ADD_STR returns the resulting date as a string directly (see
         // CouchbaseDateTimeMethodTranslator's doc comment); this proves the comparison actually
         // executes and matches against real stored data, not just that it generates plausible SQL.
-        var expected = new DateTime(2026, 3, 15, 9, 26, 53, 123, DateTimeKind.Utc);
+        var expected = Published.AddDays(1);
         var result = await _context.Entities.Where(e => e.Published.AddDays(1) == expected).ToListAsync();
         Assert.Single(result);
     }
@@ -245,7 +252,7 @@ public class FunctionTranslationTests(BloggingFixture fixture, ITestOutputHelper
     [Fact]
     public async Task DateTime_AddYears_ProducesUsableDateTimeForComparison()
     {
-        var expected = new DateTime(2027, 3, 14, 9, 26, 53, 123, DateTimeKind.Utc);
+        var expected = Published.AddYears(1);
         var result = await _context.Entities.Where(e => e.Published.AddYears(1) == expected).ToListAsync();
         Assert.Single(result);
     }
@@ -253,7 +260,7 @@ public class FunctionTranslationTests(BloggingFixture fixture, ITestOutputHelper
     [Fact]
     public async Task DateTime_UtcNow_ComparesAgainstStoredDate()
     {
-        // Published is in the past (2026-03-14); UtcNow at test-run time must be later.
+        // Published is anchored to last year, so it's always in the past relative to UtcNow.
         var result = await _context.Entities.Where(e => e.Published < DateTime.UtcNow).ToListAsync();
         Assert.Single(result);
     }

--- a/tests/Couchbase.EntityFrameworkCore.UnitTests/Couchbase/EntityFrameworkCore/Query/CouchbaseDateTimeFunctionSqlGenerationTests.cs
+++ b/tests/Couchbase.EntityFrameworkCore.UnitTests/Couchbase/EntityFrameworkCore/Query/CouchbaseDateTimeFunctionSqlGenerationTests.cs
@@ -1,0 +1,132 @@
+using Couchbase.EntityFrameworkCore.Extensions;
+using Microsoft.EntityFrameworkCore;
+using Xunit;
+
+namespace Couchbase.EntityFrameworkCore.UnitTests.Couchbase.EntityFrameworkCore.Query;
+
+/// <summary>
+/// Verifies LINQ <see cref="DateTime"/> member/method translation to SQL++ (CBEF-23), via the new
+/// <c>CouchbaseDateTimeMemberTranslator</c>/<c>CouchbaseDateTimeMethodTranslator</c>.
+/// </summary>
+public class CouchbaseDateTimeFunctionSqlGenerationTests
+{
+    [Fact]
+    public void Year_TranslatesToDatePartStr()
+    {
+        using var ctx = CreateContext();
+        var query = ctx.Posts.Where(p => p.Published.Year == 2026);
+
+        var sql = query.ToQueryString();
+        Assert.Contains("DATE_PART_STR(", sql, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("'year'", sql);
+    }
+
+    [Fact]
+    public void Month_TranslatesToDatePartStr()
+    {
+        using var ctx = CreateContext();
+        var query = ctx.Posts.Where(p => p.Published.Month == 3);
+
+        var sql = query.ToQueryString();
+        Assert.Contains("DATE_PART_STR(", sql, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("'month'", sql);
+    }
+
+    [Fact]
+    public void Date_TranslatesToDateTruncStr()
+    {
+        using var ctx = CreateContext();
+        var stamp = new DateTime(2026, 1, 1);
+        var query = ctx.Posts.Where(p => p.Published.Date == stamp);
+
+        var sql = query.ToQueryString();
+        Assert.Contains("DATE_TRUNC_STR(", sql, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("'day'", sql);
+    }
+
+    [Fact]
+    public void UtcNow_TranslatesToNowUtc()
+    {
+        using var ctx = CreateContext();
+        var query = ctx.Posts.Where(p => p.Published < DateTime.UtcNow);
+
+        Assert.Contains("NOW_UTC(", query.ToQueryString(), StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void Now_TranslatesToNowLocal()
+    {
+        using var ctx = CreateContext();
+        var query = ctx.Posts.Where(p => p.Published < DateTime.Now);
+
+        Assert.Contains("NOW_LOCAL(", query.ToQueryString(), StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void Today_TranslatesToTruncatedNowUtc()
+    {
+        using var ctx = CreateContext();
+        var query = ctx.Posts.Where(p => p.Published < DateTime.Today);
+
+        var sql = query.ToQueryString();
+        Assert.Contains("NOW_UTC(", sql, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("DATE_TRUNC_STR(", sql, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void AddDays_TranslatesToDateAddStr()
+    {
+        // DATE_ADD_STR returns the resulting date as a string directly (confirmed against a
+        // live cluster) -- no MILLIS_TO_STR/MILLIS_TO_UTC wrapping needed or wanted.
+        using var ctx = CreateContext();
+        var stamp = new DateTime(2026, 1, 1);
+        var query = ctx.Posts.Where(p => p.Published.AddDays(1) == stamp);
+
+        var sql = query.ToQueryString();
+        Assert.Contains("DATE_ADD_STR(", sql, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("'day'", sql);
+    }
+
+    [Fact]
+    public void AddYears_TranslatesToDateAddStrWithYearPart()
+    {
+        using var ctx = CreateContext();
+        var stamp = new DateTime(2026, 1, 1);
+        var query = ctx.Posts.Where(p => p.Published.AddYears(1) == stamp);
+
+        var sql = query.ToQueryString();
+        Assert.Contains("DATE_ADD_STR(", sql, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("'year'", sql);
+    }
+
+    private static PostContext CreateContext()
+    {
+        var clusterOptions = new ClusterOptions()
+            .WithConnectionString("couchbase://localhost")
+            .WithPasswordAuthentication("Administrator", "password");
+
+        var builder = new DbContextOptionsBuilder<PostContext>();
+        builder.UseCouchbaseProvider(clusterOptions);
+        return new PostContext(builder.Options);
+    }
+
+    private class Post
+    {
+        public int PostId { get; set; }
+        public DateTime Published { get; set; }
+    }
+
+    private class PostContext(DbContextOptions<PostContext> options) : DbContext(options)
+    {
+        public DbSet<Post> Posts { get; set; } = null!;
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            modelBuilder.Entity<Post>(b =>
+            {
+                b.ToCouchbaseCollection("bucket", "scope", "post");
+                b.HasKey(p => p.PostId);
+            });
+        }
+    }
+}

--- a/tests/Couchbase.EntityFrameworkCore.UnitTests/Couchbase/EntityFrameworkCore/Query/CouchbaseGuidFunctionSqlGenerationTests.cs
+++ b/tests/Couchbase.EntityFrameworkCore.UnitTests/Couchbase/EntityFrameworkCore/Query/CouchbaseGuidFunctionSqlGenerationTests.cs
@@ -1,0 +1,52 @@
+using Couchbase.EntityFrameworkCore.Extensions;
+using Microsoft.EntityFrameworkCore;
+using Xunit;
+
+namespace Couchbase.EntityFrameworkCore.UnitTests.Couchbase.EntityFrameworkCore.Query;
+
+/// <summary>
+/// Verifies <see cref="Guid.NewGuid"/> translates to N1QL's <c>UUID()</c> (CBEF-23).
+/// </summary>
+public class CouchbaseGuidFunctionSqlGenerationTests
+{
+    [Fact]
+    public void NewGuid_TranslatesToUuid()
+    {
+        using var ctx = CreateContext();
+        var query = ctx.Posts.Select(p => Guid.NewGuid());
+
+        var sql = query.ToQueryString();
+
+        Assert.Contains("UUID()", sql, StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static PostContext CreateContext()
+    {
+        var clusterOptions = new ClusterOptions()
+            .WithConnectionString("couchbase://localhost")
+            .WithPasswordAuthentication("Administrator", "password");
+
+        var builder = new DbContextOptionsBuilder<PostContext>();
+        builder.UseCouchbaseProvider(clusterOptions);
+        return new PostContext(builder.Options);
+    }
+
+    private class Post
+    {
+        public int PostId { get; set; }
+    }
+
+    private class PostContext(DbContextOptions<PostContext> options) : DbContext(options)
+    {
+        public DbSet<Post> Posts { get; set; } = null!;
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            modelBuilder.Entity<Post>(b =>
+            {
+                b.ToCouchbaseCollection("bucket", "scope", "post");
+                b.HasKey(p => p.PostId);
+            });
+        }
+    }
+}

--- a/tests/Couchbase.EntityFrameworkCore.UnitTests/Couchbase/EntityFrameworkCore/Query/CouchbaseMathFunctionSqlGenerationTests.cs
+++ b/tests/Couchbase.EntityFrameworkCore.UnitTests/Couchbase/EntityFrameworkCore/Query/CouchbaseMathFunctionSqlGenerationTests.cs
@@ -1,0 +1,166 @@
+using Couchbase.EntityFrameworkCore.Extensions;
+using Microsoft.EntityFrameworkCore;
+using Xunit;
+
+namespace Couchbase.EntityFrameworkCore.UnitTests.Couchbase.EntityFrameworkCore.Query;
+
+/// <summary>
+/// Verifies LINQ <see cref="Math"/> method translation to SQL++ (CBEF-23) via the new
+/// <c>CouchbaseMathMethodTranslator</c> -- previously nonexistent in this provider (the
+/// method-call translator provider only ever registered a string translator; Math/DateTime/etc.
+/// translators SQLite ships were left commented out and never implemented for Couchbase).
+/// </summary>
+public class CouchbaseMathFunctionSqlGenerationTests
+{
+    [Fact]
+    public void Abs_TranslatesToAbs()
+    {
+        using var ctx = CreateContext();
+        var query = ctx.Posts.Where(p => Math.Abs(p.Score) > 1);
+
+        Assert.Contains("ABS(", query.ToQueryString(), StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void Ceiling_TranslatesToCeil()
+    {
+        using var ctx = CreateContext();
+        var query = ctx.Posts.Where(p => Math.Ceiling(p.Score) > 1);
+
+        Assert.Contains("CEIL(", query.ToQueryString(), StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void Floor_TranslatesToFloor()
+    {
+        using var ctx = CreateContext();
+        var query = ctx.Posts.Where(p => Math.Floor(p.Score) > 1);
+
+        Assert.Contains("FLOOR(", query.ToQueryString(), StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void Round_NoDigits_TranslatesToRound()
+    {
+        using var ctx = CreateContext();
+        var query = ctx.Posts.Where(p => Math.Round(p.Score) > 1);
+
+        Assert.Contains("ROUND(", query.ToQueryString(), StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void Round_WithDigits_TranslatesToRoundWithTwoArgs()
+    {
+        using var ctx = CreateContext();
+        var query = ctx.Posts.Where(p => Math.Round(p.Score, 2) > 1);
+
+        var sql = query.ToQueryString();
+        Assert.Contains("ROUND(", sql, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains(", 2)", sql);
+    }
+
+    [Fact]
+    public void Truncate_TranslatesToTrunc()
+    {
+        using var ctx = CreateContext();
+        var query = ctx.Posts.Where(p => Math.Truncate(p.Score) > 1);
+
+        Assert.Contains("TRUNC(", query.ToQueryString(), StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void Pow_TranslatesToPower()
+    {
+        using var ctx = CreateContext();
+        var query = ctx.Posts.Where(p => Math.Pow(p.Score, 2) > 1);
+
+        Assert.Contains("POWER(", query.ToQueryString(), StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void Sqrt_TranslatesToSqrt()
+    {
+        using var ctx = CreateContext();
+        var query = ctx.Posts.Where(p => Math.Sqrt(p.Score) > 1);
+
+        Assert.Contains("SQRT(", query.ToQueryString(), StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void Sign_TranslatesToSign()
+    {
+        using var ctx = CreateContext();
+        var query = ctx.Posts.Where(p => Math.Sign(p.Score) > 0);
+
+        Assert.Contains("SIGN(", query.ToQueryString(), StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void Log_TranslatesToLn()
+    {
+        using var ctx = CreateContext();
+        var query = ctx.Posts.Where(p => Math.Log(p.Score) > 1);
+
+        Assert.Contains("LN(", query.ToQueryString(), StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void Log10_TranslatesToLog()
+    {
+        using var ctx = CreateContext();
+        var query = ctx.Posts.Where(p => Math.Log10(p.Score) > 1);
+
+        Assert.Contains("LOG(", query.ToQueryString(), StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void Exp_TranslatesToExp()
+    {
+        using var ctx = CreateContext();
+        var query = ctx.Posts.Where(p => Math.Exp(p.Score) > 1);
+
+        Assert.Contains("EXP(", query.ToQueryString(), StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void LogWithNewBase_TranslatesToChangeOfBaseViaLn()
+    {
+        using var ctx = CreateContext();
+        var query = ctx.Posts.Where(p => Math.Log(p.Score, 2) > 1);
+
+        var sql = query.ToQueryString();
+        Assert.Contains("LN(", sql, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("/", sql);
+    }
+
+    private static PostContext CreateContext()
+    {
+        var clusterOptions = new ClusterOptions()
+            .WithConnectionString("couchbase://localhost")
+            .WithPasswordAuthentication("Administrator", "password");
+
+        var builder = new DbContextOptionsBuilder<PostContext>();
+        builder.UseCouchbaseProvider(clusterOptions);
+        return new PostContext(builder.Options);
+    }
+
+    private class Post
+    {
+        public int PostId { get; set; }
+        public double Score { get; set; }
+    }
+
+    private class PostContext(DbContextOptions<PostContext> options) : DbContext(options)
+    {
+        public DbSet<Post> Posts { get; set; } = null!;
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            modelBuilder.Entity<Post>(b =>
+            {
+                b.ToCouchbaseCollection("bucket", "scope", "post");
+                b.HasKey(p => p.PostId);
+            });
+        }
+    }
+}

--- a/tests/Couchbase.EntityFrameworkCore.UnitTests/Couchbase/EntityFrameworkCore/Query/CouchbaseMemberTranslationSqlGenerationTests.cs
+++ b/tests/Couchbase.EntityFrameworkCore.UnitTests/Couchbase/EntityFrameworkCore/Query/CouchbaseMemberTranslationSqlGenerationTests.cs
@@ -1,0 +1,56 @@
+using Couchbase.EntityFrameworkCore.Extensions;
+using Microsoft.EntityFrameworkCore;
+using Xunit;
+
+namespace Couchbase.EntityFrameworkCore.UnitTests.Couchbase.EntityFrameworkCore.Query;
+
+/// <summary>
+/// Verifies LINQ property/member translation to SQL++ (CBEF-23), via the new
+/// <c>CouchbaseMemberTranslatorProvider</c> pipeline (previously nonexistent in this provider --
+/// properties like <c>string.Length</c> go through <c>IMemberTranslator</c>, not
+/// <c>IMethodCallTranslator</c>, which only handles method calls like <c>.ToLower()</c>).
+/// </summary>
+public class CouchbaseMemberTranslationSqlGenerationTests
+{
+    [Fact]
+    public void StringLength_TranslatesToLength()
+    {
+        using var ctx = CreateContext();
+        var query = ctx.Posts.Where(p => p.Title.Length > 5);
+
+        var sql = query.ToQueryString();
+
+        Assert.Contains("LENGTH(", sql, StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static PostContext CreateContext()
+    {
+        var clusterOptions = new ClusterOptions()
+            .WithConnectionString("couchbase://localhost")
+            .WithPasswordAuthentication("Administrator", "password");
+
+        var builder = new DbContextOptionsBuilder<PostContext>();
+        builder.UseCouchbaseProvider(clusterOptions);
+        return new PostContext(builder.Options);
+    }
+
+    private class Post
+    {
+        public int PostId { get; set; }
+        public string Title { get; set; } = null!;
+    }
+
+    private class PostContext(DbContextOptions<PostContext> options) : DbContext(options)
+    {
+        public DbSet<Post> Posts { get; set; } = null!;
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            modelBuilder.Entity<Post>(b =>
+            {
+                b.ToCouchbaseCollection("bucket", "scope", "post");
+                b.HasKey(p => p.PostId);
+            });
+        }
+    }
+}

--- a/tests/Couchbase.EntityFrameworkCore.UnitTests/Couchbase/EntityFrameworkCore/Query/CouchbaseStringFunctionSqlGenerationTests.cs
+++ b/tests/Couchbase.EntityFrameworkCore.UnitTests/Couchbase/EntityFrameworkCore/Query/CouchbaseStringFunctionSqlGenerationTests.cs
@@ -1,0 +1,145 @@
+using Couchbase.EntityFrameworkCore.Extensions;
+using Microsoft.EntityFrameworkCore;
+using Xunit;
+
+namespace Couchbase.EntityFrameworkCore.UnitTests.Couchbase.EntityFrameworkCore.Query;
+
+/// <summary>
+/// Verifies LINQ string-method translation to SQL++ (CBEF-23), including the
+/// <c>IndexOf</c>/<c>CONTAINS</c> fix: <c>CONTAINS</c> returns a boolean, not the integer
+/// position <c>string.IndexOf</c> must return. The correct N1QL function is <c>POSITION</c>.
+/// </summary>
+public class CouchbaseStringFunctionSqlGenerationTests
+{
+    [Fact]
+    public void IndexOf_TranslatesToPosition_NotContains()
+    {
+        using var ctx = CreateContext();
+        var query = ctx.Posts.Where(p => p.Title.IndexOf("abc") > 0);
+
+        var sql = query.ToQueryString();
+
+        Assert.Contains("POSITION(", sql, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("CONTAINS(", sql, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void IsNullOrEmpty_OnNullableColumn_ChecksIsNullOrEqualToEmptyString()
+    {
+        // Title must be nullable here: on a non-nullable column EF Core's null-semantics
+        // optimizer provably prunes the IS NULL branch, which would make this test pass for the
+        // wrong reason (already observed: on a non-nullable column this collapses to `= ''`).
+        using var ctx = CreateContext();
+        var query = ctx.Posts.Where(p => string.IsNullOrEmpty(p.NullableTitle));
+
+        var sql = query.ToQueryString();
+
+        Assert.Contains("IS NULL", sql, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("''", sql);
+    }
+
+    [Fact]
+    public void PadLeft_InWherePredicate_TranslatesToLpad()
+    {
+        // A Select-projection PadLeft can silently client-evaluate instead of throwing; a Where
+        // predicate cannot -- it must translate or the query throws. Using Where here proves the
+        // function genuinely reached SQL++ rather than being materialized client-side.
+        using var ctx = CreateContext();
+        var query = ctx.Posts.Where(p => p.Title.PadLeft(10) == "x");
+
+        var sql = query.ToQueryString();
+
+        Assert.Contains("LPAD(", sql, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void PadRight_InWherePredicate_TranslatesToRpad()
+    {
+        using var ctx = CreateContext();
+        var query = ctx.Posts.Where(p => p.Title.PadRight(10) == "x");
+
+        var sql = query.ToQueryString();
+
+        Assert.Contains("RPAD(", sql, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void StartsWith_ConstantPattern_TranslatesToLike()
+    {
+        using var ctx = CreateContext();
+        var query = ctx.Posts.Where(p => p.Title.StartsWith("abc"));
+
+        var sql = query.ToQueryString();
+
+        Assert.Contains("LIKE", sql, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void EndsWith_ConstantPattern_TranslatesToLike()
+    {
+        using var ctx = CreateContext();
+        var query = ctx.Posts.Where(p => p.Title.EndsWith("xyz"));
+
+        var sql = query.ToQueryString();
+
+        Assert.Contains("LIKE", sql, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void StartsWith_ConstantPatternContainingWildcard_EscapesLiteralPercent()
+    {
+        // A StartsWith("50%") search must not treat the literal '%' as a wildcard.
+        using var ctx = CreateContext();
+        var query = ctx.Posts.Where(p => p.Title.StartsWith("50%"));
+
+        var sql = query.ToQueryString();
+
+        Assert.Contains("ESCAPE", sql, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("50!%%", sql);
+    }
+
+    [Fact]
+    public void StartsWith_NonConstantPattern_EscapesAtRuntimeViaReplace()
+    {
+        using var ctx = CreateContext();
+        var pattern = "abc"; // a local variable, so EF Core parameterizes it, not folds it to a constant
+        var query = ctx.Posts.Where(p => p.Title.StartsWith(pattern));
+
+        var sql = query.ToQueryString();
+
+        Assert.Contains("REPLACE(", sql, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("LIKE", sql, StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static PostContext CreateContext()
+    {
+        var clusterOptions = new ClusterOptions()
+            .WithConnectionString("couchbase://localhost")
+            .WithPasswordAuthentication("Administrator", "password");
+
+        var builder = new DbContextOptionsBuilder<PostContext>();
+        builder.UseCouchbaseProvider(clusterOptions);
+        return new PostContext(builder.Options);
+    }
+
+    private class Post
+    {
+        public int PostId { get; set; }
+        public string Title { get; set; } = null!;
+        public string? NullableTitle { get; set; }
+    }
+
+    private class PostContext(DbContextOptions<PostContext> options) : DbContext(options)
+    {
+        public DbSet<Post> Posts { get; set; } = null!;
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            modelBuilder.Entity<Post>(b =>
+            {
+                b.ToCouchbaseCollection("bucket", "scope", "post");
+                b.HasKey(p => p.PostId);
+            });
+        }
+    }
+}


### PR DESCRIPTION
Fixes string.IndexOf translating to CONTAINS (boolean) instead of POSITION (integer index). Adds translation for StartsWith/EndsWith, PadLeft/PadRight, string.Length (new IMemberTranslatorProvider infrastructure), Math.Abs/ Ceiling/Floor/Round/Truncate/Pow/Sqrt/Sign/Log/Log10/Exp, Guid.NewGuid(), and DateTime member access/arithmetic -- all previously unsupported and either throwing at query-compile time or silently mistranslating.