### PR TITLE
Add configurable DateTimeFormat option (CBEF-23 follow-up)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,12 @@ and this project aims to follow [Semantic Versioning](https://semver.org/spec/v2
   `DateTime`/`Guid` member access) had no translator at all. See
   [Querying — Supported functions](docs/Queries.md#supported-functions) for the full list and what
   remains unsupported (`Math.Min`/`Max`, trig functions).
+- **`DateTimeFormat` option.** Configures the .NET custom `DateTime` format string this provider
+  assumes when generating or comparing against `DateTime` string values in SQL++ — used by the
+  `.Date`/`.Now`/`.UtcNow`/`.Today` translators and for inline `DateTime` literals. Defaults to
+  `"yyyy-MM-ddTHH:mm:ss.FFFK"` (this provider's own default serialization), but is configurable
+  since N1QL has no native date type and data can legitimately be stored in a different
+  convention. See [Configuration — DateTime string format](docs/configuration.md#datetime-string-format).
 
 ### Fixed
 
@@ -32,14 +38,24 @@ and this project aims to follow [Semantic Versioning](https://semver.org/spec/v2
   boolean masquerading as an `int`. Fixed to use `POSITION`, which matches `IndexOf`'s exact
   semantics (zero-based, `-1` if not found).
 
+- **`CouchbaseDateTimeMemberTranslator` hardcoded a Go-layout format constant** for
+  `.Date`/`.Now`/`.UtcNow`/`.Today`, assuming every `DateTime` was stored in this provider's own
+  default format. Now driven by the configurable `DateTimeFormat` option instead.
+
+- **`CouchbaseTypeMappingSource` used EF Core's stock `DateTimeTypeMapping`**, which generates a
+  `TIMESTAMP 'yyyy-MM-dd HH:mm:ss.fffffff'` literal for inline `DateTime` constants — a syntax no
+  N1QL date-string convention uses and likely invalid SQL++. New `CouchbaseDateTimeTypeMapping`
+  generates a plain quoted string literal in the configured `DateTimeFormat` instead.
+
 - **`CouchbaseOptionsExtensionInfo.ShouldUseSameServiceProvider`/`GetServiceProviderHashCode` did
-  not account for `AutoCreateScopes`, `ScanConsistency`, or `FieldNamingPolicy`** (in addition to
-  the new `AutoCreateIndexes`). Two `DbContext`s that shared a connection string/bucket/scope/
-  service key but differed in one of these settings were judged "equivalent" by EF Core and could
-  share one internal service provider — including its singleton `ICouchbaseDbContextOptionsBuilder`
-  — silently causing one context to run with the other's setting instead of its own. Caught via a
-  reproducible test-suite flake while validating `AutoCreateIndexes` under concurrent load; fixed
-  by including all of these in both methods, and `SerializerOptions` via reference equality.
+  not account for `AutoCreateScopes`, `ScanConsistency`, `FieldNamingPolicy`, or `DateTimeFormat`**
+  (in addition to the new `AutoCreateIndexes`). Two `DbContext`s that shared a connection string/
+  bucket/scope/service key but differed in one of these settings were judged "equivalent" by EF
+  Core and could share one internal service provider — including its singleton
+  `ICouchbaseDbContextOptionsBuilder` — silently causing one context to run with the other's
+  setting instead of its own. Caught via a reproducible test-suite flake while validating
+  `AutoCreateIndexes` under concurrent load; fixed by including all of these in both methods, and
+  `SerializerOptions` via reference equality.
 
 ## [2.0.0-beta.2] - 2026-07-15
 

--- a/docs/Queries.md
+++ b/docs/Queries.md
@@ -146,9 +146,13 @@ are escaped once at translation time; parameter/column patterns are escaped at q
 nested `REPLACE` calls) so a literal `%` or `_` in the search text is matched literally rather than
 treated as a wildcard.
 
-`DateTime` comparisons/arithmetic work against the ISO-8601 string format the provider stores
-(millisecond precision, e.g. `2026-03-14T09:26:53.123Z`, with the fractional-seconds group and its
-decimal point entirely omitted when milliseconds are exactly zero, e.g. `2026-03-14T00:00:00Z`).
+`fmt` in the table above is the [`DateTimeFormat`](configuration.md#datetime-string-format) option
+(converted to the equivalent Go layout N1QL's date functions expect) — it defaults to this
+provider's own default `DateTime` serialization (millisecond precision, e.g.
+`2026-03-14T09:26:53.123Z`, with the fractional-seconds group and its decimal point entirely
+omitted when milliseconds are exactly zero, e.g. `2026-03-14T00:00:00Z`), but is configurable if
+your data uses a different string convention — see
+[DateTime string format](configuration.md#datetime-string-format).
 
 Not yet supported: `Math.Min`/`Math.Max` (N1QL's `ARRAY_MAX`/`ARRAY_MIN` take a single array
 argument, not two scalars — no array-literal expression support exists yet to build one), trig

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -55,6 +55,7 @@ The [CouchbaseDbContextOptionsBuilder](https://github.com/couchbaselabs/couchbas
 | `AutoCreateIndexes` | `false` | Whether `EnsureCreatedAsync` automatically creates a primary index on every collection it creates or already owns, waiting for each index to come online before returning. Does not create secondary indexes — see [Limitations](limitations.md#schema-management-and-migrations). |
 | `FieldNamingPolicy` | `JsonNamingPolicy.CamelCase` | Controls how CLR navigation names are converted to JSON field names when reading/writing `OwnsMany` embedded collections. Set to `null` to use the CLR name verbatim (PascalCase), or supply a different policy such as `JsonNamingPolicy.SnakeCaseLower`. |
 | `SerializerOptions` | `null` (uses `JsonSerializerDefaults.Web`) | `JsonSerializerOptions` used when deserializing scalar values inside `OwnsMany` collections. Supply a custom instance to match a non-default serializer configured on the Couchbase SDK (custom converters, different enum handling, etc.). |
+| `DateTimeFormat` | `"yyyy-MM-ddTHH:mm:ss.FFFK"` | The .NET custom `DateTime` format string this provider assumes when generating or comparing against `DateTime` string values in SQL++ — used by the LINQ `DateTime` function translators (`.Date`, `.Now`, `.UtcNow`, `.Today`) and for inline `DateTime` literals. See [DateTime string format](#datetime-string-format) below. |
 | `ServiceKey` | `null` | Selects which application-registered, keyed Couchbase cluster this context uses — see [Multiple clusters](#multiple-clusters). |
 
 > [!NOTE]
@@ -63,6 +64,49 @@ The [CouchbaseDbContextOptionsBuilder](https://github.com/couchbaselabs/couchbas
 > handled by [EFCore.NamingConventions](#controlling-querying-casing). If you change one, make sure
 > it still matches the other (and your actual document casing), or fields will silently come back
 > with default values instead of an error — see [Controlling Querying Casing](#controlling-querying-casing).
+
+### DateTime string format
+
+N1QL has no native date type — a `DateTime` is stored as a plain JSON string, so nothing stops
+different data from using a different string convention (a different precision, a date-only value,
+or data written by another system entirely). The `DateTimeFormat` option tells the provider which
+convention your data actually uses, so `.Date`/`.Now`/`.UtcNow`/`.Today` comparisons and generated
+`DateTime` literals stay correct instead of assuming one hardcoded format.
+
+`DateTimeFormat` is a .NET custom `DateTime` format string. The default,
+`"yyyy-MM-ddTHH:mm:ss.FFFK"`, matches this provider's own default `DateTime` serialization
+(millisecond precision, `Z` for UTC or a real offset otherwise — e.g. `2026-03-14T09:26:53.123Z`).
+Only the following tokens are supported (the ISO-8601-relevant subset — internally converted to
+the equivalent [Go reference-time](https://pkg.go.dev/time#pkg-constants) layout N1QL's date
+functions expect):
+
+| Token | Meaning |
+|---|---|
+| `yyyy` | 4-digit year |
+| `MM` | 2-digit month |
+| `dd` | 2-digit day |
+| `HH` | 2-digit hour (24-hour) |
+| `mm` | 2-digit minute |
+| `ss` | 2-digit second |
+| `f` (repeated 1–7 times) | Fixed-width fractional seconds |
+| `F` (repeated 1–7 times) | Trimmed fractional seconds (dropped, along with the decimal point, when the value is exactly zero) |
+| `K` | `Z` for UTC, or a real `+hh:mm`/`-hh:mm` offset |
+| `T` | Literal `T` — not a reserved .NET specifier, so it needs no quoting (unlike other letters) |
+| non-letter characters (`-`, `:`, `.`, space, etc.) | Passed through as literal separators |
+| `'...'` / `"..."` | A quoted literal string, copied through verbatim (needed to use a letter — other than `T` — as a literal, e.g. `'Z'`) |
+| `\x` | Escapes the next character `x` as a literal, usable inside or outside a quoted section |
+
+Any other bare letter (`tt`, `ddd`, `zzz`, 12-hour `hh`, an un-quoted `Z`, etc.) throws an
+`ArgumentException` at configuration time (when `DateTimeFormat` is set) naming the unsupported
+token, rather than failing later with a confusing SQL++ error. Configure it alongside your other
+provider options:
+
+```csharp
+couchbaseDbContextOptions.DateTimeFormat = "yyyy-MM-dd"; // date-only convention
+```
+
+This is unrelated to `FieldNamingPolicy` — `DateTimeFormat` controls how `DateTime` *values* are
+compared/generated in SQL++, while `FieldNamingPolicy` controls JSON *field name* casing.
 
 ## Multiple buckets and clusters
 

--- a/src/Couchbase.EntityFrameworkCore/Extensions/CouchbaseDbContextOptionsBuilderExtensions.cs
+++ b/src/Couchbase.EntityFrameworkCore/Extensions/CouchbaseDbContextOptionsBuilderExtensions.cs
@@ -64,6 +64,20 @@ public static class CouchbaseDbContextOptionsBuilderExtensions
         return builder;
     }
 
+    /// <summary>
+    /// Sets the .NET custom <see cref="DateTime"/> format string this provider assumes when
+    /// comparing against or generating <see cref="DateTime"/> string values in SQL++. Defaults to
+    /// <c>"yyyy-MM-ddTHH:mm:ss.FFFK"</c>. See <see cref="CouchbaseDbContextOptionsBuilder.DateTimeFormat"/>
+    /// for the supported token set.
+    /// </summary>
+    public static CouchbaseDbContextOptionsBuilder UseDateTimeFormat(
+        this CouchbaseDbContextOptionsBuilder builder,
+        string format)
+    {
+        builder.DateTimeFormat = format;
+        return builder;
+    }
+
     internal static void AddSaveChangesInterceptor(DbContextOptionsBuilder optionsBuilder)
     {
         var coreOptionsExtension = optionsBuilder.Options.FindExtension<CoreOptionsExtension>()

--- a/src/Couchbase.EntityFrameworkCore/Extensions/CouchbaseServiceCollectionExtensions.cs
+++ b/src/Couchbase.EntityFrameworkCore/Extensions/CouchbaseServiceCollectionExtensions.cs
@@ -21,6 +21,7 @@ using Microsoft.EntityFrameworkCore.Storage;
 using Microsoft.EntityFrameworkCore.Update;
 using Microsoft.EntityFrameworkCore.ValueGeneration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 using Couchbase.Extensions.DependencyInjection;
 using Microsoft.EntityFrameworkCore.Query.Internal;
 using Microsoft.Extensions.Logging;
@@ -48,8 +49,19 @@ public static class CouchbaseServiceCollectionExtensions
     {
         serviceCollection.AddLogging(); //this should be injectable from the app side
 
+        // IRelationalTypeMappingSource is Singleton-lifetime (EF Core), while
+        // ICouchbaseDbContextOptionsBuilder (which carries DateTimeFormat) is Scoped --
+        // constructor-injecting the latter into the former would be a captive-dependency
+        // mismatch. Instead, capture optionsExtension.DbContextOptionsBuilder.DateTimeFormat *by
+        // value* in this factory, registered before TryAddCoreServices() so it wins under the
+        // standard skip-if-already-registered TryAdd semantics (must come first here, unlike the
+        // remove-and-AddScoped services below, which sidestep ordering entirely).
+        serviceCollection.TryAddSingleton<IRelationalTypeMappingSource>(sp => new CouchbaseTypeMappingSource(
+            sp.GetRequiredService<TypeMappingSourceDependencies>(),
+            sp.GetRequiredService<RelationalTypeMappingSourceDependencies>(),
+            optionsExtension.DbContextOptionsBuilder.DateTimeFormat));
+
         var builder = new EntityFrameworkRelationalServicesBuilder(serviceCollection)
-            .TryAdd<IRelationalTypeMappingSource, CouchbaseTypeMappingSource>()
             .TryAdd<IDatabaseProvider, DatabaseProvider<CouchbaseOptionsExtension>>()
             .TryAdd<LoggingDefinitions, CouchbaseLoggingDefinitions>()
             .TryAdd<IModificationCommandBatchFactory, CouchbaseModificationCommandBatchFactory>()

--- a/src/Couchbase.EntityFrameworkCore/Infrastructure/CouchbaseDbContextOptionsBuilder.cs
+++ b/src/Couchbase.EntityFrameworkCore/Infrastructure/CouchbaseDbContextOptionsBuilder.cs
@@ -1,5 +1,6 @@
 using System.Text.Json;
 using Couchbase.EntityFrameworkCore.Extensions;
+using Couchbase.EntityFrameworkCore.Storage.Internal;
 using Couchbase.Query;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
@@ -38,6 +39,24 @@ public class CouchbaseDbContextOptionsBuilder : ICouchbaseDbContextOptionsBuilde
     public bool AutoCreateIndexes { get; set; }
 
     public JsonNamingPolicy? FieldNamingPolicy { get; set; } = JsonNamingPolicy.CamelCase;
+
+    private string _dateTimeFormat = "yyyy-MM-ddTHH:mm:ss.FFFK";
+    private string _goDateTimeFormat = DotNetToGoDateFormatConverter.Convert("yyyy-MM-ddTHH:mm:ss.FFFK");
+
+    public string DateTimeFormat
+    {
+        get => _dateTimeFormat;
+        set
+        {
+            // Convert eagerly so an unsupported token throws here, at configuration time, rather
+            // than being deferred to whenever GoDateTimeFormat first happens to be read (typically
+            // first query compilation) -- the XML doc on the interface promises the former.
+            _goDateTimeFormat = DotNetToGoDateFormatConverter.Convert(value);
+            _dateTimeFormat = value;
+        }
+    }
+
+    public string GoDateTimeFormat => _goDateTimeFormat;
 
     public JsonSerializerOptions? SerializerOptions { get; set; }
 
@@ -128,6 +147,38 @@ public interface ICouchbaseDbContextOptionsBuilder
     /// such as <see cref="JsonNamingPolicy.SnakeCaseLower"/>.
     /// </summary>
     public JsonNamingPolicy? FieldNamingPolicy { get; set; }
+
+    /// <summary>
+    /// The .NET custom <see cref="DateTime"/> format string this provider assumes when comparing
+    /// against or generating <see cref="DateTime"/> string values in SQL++ — used for the LINQ
+    /// <c>DateTime</c> function translators (<c>.Date</c>, <c>.Now</c>, <c>.UtcNow</c>, <c>.Today</c>)
+    /// and for generating inline <see cref="DateTime"/> literals. Defaults to
+    /// <c>"yyyy-MM-ddTHH:mm:ss.FFFK"</c> — millisecond-precision ISO-8601 with <c>Z</c> for UTC or
+    /// a real offset otherwise — matching this provider's own default <see cref="DateTime"/>
+    /// serialization.
+    /// </summary>
+    /// <remarks>
+    /// N1QL has no native date type — dates are just JSON strings — so nothing stops a
+    /// <see cref="DateTime"/> from being stored in a different format (date-only, different
+    /// precision, or written by another system entirely). Set this to match your actual stored
+    /// format if it differs from the default; a mismatch produces wrong comparisons, not an error.
+    /// Only a bounded, ISO-8601-relevant subset of .NET custom format tokens is supported:
+    /// <c>yyyy</c>, <c>MM</c>, <c>dd</c>, <c>HH</c>, <c>mm</c>, <c>ss</c>, <c>f</c>/<c>F</c>
+    /// (repeated 1-7 times), <c>K</c>, non-letter literal separator characters (<c>-</c>,
+    /// <c>:</c>, <c>.</c>, space), and the literal <c>T</c> (not a reserved .NET specifier, so it
+    /// needs no quoting). A quoted literal string (<c>'...'</c>/<c>"..."</c>) or a
+    /// backslash-escaped character (<c>\x</c>) can be used to include any other literal text,
+    /// including letters — an unsupported bare token throws <see cref="ArgumentException"/>
+    /// as soon as this is set, rather than producing a confusing SQL++ error later.
+    /// </remarks>
+    public string DateTimeFormat { get; set; }
+
+    /// <summary>
+    /// The Go reference-time layout string equivalent of <see cref="DateTimeFormat"/>, computed
+    /// automatically. N1QL's date functions (<c>DATE_TRUNC_STR</c>, <c>NOW_LOCAL</c>,
+    /// <c>NOW_UTC</c>) expect their <c>fmt</c> argument in this layout language, not .NET's.
+    /// </summary>
+    public string GoDateTimeFormat { get; }
 
     /// <summary>
     /// <see cref="JsonSerializerOptions"/> used when deserializing scalar values inside

--- a/src/Couchbase.EntityFrameworkCore/Infrastructure/Internal/CouchbaseOptionsExtension.cs
+++ b/src/Couchbase.EntityFrameworkCore/Infrastructure/Internal/CouchbaseOptionsExtension.cs
@@ -183,6 +183,8 @@ public class CouchbaseOptionsExtension: RelationalOptionsExtension
                 Extension._couchbaseDbContextOptionsBuilder.AutoCreateIndexes,
                 Extension._couchbaseDbContextOptionsBuilder.ScanConsistency,
                 Extension._couchbaseDbContextOptionsBuilder.FieldNamingPolicy),
+            // Nested again: HashCode.Combine caps at 8 arguments, and the group above is already full.
+            Extension._couchbaseDbContextOptionsBuilder.DateTimeFormat,
             // JsonSerializerOptions has no value equality, so this is intentionally reference
             // equality — two contexts built with separate (even if equivalently-configured)
             // instances won't share a provider, which is safe (just slightly less sharing) rather
@@ -206,6 +208,7 @@ public class CouchbaseOptionsExtension: RelationalOptionsExtension
                 && Extension._couchbaseDbContextOptionsBuilder.AutoCreateIndexes == otherInfo.Extension._couchbaseDbContextOptionsBuilder.AutoCreateIndexes
                 && Extension._couchbaseDbContextOptionsBuilder.ScanConsistency == otherInfo.Extension._couchbaseDbContextOptionsBuilder.ScanConsistency
                 && Extension._couchbaseDbContextOptionsBuilder.FieldNamingPolicy == otherInfo.Extension._couchbaseDbContextOptionsBuilder.FieldNamingPolicy
+                && Extension._couchbaseDbContextOptionsBuilder.DateTimeFormat == otherInfo.Extension._couchbaseDbContextOptionsBuilder.DateTimeFormat
                 && ReferenceEquals(Extension._couchbaseDbContextOptionsBuilder.SerializerOptions, otherInfo.Extension._couchbaseDbContextOptionsBuilder.SerializerOptions)
                 && ReferenceEquals(ApplicationContainerIdentity, otherInfo.ApplicationContainerIdentity);
 

--- a/src/Couchbase.EntityFrameworkCore/Query/Internal/Translators/CouchbaseDateTimeMemberTranslator.cs
+++ b/src/Couchbase.EntityFrameworkCore/Query/Internal/Translators/CouchbaseDateTimeMemberTranslator.cs
@@ -1,4 +1,5 @@
 using System.Reflection;
+using Couchbase.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.Query;
@@ -8,37 +9,33 @@ namespace Couchbase.EntityFrameworkCore.Query.Internal.Translators;
 
 /// <summary>
 /// Translates <see cref="DateTime"/> member access to SQL++. This provider's <see cref="DateTime"/>
-/// type mapping is <c>STRING</c> (ISO-8601), and the stored/parameter format was confirmed
-/// empirically (CBEF-23 step-0 spike, <c>DateTimeFormatSpikeTests</c>) to be millisecond-precision
-/// with a literal <c>Z</c> suffix for UTC values, e.g. <c>2026-03-14T09:26:53.123Z</c> --
-/// <see cref="Fmt"/> reproduces that format for every N1QL date function that accepts an explicit
-/// format string, so results stay comparable against already-stored data.
+/// type mapping is <c>STRING</c> (ISO-8601). The format used for every N1QL date function that
+/// accepts an explicit format string is <see cref="ICouchbaseDbContextOptionsBuilder.GoDateTimeFormat"/>
+/// -- the Go reference-time layout equivalent of the user-configurable
+/// <see cref="ICouchbaseDbContextOptionsBuilder.DateTimeFormat"/> -- so results stay comparable
+/// against however the user's <see cref="DateTime"/> data is actually stored, rather than assuming
+/// one hardcoded format (N1QL has no native date type; dates are just JSON strings, so nothing
+/// stops a user from storing a different convention). The default format
+/// (<c>"yyyy-MM-ddTHH:mm:ss.FFFK"</c>) was confirmed empirically (CBEF-23 step-0 spike,
+/// <c>DateTimeFormatSpikeTests</c>) to match this provider's own default <see cref="DateTime"/>
+/// serialization -- millisecond-precision with a literal <c>Z</c> suffix for UTC values, e.g.
+/// <c>2026-03-14T09:26:53.123Z</c>.
 /// <para>
-/// Non-obvious gotcha, confirmed against a live cluster: the fractional-seconds group must use
-/// Go's <c>.999</c> trimming convention, not a fixed-width <c>.000</c>. .NET's serializer omits
-/// the fractional group entirely (and the decimal point with it) when milliseconds are exactly
-/// zero -- e.g. midnight serializes as <c>2026-03-14T00:00:00Z</c>, with no <c>.000</c> at all.
-/// A fixed-width format produces a string that never matches such a parameter.
-/// </para>
-/// <para>
-/// Second gotcha: the offset directive must be <c>Z07:00</c>, not a literal <c>Z</c>. A literal
-/// <c>Z</c> is only correct for UTC values (<c>NOW_UTC</c>, <c>DATE_PART_STR</c>/<c>DATE_TRUNC_STR</c>
-/// on the UTC-stored data this provider writes) -- <c>NOW_LOCAL</c> (<see cref="DateTime.Now"/>)
-/// returns a value in the query service's local timezone, which is not UTC in general, so forcing
-/// a trailing <c>Z</c> onto it would produce a string that both lies about the offset and won't
-/// match how a <see cref="DateTimeKind.Local"/> value actually serializes (typically a real
-/// <c>+hh:mm</c>/<c>-hh:mm</c> offset). <c>Z07:00</c> renders <c>Z</c> when the offset is zero and
-/// the real offset otherwise, so the same format string is correct for both cases.
+/// Two non-obvious gotchas that motivated the default format's exact token choices, both confirmed
+/// against a live cluster (see <see cref="DotNetToGoDateFormatConverter"/> for the token mapping):
+/// (1) the fractional-seconds group must use .NET's <c>F</c> (trimmed) specifier / Go's <c>.999</c>
+/// convention, not a fixed-width <c>f</c>/<c>.000</c> -- .NET's serializer omits the fractional
+/// group entirely (and the decimal point with it) when milliseconds are exactly zero, e.g. midnight
+/// serializes as <c>2026-03-14T00:00:00Z</c> with no <c>.000</c> at all, so a fixed-width format
+/// would never match such a value. (2) the offset directive must be .NET's <c>K</c> / Go's
+/// <c>Z07:00</c>, not a literal <c>Z</c> -- a literal <c>Z</c> is only correct for UTC values
+/// (<c>NOW_UTC</c>, <c>DATE_PART_STR</c>/<c>DATE_TRUNC_STR</c> on UTC-stored data) but
+/// <c>NOW_LOCAL</c> (<see cref="DateTime.Now"/>) returns a value in the query service's local
+/// timezone, which is not UTC in general.
 /// </para>
 /// </summary>
 public class CouchbaseDateTimeMemberTranslator : IMemberTranslator
 {
-    // N1QL's Go-reference-time format style; .999 mirrors .NET's variable-width fractional
-    // seconds (trimmed, including the dot, when all-zero) rather than always padding to 3 digits.
-    // Z07:00 emits Z for a zero offset (UTC) and a real +hh:mm/-hh:mm offset otherwise, rather
-    // than forcing an incorrect literal Z onto non-UTC values (see NOW_LOCAL usage below).
-    private const string Fmt = "2006-01-02T15:04:05.999Z07:00";
-
     private static readonly IReadOnlyDictionary<MemberInfo, string> DatePartMappings = new Dictionary<MemberInfo, string>
     {
         { GetDateTimeProperty(nameof(DateTime.Year)), "year" },
@@ -58,10 +55,14 @@ public class CouchbaseDateTimeMemberTranslator : IMemberTranslator
     private static readonly MemberInfo TodayMemberInfo = GetDateTimeProperty(nameof(DateTime.Today));
 
     private readonly ISqlExpressionFactory _sqlExpressionFactory;
+    private readonly string _fmt;
 
-    public CouchbaseDateTimeMemberTranslator(ISqlExpressionFactory sqlExpressionFactory)
+    public CouchbaseDateTimeMemberTranslator(
+        ISqlExpressionFactory sqlExpressionFactory,
+        ICouchbaseDbContextOptionsBuilder optionsBuilder)
     {
         _sqlExpressionFactory = sqlExpressionFactory;
+        _fmt = optionsBuilder.GoDateTimeFormat;
     }
 
     public virtual SqlExpression? Translate(
@@ -84,7 +85,7 @@ public class CouchbaseDateTimeMemberTranslator : IMemberTranslator
         {
             return _sqlExpressionFactory.Function(
                 "DATE_TRUNC_STR",
-                new[] { instance, _sqlExpressionFactory.Constant("day"), _sqlExpressionFactory.Constant(Fmt) },
+                new[] { instance, _sqlExpressionFactory.Constant("day"), _sqlExpressionFactory.Constant(_fmt) },
                 nullable: true,
                 argumentsPropagateNullability: new[] { true, false, false },
                 returnType,
@@ -95,7 +96,7 @@ public class CouchbaseDateTimeMemberTranslator : IMemberTranslator
         {
             return _sqlExpressionFactory.Function(
                 "NOW_LOCAL",
-                new[] { _sqlExpressionFactory.Constant(Fmt) },
+                new[] { _sqlExpressionFactory.Constant(_fmt) },
                 nullable: false,
                 argumentsPropagateNullability: new[] { false },
                 returnType);
@@ -105,7 +106,7 @@ public class CouchbaseDateTimeMemberTranslator : IMemberTranslator
         {
             return _sqlExpressionFactory.Function(
                 "NOW_UTC",
-                new[] { _sqlExpressionFactory.Constant(Fmt) },
+                new[] { _sqlExpressionFactory.Constant(_fmt) },
                 nullable: false,
                 argumentsPropagateNullability: new[] { false },
                 returnType);
@@ -115,14 +116,14 @@ public class CouchbaseDateTimeMemberTranslator : IMemberTranslator
         {
             var nowUtc = _sqlExpressionFactory.Function(
                 "NOW_UTC",
-                new[] { _sqlExpressionFactory.Constant(Fmt) },
+                new[] { _sqlExpressionFactory.Constant(_fmt) },
                 nullable: false,
                 argumentsPropagateNullability: new[] { false },
                 returnType);
 
             return _sqlExpressionFactory.Function(
                 "DATE_TRUNC_STR",
-                new[] { nowUtc, _sqlExpressionFactory.Constant("day"), _sqlExpressionFactory.Constant(Fmt) },
+                new[] { nowUtc, _sqlExpressionFactory.Constant("day"), _sqlExpressionFactory.Constant(_fmt) },
                 nullable: false,
                 argumentsPropagateNullability: new[] { false, false, false },
                 returnType);

--- a/src/Couchbase.EntityFrameworkCore/Query/Internal/Translators/CouchbaseMemberTranslatorProvider.cs
+++ b/src/Couchbase.EntityFrameworkCore/Query/Internal/Translators/CouchbaseMemberTranslatorProvider.cs
@@ -1,10 +1,14 @@
+using Couchbase.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Query;
 
 namespace Couchbase.EntityFrameworkCore.Query.Internal.Translators;
 
 public class CouchbaseMemberTranslatorProvider : RelationalMemberTranslatorProvider
 {
-    public CouchbaseMemberTranslatorProvider(RelationalMemberTranslatorProviderDependencies dependencies) : base(dependencies)
+    public CouchbaseMemberTranslatorProvider(
+        RelationalMemberTranslatorProviderDependencies dependencies,
+        ICouchbaseDbContextOptionsBuilder optionsBuilder)
+        : base(dependencies)
     {
         var sqlExpressionFactory = dependencies.SqlExpressionFactory;
 
@@ -12,7 +16,7 @@ public class CouchbaseMemberTranslatorProvider : RelationalMemberTranslatorProvi
             new IMemberTranslator[]
             {
                 new CouchbaseStringMemberTranslator(sqlExpressionFactory),
-                new CouchbaseDateTimeMemberTranslator(sqlExpressionFactory),
+                new CouchbaseDateTimeMemberTranslator(sqlExpressionFactory, optionsBuilder),
             });
     }
 }

--- a/src/Couchbase.EntityFrameworkCore/Storage/Internal/CouchbaseDateTimeTypeMapping.cs
+++ b/src/Couchbase.EntityFrameworkCore/Storage/Internal/CouchbaseDateTimeTypeMapping.cs
@@ -1,0 +1,75 @@
+using Microsoft.EntityFrameworkCore.Storage;
+
+namespace Couchbase.EntityFrameworkCore.Storage.Internal;
+
+/// <summary>
+/// Type mapping for <see cref="DateTime"/> values in Couchbase SQL++.
+/// </summary>
+/// <remarks>
+/// The stock EF Core <see cref="DateTimeTypeMapping"/> generates inline literals as
+/// <c>TIMESTAMP 'yyyy-MM-dd HH:mm:ss.fffffff'</c> — a SQL-standard typed-literal syntax no N1QL
+/// date-string convention uses, and a fixed format that ignores
+/// <see cref="Infrastructure.CouchbaseDbContextOptionsBuilder.DateTimeFormat"/>. This subclass
+/// overrides <see cref="SqlLiteralFormatString"/> (the composite format string
+/// <see cref="RelationalTypeMapping.GenerateNonNullSqlLiteral"/> feeds through
+/// <see cref="string.Format(System.Globalization.CultureInfo,string,object?)"/>) to use the
+/// configured format directly as a plain quoted string literal instead.
+/// </remarks>
+public class CouchbaseDateTimeTypeMapping : DateTimeTypeMapping
+{
+    private readonly string _dateTimeFormat;
+    private readonly string _goDateTimeFormat;
+
+    public CouchbaseDateTimeTypeMapping(string dateTimeFormat)
+        : base("STRING", System.Data.DbType.DateTime)
+    {
+        // Converted eagerly, in the constructor, so an unsupported token throws as soon as this
+        // mapping is constructed (model-build time for a per-property override) rather than being
+        // deferred to whenever GoDateTimeFormat first happens to be read.
+        _goDateTimeFormat = DotNetToGoDateFormatConverter.Convert(dateTimeFormat);
+        _dateTimeFormat = dateTimeFormat;
+    }
+
+    /// <summary>
+    /// The Go reference-time layout equivalent of this mapping's .NET format string, for use in
+    /// N1QL date functions (<c>DATE_TRUNC_STR</c>, <c>NOW_UTC</c>, <c>NOW_LOCAL</c>, etc.), which
+    /// expect a Go-style layout rather than a .NET custom format string.
+    /// </summary>
+    public string GoDateTimeFormat => _goDateTimeFormat;
+
+    /// <summary>
+    /// Creates a new instance from existing parameters (used for cloning).
+    /// </summary>
+    protected CouchbaseDateTimeTypeMapping(RelationalTypeMappingParameters parameters, string dateTimeFormat)
+        : base(parameters)
+    {
+        _goDateTimeFormat = DotNetToGoDateFormatConverter.Convert(dateTimeFormat);
+        _dateTimeFormat = dateTimeFormat;
+    }
+
+    /// <inheritdoc />
+    protected override RelationalTypeMapping Clone(RelationalTypeMappingParameters parameters)
+        => new CouchbaseDateTimeTypeMapping(parameters, _dateTimeFormat);
+
+    /// <inheritdoc />
+    protected override string SqlLiteralFormatString => $"'{{0:{_dateTimeFormat}}}'";
+}
+
+/* ************************************************************
+ *
+ *    @author Couchbase <info@couchbase.com>
+ *    @copyright 2025 Couchbase, Inc.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ *
+ * ************************************************************/

--- a/src/Couchbase.EntityFrameworkCore/Storage/Internal/CouchbaseTypeMappingSource.cs
+++ b/src/Couchbase.EntityFrameworkCore/Storage/Internal/CouchbaseTypeMappingSource.cs
@@ -24,7 +24,8 @@ public class CouchbaseTypeMappingSource : RelationalTypeMappingSource
 
     public CouchbaseTypeMappingSource(
         TypeMappingSourceDependencies dependencies,
-        RelationalTypeMappingSourceDependencies relationalDependencies)
+        RelationalTypeMappingSourceDependencies relationalDependencies,
+        string dateTimeFormat)
         : base(dependencies, relationalDependencies)
     {
         _clrTypeMappings = new Dictionary<Type, RelationalTypeMapping>
@@ -50,7 +51,7 @@ public class CouchbaseTypeMappingSource : RelationalTypeMappingSource
             { typeof(char), new CharTypeMapping("STRING", DbType.StringFixedLength) },
 
             // Date/time types -> STRING (ISO 8601 format)
-            { typeof(DateTime), new DateTimeTypeMapping("STRING", DbType.DateTime) },
+            { typeof(DateTime), new CouchbaseDateTimeTypeMapping(dateTimeFormat) },
             { typeof(DateTimeOffset), new DateTimeOffsetTypeMapping("STRING", DbType.DateTimeOffset) },
             { typeof(DateOnly), new DateOnlyTypeMapping("STRING") },
             { typeof(TimeOnly), new TimeOnlyTypeMapping("STRING") },

--- a/src/Couchbase.EntityFrameworkCore/Storage/Internal/DotNetToGoDateFormatConverter.cs
+++ b/src/Couchbase.EntityFrameworkCore/Storage/Internal/DotNetToGoDateFormatConverter.cs
@@ -1,0 +1,207 @@
+using System.Text;
+
+namespace Couchbase.EntityFrameworkCore.Storage.Internal;
+
+/// <summary>
+/// Translates a bounded, ISO-8601-relevant subset of .NET custom <see cref="DateTime"/> format
+/// tokens into the equivalent Go reference-time layout tokens N1QL's date functions
+/// (<c>DATE_TRUNC_STR</c>, <c>NOW_LOCAL</c>, <c>NOW_UTC</c>) expect for their <c>fmt</c> argument.
+/// </summary>
+/// <remarks>
+/// This is deliberately not a general-purpose .NET-format-string engine: it recognizes exactly the
+/// tokens needed to express ISO-8601-family date/timestamp conventions (the ones Couchbase's own
+/// N1QL documentation recommends) and throws a clear <see cref="ArgumentException"/> naming the
+/// unsupported token for anything else, rather than silently producing a wrong or nonsensical Go
+/// layout string that would only surface as a confusing SQL++ error (or worse, a wrong result)
+/// later at query time.
+/// <para>
+/// It does honor .NET's two general-purpose escaping mechanisms -- a <c>'...'</c>/<c>"..."</c>
+/// quoted literal string and a <c>\x</c> backslash escape -- since without them a very common way
+/// to write this exact ISO-8601 pattern, <c>"yyyy-MM-dd'T'HH:mm:ss"</c>, would have its quoted
+/// <c>T</c> passed through as literal quote characters plus a T, producing a Go layout that never
+/// matches what <see cref="DateTime.ToString(string)"/> actually emits for that same format
+/// string (which strips the quotes and emits just <c>T</c>).
+/// </para>
+/// </remarks>
+public static class DotNetToGoDateFormatConverter
+{
+    // Case-sensitive: .NET's 'M' (month) and 'm' (minute) tokens are distinct, matching how the
+    // character-run scan below treats them as separate runs.
+    private static readonly IReadOnlyDictionary<(char Character, int Length), string> ExactTokenMappings =
+        new Dictionary<(char, int), string>
+        {
+            { ('y', 4), "2006" },
+            { ('M', 2), "01" },
+            { ('d', 2), "02" },
+            { ('H', 2), "15" },
+            { ('m', 2), "04" },
+            { ('s', 2), "05" },
+            { ('K', 1), "Z07:00" },
+        };
+
+    /// <summary>
+    /// Converts a .NET custom <see cref="DateTime"/> format string to the equivalent Go
+    /// reference-time layout string.
+    /// </summary>
+    /// <exception cref="ArgumentException">
+    /// The format string contains a token this converter does not recognize, an unterminated
+    /// literal string section, or a trailing escape character.
+    /// </exception>
+    public static string Convert(string dotNetFormat)
+    {
+        var result = new StringBuilder(dotNetFormat.Length);
+        var i = 0;
+
+        while (i < dotNetFormat.Length)
+        {
+            var c = dotNetFormat[i];
+
+            // .NET custom format strings support two escaping mechanisms, both of which must be
+            // honored BEFORE any token interpretation -- otherwise, e.g., "yyyy-MM-dd'T'HH:mm:ss"
+            // (a very common way to write this exact ISO-8601 pattern) would have its quoted 'T'
+            // passed through as two literal quote characters plus a T, producing a Go layout that
+            // never matches what .NET's own DateTime.ToString actually emits (which strips the
+            // quotes and emits just "T"): (1) a literal string delimited by matching single or
+            // double quotes, whose contents are copied verbatim with no token interpretation, and
+            // (2) a backslash escaping exactly the next character, usable both inside and outside
+            // a literal string section.
+            if (c is '\'' or '"')
+            {
+                i = AppendLiteralSection(dotNetFormat, i, c, result);
+                continue;
+            }
+
+            if (c == '\\')
+            {
+                if (i + 1 >= dotNetFormat.Length)
+                {
+                    throw new ArgumentException(
+                        $"Format string \"{dotNetFormat}\" ends with a trailing escape character ('\\') with no character to escape.",
+                        nameof(dotNetFormat));
+                }
+
+                result.Append(dotNetFormat[i + 1]);
+                i += 2;
+                continue;
+            }
+
+            // Uppercase 'T' -- the ISO-8601 date/time separator -- is not a reserved .NET custom
+            // format specifier (only lowercase 't'/'tt', the AM/PM designator, are reserved), so
+            // .NET itself passes it through literally without requiring it to be escaped. Treat it
+            // the same way here rather than mistaking it for an attempted, unsupported specifier.
+            if (!char.IsLetter(c) || c == 'T')
+            {
+                result.Append(c);
+                i++;
+                continue;
+            }
+
+            var runStart = i;
+            while (i < dotNetFormat.Length && dotNetFormat[i] == c)
+            {
+                i++;
+            }
+
+            var runLength = i - runStart;
+
+            if (c is 'f' or 'F')
+            {
+                if (runLength is < 1 or > 7)
+                {
+                    throw UnsupportedToken(dotNetFormat, c, runLength);
+                }
+
+                // Lowercase 'f' is .NET's fixed-width (zero-padded) fractional-seconds specifier;
+                // Go's matching directive is a run of '0'. Uppercase 'F' trims trailing zeros
+                // (and the decimal point itself if the whole fraction is zero); Go's matching
+                // directive is a run of '9'.
+                result.Append(c == 'f' ? '0' : '9', runLength);
+                continue;
+            }
+
+            if (ExactTokenMappings.TryGetValue((c, runLength), out var goToken))
+            {
+                result.Append(goToken);
+                continue;
+            }
+
+            throw UnsupportedToken(dotNetFormat, c, runLength);
+        }
+
+        return result.ToString();
+    }
+
+    /// <summary>
+    /// Appends the contents of a literal string section (delimited by matching single or double
+    /// quotes, starting at <paramref name="delimiterIndex"/>) to <paramref name="result"/>
+    /// verbatim -- no token interpretation inside the section -- honoring backslash escapes the
+    /// same way <see cref="Convert"/> does outside a literal section. Returns the index just past
+    /// the closing delimiter.
+    /// </summary>
+    private static int AppendLiteralSection(string dotNetFormat, int delimiterIndex, char delimiter, StringBuilder result)
+    {
+        var i = delimiterIndex + 1;
+
+        while (true)
+        {
+            if (i >= dotNetFormat.Length)
+            {
+                throw new ArgumentException(
+                    $"Format string \"{dotNetFormat}\" has an unterminated literal string starting at "
+                    + $"position {delimiterIndex} (missing closing '{delimiter}').",
+                    nameof(dotNetFormat));
+            }
+
+            var c = dotNetFormat[i];
+
+            if (c == '\\')
+            {
+                if (i + 1 >= dotNetFormat.Length)
+                {
+                    throw new ArgumentException(
+                        $"Format string \"{dotNetFormat}\" ends with a trailing escape character ('\\') with no character to escape.",
+                        nameof(dotNetFormat));
+                }
+
+                result.Append(dotNetFormat[i + 1]);
+                i += 2;
+                continue;
+            }
+
+            if (c == delimiter)
+            {
+                return i + 1;
+            }
+
+            result.Append(c);
+            i++;
+        }
+    }
+
+    private static ArgumentException UnsupportedToken(string dotNetFormat, char character, int runLength)
+        => new(
+            $"Unsupported DateTime format token '{new string(character, runLength)}' in \"{dotNetFormat}\". "
+            + "Supported tokens: yyyy, MM, dd, HH, mm, ss, f/F (repeated 1-7 times), K, the literal 'T', "
+            + "non-letter separator characters (e.g. '-', ':', '.', space), a quoted literal string "
+            + "('...' or \"...\"), or a backslash-escaped character (\\x) for any other literal text.",
+            nameof(dotNetFormat));
+}
+
+/* ************************************************************
+ *
+ *    @author Couchbase <info@couchbase.com>
+ *    @copyright 2025 Couchbase, Inc.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ *
+ * ************************************************************/

--- a/tests/Couchbase.EntityFrameworkCore.IntegrationTests/Tests/DateTimeCustomFormatTests.cs
+++ b/tests/Couchbase.EntityFrameworkCore.IntegrationTests/Tests/DateTimeCustomFormatTests.cs
@@ -1,0 +1,138 @@
+using Couchbase.EntityFrameworkCode.IntegrationTests.Fixtures;
+using Couchbase.EntityFrameworkCore;
+using Couchbase.EntityFrameworkCore.Extensions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+
+namespace Couchbase.EntityFrameworkCode.IntegrationTests.Tests;
+
+/// <summary>
+/// Proves the configurable <c>DateTimeFormat</c> option (added after CBEF-23 shipped a hardcoded
+/// Go-layout constant) actually round-trips against a real cluster, not just that it generates
+/// plausible-looking SQL text (already covered by
+/// <c>CouchbaseDateTimeFunctionSqlGenerationTests</c>'s unit tests). The document under test here
+/// is written directly via the SDK's KV API with its <c>published</c> field as a plain
+/// <c>"yyyy-MM-dd"</c> date-only string -- deliberately NOT this provider's own default
+/// serialization -- to simulate the exact scenario that motivated this option: N1QL has no native
+/// date type, so data written by another system (or an EF context configured differently) can be
+/// in a different, still-legitimate, string convention. The <see cref="DbContext"/> under test is
+/// configured with a matching <c>DateTimeFormat</c>, proving the LINQ <c>.Date</c>/<c>.Today</c>
+/// translators correctly use the configured format rather than the old hardcoded default.
+/// </summary>
+[Collection(CouchbaseTestingCollection.Name)]
+public class DateTimeCustomFormatTests(BloggingFixture fixture) : IAsyncLifetime
+{
+    private static readonly string CollectionName = "dtfmt" + Guid.NewGuid().ToString("N");
+    private static readonly DateTime StoredDate = new(DateTime.UtcNow.Year - 1, 3, 14);
+
+    private CustomFormatDbContext _context = null!;
+
+    public async Task InitializeAsync()
+    {
+        var optionsBuilder = new DbContextOptionsBuilder<CustomFormatDbContext>();
+        optionsBuilder.UseCouchbase(
+            new global::Couchbase.ClusterOptions()
+                .WithConnectionString(fixture.Host)
+                .WithPasswordAuthentication(fixture.Username, fixture.Password),
+            o =>
+            {
+                o.Bucket = fixture.BucketName;
+                o.Scope = fixture.ScopeName;
+                o.AutoCreateIndexes = true;
+                o.ScanConsistency = global::Couchbase.Query.QueryScanConsistency.RequestPlus;
+                // Deliberately different from the default ("yyyy-MM-ddTHH:mm:ss.FFFK") -- a
+                // date-only convention with no time component at all.
+                o.DateTimeFormat = "yyyy-MM-dd";
+            });
+        optionsBuilder.ConfigureWarnings(w => w.Ignore(CoreEventId.ManyServiceProvidersCreatedWarning));
+
+        _context = new CustomFormatDbContext(optionsBuilder.Options, CollectionName);
+        await _context.Database.EnsureCreatedAsync();
+
+        // Written directly via the KV API rather than SaveChangesAsync -- this provider's own
+        // default DateTime serialization always includes time-of-day/offset, so the only way to
+        // get a genuinely date-only stored string (the scenario this test exists to cover) is to
+        // bypass it and write the JSON exactly as a different DateTimeFormat convention expects.
+        // Must explicitly opt into SystemTextJsonSerializer, matching what CouchbaseOptionsExtension
+        // configures for the EF-managed cluster -- the SDK's own raw default (Newtonsoft-based)
+        // recases Dictionary keys to camelCase, which would silently corrupt the exact-casing
+        // "Id"/"Title"/"Published" field names EF's column-name convention expects.
+        var clusterOptions = new global::Couchbase.ClusterOptions()
+            .WithConnectionString(fixture.Host)
+            .WithPasswordAuthentication(fixture.Username, fixture.Password)
+            .WithSerializer(global::Couchbase.Core.IO.Serializers.SystemTextJsonSerializer.Create());
+        using var cluster = await global::Couchbase.Cluster.ConnectAsync(clusterOptions);
+        var bucket = await cluster.BucketAsync(fixture.BucketName);
+        var scope = await bucket.ScopeAsync(fixture.ScopeName);
+        var collection = scope.Collection(CollectionName);
+        // Regular (non-owned) properties keep their exact C# property name as the JSON field
+        // name by default (GetColumnName() == property name unless a [JsonPropertyName]-style
+        // attribute or convention overrides it) -- FieldNamingPolicy only affects owned-type
+        // navigation field names, not top-level scalar columns. A plain anonymous-object insert
+        // would get re-cased by the SDK's default serializer (it applies its own camelCase
+        // convention), so use a Dictionary<string, object> instead -- its keys are serialized
+        // verbatim, matching how this provider's own write path (HydrateObjectFromEntity)
+        // avoids the same pitfall for shared/owned document shapes.
+        await collection.InsertAsync("1", new Dictionary<string, object>
+        {
+            ["Id"] = 1L,
+            ["Title"] = "Custom Format Post",
+            ["Published"] = StoredDate.ToString("yyyy-MM-dd"),
+        });
+    }
+
+    [Fact]
+    public async Task Date_WithCustomDateOnlyFormat_MatchesStoredDateOnlyString()
+    {
+        var result = await _context.Entities.Where(e => e.Published.Date == StoredDate).ToListAsync();
+        Assert.Single(result);
+    }
+
+    [Fact]
+    public async Task Date_WithCustomDateOnlyFormat_ComparesBeforeToday()
+    {
+        // StoredDate is anchored to last year, so it must be strictly before today. Both sides of
+        // this comparison (the stored .Date truncation and DateTime.Today's NOW_UTC/DATE_TRUNC_STR
+        // translation) must use the SAME configured "yyyy-MM-dd" format for the string comparison
+        // to order correctly -- proving DateTimeFormat threads through both call sites.
+        var result = await _context.Entities.Where(e => e.Published.Date < DateTime.Today).ToListAsync();
+        Assert.Single(result);
+    }
+
+    public async Task DisposeAsync()
+    {
+        await _context.DisposeAsync();
+
+        try
+        {
+            var clusterOptions = new global::Couchbase.ClusterOptions()
+                .WithConnectionString(fixture.Host)
+                .WithCredentials(fixture.Username, fixture.Password);
+            using var cluster = await global::Couchbase.Cluster.ConnectAsync(clusterOptions);
+            var bucket = await cluster.BucketAsync(fixture.BucketName);
+            await bucket.Collections.DropCollectionAsync(fixture.ScopeName, CollectionName);
+        }
+        catch (global::Couchbase.Management.Collections.CollectionNotFoundException)
+        {
+        }
+    }
+
+    public class CustomFormatEntity
+    {
+        public long Id { get; set; }
+        public string Title { get; set; } = string.Empty;
+        public DateTime Published { get; set; }
+    }
+
+    public class CustomFormatDbContext(DbContextOptions<CustomFormatDbContext> options, string collectionName)
+        : DbContext(options)
+    {
+        public DbSet<CustomFormatEntity> Entities { get; set; } = null!;
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            base.OnModelCreating(modelBuilder);
+            modelBuilder.Entity<CustomFormatEntity>().ToCouchbaseCollection(this, collectionName);
+        }
+    }
+}

--- a/tests/Couchbase.EntityFrameworkCore.UnitTests/Couchbase/EntityFrameworkCore/Infrastructure/CouchbaseDbContextOptionsBuilderTests.cs
+++ b/tests/Couchbase.EntityFrameworkCore.UnitTests/Couchbase/EntityFrameworkCore/Infrastructure/CouchbaseDbContextOptionsBuilderTests.cs
@@ -155,4 +155,50 @@ public class CouchbaseDbContextOptionsBuilderTests
         // Assert
         Assert.Same(clusterOptions, builder.ClusterOptions);
     }
+
+    [Fact]
+    public void DateTimeFormat_DefaultsToIso8601MillisecondPrecision()
+    {
+        var builder = new CouchbaseDbContextOptionsBuilder(new DbContextOptionsBuilder(), "couchbase://localhost");
+
+        Assert.Equal("yyyy-MM-ddTHH:mm:ss.FFFK", builder.DateTimeFormat);
+        Assert.Equal("2006-01-02T15:04:05.999Z07:00", builder.GoDateTimeFormat);
+    }
+
+    [Fact]
+    public void DateTimeFormat_Setter_UpdatesGoDateTimeFormat()
+    {
+        var builder = new CouchbaseDbContextOptionsBuilder(new DbContextOptionsBuilder(), "couchbase://localhost");
+
+        builder.DateTimeFormat = "yyyy-MM-dd";
+
+        Assert.Equal("yyyy-MM-dd", builder.DateTimeFormat);
+        Assert.Equal("2006-01-02", builder.GoDateTimeFormat);
+    }
+
+    [Fact]
+    public void DateTimeFormat_Setter_WithUnsupportedToken_ThrowsImmediately()
+    {
+        // Must fail at configuration time (when DateTimeFormat is set), per the interface's own
+        // documented contract -- not deferred to whenever GoDateTimeFormat first happens to be
+        // read (typically first query compilation), which would turn a configuration mistake into
+        // a confusing failure far away from its cause.
+        var builder = new CouchbaseDbContextOptionsBuilder(new DbContextOptionsBuilder(), "couchbase://localhost");
+
+        Assert.Throws<ArgumentException>(() => builder.DateTimeFormat = "yyyy-MM-dd tt");
+    }
+
+    [Fact]
+    public void DateTimeFormat_Setter_WithUnsupportedToken_LeavesPreviousValueInPlace()
+    {
+        var builder = new CouchbaseDbContextOptionsBuilder(new DbContextOptionsBuilder(), "couchbase://localhost")
+        {
+            DateTimeFormat = "yyyy-MM-dd"
+        };
+
+        Assert.Throws<ArgumentException>(() => builder.DateTimeFormat = "yyyy-MM-dd tt");
+
+        Assert.Equal("yyyy-MM-dd", builder.DateTimeFormat);
+        Assert.Equal("2006-01-02", builder.GoDateTimeFormat);
+    }
 }

--- a/tests/Couchbase.EntityFrameworkCore.UnitTests/Couchbase/EntityFrameworkCore/Infrastructure/CouchbaseOptionsExtensionInfoTests.cs
+++ b/tests/Couchbase.EntityFrameworkCore.UnitTests/Couchbase/EntityFrameworkCore/Infrastructure/CouchbaseOptionsExtensionInfoTests.cs
@@ -173,6 +173,25 @@ public class CouchbaseOptionsExtensionInfoTests
     }
 
     [Fact]
+    public void DifferentDateTimeFormat_DoesNotShareServiceProvider()
+    {
+        var aBuilder = new CouchbaseDbContextOptionsBuilder(new DbContextOptionsBuilder(), "couchbase://localhost")
+        {
+            Bucket = "bucketA", Scope = "scopeA", DateTimeFormat = "yyyy-MM-ddTHH:mm:ss.FFFK"
+        };
+        var bBuilder = new CouchbaseDbContextOptionsBuilder(new DbContextOptionsBuilder(), "couchbase://localhost")
+        {
+            Bucket = "bucketA", Scope = "scopeA", DateTimeFormat = "yyyy-MM-dd"
+        };
+
+        var a = new CouchbaseOptionsExtension(aBuilder).Info;
+        var b = new CouchbaseOptionsExtension(bBuilder).Info;
+
+        Assert.False(a.ShouldUseSameServiceProvider(b));
+        Assert.NotEqual(a.GetServiceProviderHashCode(), b.GetServiceProviderHashCode());
+    }
+
+    [Fact]
     public void DifferentSerializerOptions_DoesNotShareServiceProvider()
     {
         var aBuilder = new CouchbaseDbContextOptionsBuilder(new DbContextOptionsBuilder(), "couchbase://localhost")

--- a/tests/Couchbase.EntityFrameworkCore.UnitTests/Couchbase/EntityFrameworkCore/Query/CouchbaseDateTimeFunctionSqlGenerationTests.cs
+++ b/tests/Couchbase.EntityFrameworkCore.UnitTests/Couchbase/EntityFrameworkCore/Query/CouchbaseDateTimeFunctionSqlGenerationTests.cs
@@ -99,14 +99,51 @@ public class CouchbaseDateTimeFunctionSqlGenerationTests
         Assert.Contains("'year'", sql);
     }
 
-    private static PostContext CreateContext()
+    [Fact]
+    public void UtcNow_DefaultFormat_UsesObservedGoLayoutByteForByte()
+    {
+        // Regression guard: this exact Go layout string was empirically confirmed (CBEF-23 step-0
+        // spike) to match this provider's own default DateTime serialization. The DateTimeFormat
+        // refactor must not silently change this default.
+        using var ctx = CreateContext();
+        var query = ctx.Posts.Where(p => p.Published < DateTime.UtcNow);
+
+        Assert.Contains("2006-01-02T15:04:05.999Z07:00", query.ToQueryString());
+    }
+
+    [Fact]
+    public void Date_CustomFormat_UsesConfiguredGoLayoutNotDefault()
+    {
+        using var ctx = CreateContext("yyyy-MM-dd");
+        var stamp = new DateTime(2026, 1, 1);
+        var query = ctx.Posts.Where(p => p.Published.Date == stamp);
+
+        var sql = query.ToQueryString();
+        Assert.Contains("2006-01-02", sql);
+        Assert.DoesNotContain("2006-01-02T15:04:05.999Z07:00", sql);
+    }
+
+    [Fact]
+    public void UtcNow_CustomFormat_UsesConfiguredGoLayoutNotDefault()
+    {
+        using var ctx = CreateContext("yyyy-MM-dd");
+        var query = ctx.Posts.Where(p => p.Published < DateTime.UtcNow);
+
+        var sql = query.ToQueryString();
+        Assert.Contains("2006-01-02", sql);
+        Assert.DoesNotContain("2006-01-02T15:04:05.999Z07:00", sql);
+    }
+
+    private static PostContext CreateContext(string? dateTimeFormat = null)
     {
         var clusterOptions = new ClusterOptions()
             .WithConnectionString("couchbase://localhost")
             .WithPasswordAuthentication("Administrator", "password");
 
         var builder = new DbContextOptionsBuilder<PostContext>();
-        builder.UseCouchbaseProvider(clusterOptions);
+        builder.UseCouchbaseProvider(clusterOptions, dateTimeFormat is null
+            ? null
+            : o => o.DateTimeFormat = dateTimeFormat);
         return new PostContext(builder.Options);
     }
 

--- a/tests/Couchbase.EntityFrameworkCore.UnitTests/Couchbase/EntityFrameworkCore/Storage/Internal/CouchbaseDateTimeTypeMappingTests.cs
+++ b/tests/Couchbase.EntityFrameworkCore.UnitTests/Couchbase/EntityFrameworkCore/Storage/Internal/CouchbaseDateTimeTypeMappingTests.cs
@@ -1,0 +1,77 @@
+using Couchbase.EntityFrameworkCore.Storage.Internal;
+using Microsoft.EntityFrameworkCore.Storage;
+using Xunit;
+
+namespace Couchbase.EntityFrameworkCore.UnitTests.Couchbase.EntityFrameworkCore.Storage.Internal;
+
+public class CouchbaseDateTimeTypeMappingTests
+{
+    [Fact]
+    public void Constructor_SetsStoreTypeToString()
+    {
+        var mapping = new CouchbaseDateTimeTypeMapping("yyyy-MM-ddTHH:mm:ss.FFFK");
+
+        Assert.Equal("STRING", mapping.StoreType);
+    }
+
+    [Fact]
+    public void Constructor_SetsClrTypeToDateTime()
+    {
+        var mapping = new CouchbaseDateTimeTypeMapping("yyyy-MM-ddTHH:mm:ss.FFFK");
+
+        Assert.Equal(typeof(DateTime), mapping.ClrType);
+    }
+
+    [Fact]
+    public void GenerateSqlLiteral_UsesConfiguredFormat_NotStockTimestampSyntax()
+    {
+        // The stock EF Core DateTimeTypeMapping this class replaces emits
+        // TIMESTAMP 'yyyy-MM-dd HH:mm:ss.fffffff' -- a syntax no N1QL date-string convention uses.
+        var mapping = new CouchbaseDateTimeTypeMapping("yyyy-MM-ddTHH:mm:ss.FFFK");
+        var value = new DateTime(2026, 3, 14, 9, 26, 53, 123, DateTimeKind.Utc);
+
+        var literal = mapping.GenerateSqlLiteral(value);
+
+        Assert.DoesNotContain("TIMESTAMP", literal, StringComparison.OrdinalIgnoreCase);
+        Assert.Equal("'2026-03-14T09:26:53.123Z'", literal);
+    }
+
+    [Fact]
+    public void GenerateSqlLiteral_WithDifferentConfiguredFormat_UsesThatFormat()
+    {
+        var mapping = new CouchbaseDateTimeTypeMapping("yyyy-MM-dd");
+        var value = new DateTime(2026, 3, 14, 9, 26, 53, 123, DateTimeKind.Utc);
+
+        var literal = mapping.GenerateSqlLiteral(value);
+
+        Assert.Equal("'2026-03-14'", literal);
+    }
+
+    [Fact]
+    public void GenerateSqlLiteral_WithNull_ReturnsNULL()
+    {
+        var mapping = new CouchbaseDateTimeTypeMapping("yyyy-MM-ddTHH:mm:ss.FFFK");
+
+        var literal = mapping.GenerateSqlLiteral(null);
+
+        Assert.Equal("NULL", literal);
+    }
+
+    [Fact]
+    public void Clone_PreservesConfiguredFormat()
+    {
+        var original = new CouchbaseDateTimeTypeMapping("yyyy-MM-dd");
+        var cloned = (CouchbaseDateTimeTypeMapping)original.WithComposedConverter(null);
+        var value = new DateTime(2026, 3, 14, 9, 26, 53, 123, DateTimeKind.Utc);
+
+        Assert.Equal("'2026-03-14'", cloned.GenerateSqlLiteral(value));
+    }
+
+    [Fact]
+    public void Mapping_InheritsDateTimeTypeMapping()
+    {
+        var mapping = new CouchbaseDateTimeTypeMapping("yyyy-MM-ddTHH:mm:ss.FFFK");
+
+        Assert.IsAssignableFrom<DateTimeTypeMapping>(mapping);
+    }
+}

--- a/tests/Couchbase.EntityFrameworkCore.UnitTests/Couchbase/EntityFrameworkCore/Storage/Internal/CouchbaseTypeMappingSourceTests.cs
+++ b/tests/Couchbase.EntityFrameworkCore.UnitTests/Couchbase/EntityFrameworkCore/Storage/Internal/CouchbaseTypeMappingSourceTests.cs
@@ -29,7 +29,7 @@ public class CouchbaseTypeMappingSourceTests
         var relationalDependencies = new RelationalTypeMappingSourceDependencies(
             Array.Empty<IRelationalTypeMappingSourcePlugin>());
 
-        _typeMappingSource = new CouchbaseTypeMappingSource(dependencies, relationalDependencies);
+        _typeMappingSource = new CouchbaseTypeMappingSource(dependencies, relationalDependencies, "yyyy-MM-ddTHH:mm:ss.FFFK");
     }
 
     #region Numeric Types -> NUMBER
@@ -194,6 +194,18 @@ public class CouchbaseTypeMappingSourceTests
         Assert.NotNull(mapping);
         Assert.Equal("STRING", mapping.StoreType);
         Assert.Equal(typeof(DateTime), mapping.ClrType);
+    }
+
+    [Fact]
+    public void FindMapping_DateTime_UsesConfiguredFormat_NotStockTimestampSyntax()
+    {
+        var mapping = _typeMappingSource.FindMapping(typeof(DateTime));
+
+        Assert.IsType<CouchbaseDateTimeTypeMapping>(mapping);
+
+        var literal = mapping!.GenerateSqlLiteral(new DateTime(2026, 3, 14, 9, 26, 53, 123, DateTimeKind.Utc));
+        Assert.DoesNotContain("TIMESTAMP", literal, StringComparison.OrdinalIgnoreCase);
+        Assert.Equal("'2026-03-14T09:26:53.123Z'", literal);
     }
 
     [Fact]

--- a/tests/Couchbase.EntityFrameworkCore.UnitTests/Couchbase/EntityFrameworkCore/Storage/Internal/DotNetToGoDateFormatConverterTests.cs
+++ b/tests/Couchbase.EntityFrameworkCore.UnitTests/Couchbase/EntityFrameworkCore/Storage/Internal/DotNetToGoDateFormatConverterTests.cs
@@ -1,0 +1,159 @@
+using Couchbase.EntityFrameworkCore.Storage.Internal;
+using Xunit;
+
+namespace Couchbase.EntityFrameworkCore.UnitTests.Couchbase.EntityFrameworkCore.Storage.Internal;
+
+public class DotNetToGoDateFormatConverterTests
+{
+    [Fact]
+    public void Convert_DefaultFormat_ProducesExpectedGoLayout()
+    {
+        // Must reproduce CBEF-23's originally hardcoded Fmt constant byte-for-byte -- this is the
+        // regression guard proving the configurable-format refactor didn't change already-shipped,
+        // live-verified behavior.
+        var result = DotNetToGoDateFormatConverter.Convert("yyyy-MM-ddTHH:mm:ss.FFFK");
+
+        Assert.Equal("2006-01-02T15:04:05.999Z07:00", result);
+    }
+
+    [Fact]
+    public void Convert_DateOnlyFormat_ProducesExpectedGoLayout()
+    {
+        var result = DotNetToGoDateFormatConverter.Convert("yyyy-MM-dd");
+
+        Assert.Equal("2006-01-02", result);
+    }
+
+    [Theory]
+    [InlineData("yyyy", "2006")]
+    [InlineData("MM", "01")]
+    [InlineData("dd", "02")]
+    [InlineData("HH", "15")]
+    [InlineData("mm", "04")]
+    [InlineData("ss", "05")]
+    [InlineData("K", "Z07:00")]
+    public void Convert_EachSupportedToken_MapsCorrectly(string dotNetToken, string expectedGoToken)
+    {
+        Assert.Equal(expectedGoToken, DotNetToGoDateFormatConverter.Convert(dotNetToken));
+    }
+
+    [Theory]
+    [InlineData("f", "0")]
+    [InlineData("ff", "00")]
+    [InlineData("fff", "000")]
+    [InlineData("fffffff", "0000000")]
+    [InlineData("F", "9")]
+    [InlineData("FF", "99")]
+    [InlineData("FFF", "999")]
+    [InlineData("FFFFFFF", "9999999")]
+    public void Convert_FractionalSecondsTokens_MapToMatchingLengthRun(string dotNetToken, string expectedGoToken)
+    {
+        Assert.Equal(expectedGoToken, DotNetToGoDateFormatConverter.Convert(dotNetToken));
+    }
+
+    [Theory]
+    [InlineData(" ")]
+    [InlineData("-")]
+    [InlineData(":")]
+    [InlineData(".")]
+    public void Convert_LiteralSeparators_PassThroughUnchanged(string literal)
+    {
+        Assert.Equal(literal, DotNetToGoDateFormatConverter.Convert(literal));
+    }
+
+    [Fact]
+    public void Convert_QuotedLiteralT_ProducesSameResultAsUnquotedT()
+    {
+        // "yyyy-MM-dd'T'HH:mm:ss" is a very common way to write this exact ISO-8601 pattern.
+        // DateTime.ToString strips the quotes and emits just "T", so the quotes must NOT be
+        // passed through as literal characters into the Go layout -- if they were, N1QL would
+        // never match against the actual (unquoted) stored data.
+        var quoted = DotNetToGoDateFormatConverter.Convert("yyyy-MM-dd'T'HH:mm:ss");
+        var unquoted = DotNetToGoDateFormatConverter.Convert("yyyy-MM-ddTHH:mm:ss");
+
+        Assert.Equal("2006-01-02T15:04:05", quoted);
+        Assert.Equal(unquoted, quoted);
+    }
+
+    [Fact]
+    public void Convert_QuotedLiteralLetter_TreatedAsLiteralNotToken()
+    {
+        // A quoted 'y' must be emitted as a literal character, not interpreted as (part of) the
+        // year token -- proving quoting actually suppresses token interpretation rather than just
+        // being ignored.
+        Assert.Equal("2006y", DotNetToGoDateFormatConverter.Convert("yyyy'y'"));
+    }
+
+    [Fact]
+    public void Convert_DoubleQuotedLiteral_AlsoSuppressesTokenInterpretation()
+    {
+        Assert.Equal("2006Z", DotNetToGoDateFormatConverter.Convert("yyyy\"Z\""));
+    }
+
+    [Fact]
+    public void Convert_BackslashEscape_ProducesLiteralCharacterOutsideQuotes()
+    {
+        Assert.Equal("2006'", DotNetToGoDateFormatConverter.Convert(@"yyyy\'"));
+    }
+
+    [Fact]
+    public void Convert_BackslashEscape_WorksInsideQuotedLiteral()
+    {
+        Assert.Equal("2006Z'y", DotNetToGoDateFormatConverter.Convert("yyyy'Z\\'y'"));
+    }
+
+    [Fact]
+    public void Convert_LoneQuote_ThrowsUnterminatedLiteral()
+    {
+        // A bare, unmatched quote must be rejected rather than silently passed through -- passing
+        // it through (the pre-fix behavior) would have silently mis-converted any format using a
+        // quoted literal section, e.g. "yyyy-MM-dd'T'HH:mm:ss".
+        var ex = Assert.Throws<ArgumentException>(() => DotNetToGoDateFormatConverter.Convert("'"));
+        Assert.Contains("unterminated", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void Convert_UnterminatedQuotedLiteral_Throws()
+    {
+        var ex = Assert.Throws<ArgumentException>(() => DotNetToGoDateFormatConverter.Convert("yyyy'T"));
+        Assert.Contains("unterminated", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void Convert_TrailingBackslash_Throws()
+    {
+        var ex = Assert.Throws<ArgumentException>(() => DotNetToGoDateFormatConverter.Convert(@"yyyy\"));
+        Assert.Contains("trailing escape", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void Convert_TrailingBackslashInsideQuotedLiteral_Throws()
+    {
+        var ex = Assert.Throws<ArgumentException>(() => DotNetToGoDateFormatConverter.Convert(@"'abc\"));
+        Assert.Contains("trailing escape", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Theory]
+    [InlineData("y")]      // wrong length for the year token
+    [InlineData("yy")]
+    [InlineData("M")]      // wrong length for the month token
+    [InlineData("d")]      // wrong length for the day token (ambiguous with day-name tokens)
+    [InlineData("ddd")]    // day name -- not supported
+    [InlineData("h")]      // 12-hour clock -- not supported
+    [InlineData("tt")]     // AM/PM designator -- not supported
+    [InlineData("zzz")]    // separate offset specifier -- not supported (use K instead)
+    [InlineData("ffffffff")] // 8 f's exceeds .NET's own max of 7
+    public void Convert_UnsupportedToken_Throws(string unsupportedFormat)
+    {
+        var ex = Assert.Throws<ArgumentException>(() => DotNetToGoDateFormatConverter.Convert(unsupportedFormat));
+        Assert.Contains(unsupportedFormat, ex.Message);
+    }
+
+    [Fact]
+    public void Convert_MonthAndMinuteTokens_AreCaseSensitivelyDistinct()
+    {
+        // 'M' (month) and 'm' (minute) must not be confused with each other.
+        Assert.Equal("01", DotNetToGoDateFormatConverter.Convert("MM"));
+        Assert.Equal("04", DotNetToGoDateFormatConverter.Convert("mm"));
+    }
+}


### PR DESCRIPTION
CouchbaseDateTimeMemberTranslator hardcoded a Go-layout format constant for .Date/.Now/.UtcNow/.Today, assuming every DateTime was stored in this provider's own default serialization -- but N1QL has no native date type, so a user's data can legitimately use a different string convention. Adds a DateTimeFormat option (mirroring FieldNamingPolicy's pattern) that drives both the query-side translators and a new CouchbaseDateTimeTypeMapping.

Also fixes CouchbaseTypeMappingSource generating invalid TIMESTAMP '...' literals for inline DateTime constants (EF Core's stock DateTimeTypeMapping), and adds DateTimeFormat to CouchbaseOptionsExtension's service-provider equality/hash checks so two differently-configured contexts don't silently share one internal provider.