### PR TITLE
Add per-property DateTimeFormat override (CBEF-23 follow-up #2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,12 +24,18 @@ and this project aims to follow [Semantic Versioning](https://semver.org/spec/v2
   `DateTime`/`Guid` member access) had no translator at all. See
   [Querying — Supported functions](docs/Queries.md#supported-functions) for the full list and what
   remains unsupported (`Math.Min`/`Max`, trig functions).
-- **`DateTimeFormat` option.** Configures the .NET custom `DateTime` format string this provider
-  assumes when generating or comparing against `DateTime` string values in SQL++ — used by the
-  `.Date`/`.Now`/`.UtcNow`/`.Today` translators and for inline `DateTime` literals. Defaults to
-  `"yyyy-MM-ddTHH:mm:ss.FFFK"` (this provider's own default serialization), but is configurable
-  since N1QL has no native date type and data can legitimately be stored in a different
-  convention. See [Configuration — DateTime string format](docs/configuration.md#datetime-string-format).
+- **`DateTimeFormat` option, with a per-property override.** Configures the .NET custom `DateTime`
+  format string this provider assumes when generating or comparing against `DateTime` string
+  values in SQL++ — used by the `.Date`/`.Now`/`.UtcNow`/`.Today` translators and for inline
+  `DateTime` literals. Defaults to `"yyyy-MM-ddTHH:mm:ss.FFFK"` (this provider's own default
+  serialization), but is configurable since N1QL has no native date type and data can legitimately
+  be stored in a different convention. A single property can also override the context-wide
+  default independently via the `[DateTimeFormat]` attribute or the `HasDateTimeFormat` fluent API
+  (applies to `.Date` and inline literals for that property only — the static `.Now`/`.UtcNow`/
+  `.Today` translators have no associated property and always use the context-wide default). The
+  format string supports .NET's quoted-literal (`'...'`/`"..."`) and backslash-escape (`\x`) syntax
+  for embedding literal text, e.g. `"yyyy-MM-dd'T'HH:mm:ss"`. See
+  [Configuration — DateTime string format](docs/configuration.md#datetime-string-format).
 
 ### Fixed
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -108,6 +108,35 @@ couchbaseDbContextOptions.DateTimeFormat = "yyyy-MM-dd"; // date-only convention
 This is unrelated to `FieldNamingPolicy` — `DateTimeFormat` controls how `DateTime` *values* are
 compared/generated in SQL++, while `FieldNamingPolicy` controls JSON *field name* casing.
 
+#### Per-property override
+
+`DateTimeFormat` applies to every `DateTime` property in the context by default, but a single
+property can use a different convention — via the `[DateTimeFormat]` attribute or the
+`HasDateTimeFormat` fluent API — without affecting any other property:
+
+```csharp
+public class Order
+{
+    public int Id { get; set; }
+    public DateTime Placed { get; set; }             // uses the context-wide DateTimeFormat
+
+    [DateTimeFormat("yyyy-MM-dd")]
+    public DateTime ShipDate { get; set; }            // date-only, independent of Placed
+}
+```
+
+```csharp
+// Equivalent fluent form, e.g. if you'd rather not put attributes on the entity:
+modelBuilder.Entity<Order>()
+    .Property(o => o.ShipDate)
+    .HasDateTimeFormat("yyyy-MM-dd");
+```
+
+The override only applies to the `.Date` member translator and inline `DateTime` literals for
+that specific property — the static `DateTime.Now`/`.UtcNow`/`.Today` translators have no
+associated property to read an override from, so they always use the context-wide default even
+in a query that also touches an overridden property.
+
 ## Multiple buckets and clusters
 
 By default a `DbContext` targets a single configured bucket (and scope), and every entity is

--- a/src/Couchbase.EntityFrameworkCore/Extensions/CouchbasePropertyBuilderExtensions.cs
+++ b/src/Couchbase.EntityFrameworkCore/Extensions/CouchbasePropertyBuilderExtensions.cs
@@ -1,3 +1,4 @@
+using Couchbase.EntityFrameworkCore.Storage.Internal;
 using Couchbase.EntityFrameworkCore.ValueGeneration;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
@@ -436,6 +437,55 @@ public static class CouchbasePropertyBuilderExtensions
         propertyBuilder.HasAnnotation(CouchbaseValueGeneratorSelector.GuidStringFormatAnnotation, normalizedFormat);
 
         propertyBuilder.ValueGeneratedOnAdd();
+
+        return propertyBuilder;
+    }
+
+    #endregion
+
+    #region DateTime Format Override
+
+    /// <summary>
+    /// Overrides the .NET custom <see cref="DateTime"/> format string this provider uses for this
+    /// property, instead of the DbContext-wide
+    /// <see cref="Couchbase.EntityFrameworkCore.Infrastructure.CouchbaseDbContextOptionsBuilder.DateTimeFormat"/>
+    /// default.
+    /// </summary>
+    /// <remarks>
+    /// N1QL has no native date type — dates are just JSON strings — so nothing stops different
+    /// properties (or data written by another system) from using a different string convention
+    /// than the rest of the model. Only applies to the <c>.Date</c> member translator and inline
+    /// <see cref="DateTime"/> literals for this specific property; the static <c>.Now</c>/
+    /// <c>.UtcNow</c>/<c>.Today</c> translators have no associated property and always use the
+    /// context-wide default. Equivalent to applying
+    /// <see cref="Couchbase.EntityFrameworkCore.Metadata.DateTimeFormatAttribute"/> to the property.
+    /// </remarks>
+    /// <param name="propertyBuilder">The property builder.</param>
+    /// <param name="format">The .NET custom <see cref="DateTime"/> format string.</param>
+    /// <returns>The same property builder for method chaining.</returns>
+    /// <example>
+    /// <code>
+    /// modelBuilder.Entity&lt;Order&gt;()
+    ///     .Property(e => e.ShipDate)
+    ///     .HasDateTimeFormat("yyyy-MM-dd");
+    /// </code>
+    /// </example>
+    public static PropertyBuilder<TProperty> HasDateTimeFormat<TProperty>(
+        this PropertyBuilder<TProperty> propertyBuilder,
+        string format)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(format);
+
+        var clrType = propertyBuilder.Metadata.ClrType;
+        if (clrType != typeof(DateTime) && clrType != typeof(DateTime?))
+        {
+            throw new InvalidOperationException(
+                $"HasDateTimeFormat() can only be used on properties of type DateTime or DateTime?, but property " +
+                $"'{propertyBuilder.Metadata.DeclaringType.ClrType.Name}.{propertyBuilder.Metadata.Name}' " +
+                $"is of type '{clrType.Name}'.");
+        }
+
+        propertyBuilder.HasAnnotation(CouchbaseTypeMappingSource.DateTimeFormatAnnotation, format);
 
         return propertyBuilder;
     }

--- a/src/Couchbase.EntityFrameworkCore/Metadata/Conventions/CouchbaseConventionSetBuilder.cs
+++ b/src/Couchbase.EntityFrameworkCore/Metadata/Conventions/CouchbaseConventionSetBuilder.cs
@@ -18,6 +18,7 @@ public class CouchbaseConventionSetBuilder : RelationalConventionSetBuilder
         conventionSet.Add(new CouchbaseSequenceConvention(Dependencies));
         conventionSet.Add(new JsonPropertyNameConvention(Dependencies));
         conventionSet.Add(new JsonPropertyConvention(Dependencies));
+        conventionSet.Add(new DateTimeFormatConvention(Dependencies));
         return conventionSet;
     }
 }

--- a/src/Couchbase.EntityFrameworkCore/Metadata/Conventions/DateTimeFormatConvention.cs
+++ b/src/Couchbase.EntityFrameworkCore/Metadata/Conventions/DateTimeFormatConvention.cs
@@ -1,0 +1,58 @@
+using System.Reflection;
+using Couchbase.EntityFrameworkCore.Storage.Internal;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using Microsoft.EntityFrameworkCore.Metadata.Conventions;
+using Microsoft.EntityFrameworkCore.Metadata.Conventions.Infrastructure;
+
+namespace Couchbase.EntityFrameworkCore.Metadata.Conventions;
+
+/// <summary>
+/// A convention that processes <see cref="DateTimeFormatAttribute"/> on properties and configures
+/// them to use a per-property <see cref="DateTime"/> string format override.
+/// </summary>
+public class DateTimeFormatConvention : PropertyAttributeConventionBase<DateTimeFormatAttribute>
+{
+    public DateTimeFormatConvention(ProviderConventionSetBuilderDependencies dependencies)
+        : base(dependencies)
+    {
+    }
+
+    protected override void ProcessPropertyAdded(
+        IConventionPropertyBuilder propertyBuilder,
+        DateTimeFormatAttribute attribute,
+        MemberInfo clrMember,
+        IConventionContext context)
+    {
+        // CouchbaseTypeMappingSource only honors this annotation for DateTime/DateTime? --
+        // misapplying the attribute to any other property type would otherwise be a silent no-op.
+        var clrType = propertyBuilder.Metadata.ClrType;
+        if (clrType != typeof(DateTime) && clrType != typeof(DateTime?))
+        {
+            throw new InvalidOperationException(
+                $"[DateTimeFormat] can only be applied to properties of type DateTime or DateTime?, but property " +
+                $"'{propertyBuilder.Metadata.DeclaringType.ClrType.Name}.{propertyBuilder.Metadata.Name}' " +
+                $"is of type '{clrType.Name}'.");
+        }
+
+        propertyBuilder.HasAnnotation(CouchbaseTypeMappingSource.DateTimeFormatAnnotation, attribute.Format);
+    }
+}
+
+/* ************************************************************
+ *
+ *    @author Couchbase <info@couchbase.com>
+ *    @copyright 2025 Couchbase, Inc.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ *
+ * ************************************************************/

--- a/src/Couchbase.EntityFrameworkCore/Metadata/DateTimeFormatAttribute.cs
+++ b/src/Couchbase.EntityFrameworkCore/Metadata/DateTimeFormatAttribute.cs
@@ -1,0 +1,43 @@
+namespace Couchbase.EntityFrameworkCore.Metadata;
+
+/// <summary>
+/// Overrides the .NET custom <see cref="DateTime"/> format string this provider uses for the
+/// annotated property, instead of the DbContext-wide
+/// <see cref="Infrastructure.CouchbaseDbContextOptionsBuilder.DateTimeFormat"/> default.
+/// </summary>
+/// <remarks>
+/// N1QL has no native date type — dates are just JSON strings — so nothing stops different
+/// properties (or data written by another system) from using a different string convention than
+/// the rest of the model. Only applies to the <c>.Date</c> member translator and inline
+/// <see cref="DateTime"/> literals for this specific property; the static <c>.Now</c>/<c>.UtcNow</c>/
+/// <c>.Today</c> translators have no associated property and always use the context-wide default.
+/// See <see cref="Storage.Internal.DotNetToGoDateFormatConverter"/> for the supported token subset.
+/// </remarks>
+/// <example>
+/// <code>
+/// public class Order
+/// {
+///     [DateTimeFormat("yyyy-MM-dd")]
+///     public DateTime ShipDate { get; set; }
+/// }
+/// </code>
+/// </example>
+[AttributeUsage(AttributeTargets.Property)]
+public class DateTimeFormatAttribute : Attribute
+{
+    /// <summary>
+    /// Initializes a new instance with the specified .NET custom <see cref="DateTime"/> format
+    /// string.
+    /// </summary>
+    /// <param name="format">The .NET custom <see cref="DateTime"/> format string.</param>
+    public DateTimeFormatAttribute(string format)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(format);
+        Format = format;
+    }
+
+    /// <summary>
+    /// Gets the .NET custom <see cref="DateTime"/> format string for this property.
+    /// </summary>
+    public string Format { get; }
+}

--- a/src/Couchbase.EntityFrameworkCore/Query/Internal/Translators/CouchbaseDateTimeMemberTranslator.cs
+++ b/src/Couchbase.EntityFrameworkCore/Query/Internal/Translators/CouchbaseDateTimeMemberTranslator.cs
@@ -1,5 +1,6 @@
 using System.Reflection;
 using Couchbase.EntityFrameworkCore.Infrastructure;
+using Couchbase.EntityFrameworkCore.Storage.Internal;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.Query;
@@ -32,6 +33,14 @@ namespace Couchbase.EntityFrameworkCore.Query.Internal.Translators;
 /// (<c>NOW_UTC</c>, <c>DATE_PART_STR</c>/<c>DATE_TRUNC_STR</c> on UTC-stored data) but
 /// <c>NOW_LOCAL</c> (<see cref="DateTime.Now"/>) returns a value in the query service's local
 /// timezone, which is not UTC in general.
+/// </para>
+/// <para>
+/// The <c>.Date</c> branch prefers a per-property override
+/// (<see cref="Metadata.DateTimeFormatAttribute"/>/<c>HasDateTimeFormat</c>), read directly off
+/// the instance's own resolved <see cref="CouchbaseDateTimeTypeMapping"/> with no DI wiring
+/// needed, falling back to the context-wide default. The static <c>.Now</c>/<c>.UtcNow</c>/
+/// <c>.Today</c> branches have no associated property/instance and always use the context-wide
+/// default -- there is no per-property signal available for them.
 /// </para>
 /// </summary>
 public class CouchbaseDateTimeMemberTranslator : IMemberTranslator
@@ -83,9 +92,16 @@ public class CouchbaseDateTimeMemberTranslator : IMemberTranslator
 
         if (instance != null && DateMemberInfo.Equals(member))
         {
+            // Prefer the format baked into the instance's own resolved type mapping -- this is
+            // how a per-property [DateTimeFormat]/HasDateTimeFormat override (a distinct
+            // CouchbaseDateTimeTypeMapping instance per property) takes effect, with zero DI
+            // wiring needed. Falls back to the context-wide default for anything else (e.g. a
+            // parameter or a column whose mapping didn't resolve to CouchbaseDateTimeTypeMapping).
+            var fmt = (instance.TypeMapping as CouchbaseDateTimeTypeMapping)?.GoDateTimeFormat ?? _fmt;
+
             return _sqlExpressionFactory.Function(
                 "DATE_TRUNC_STR",
-                new[] { instance, _sqlExpressionFactory.Constant("day"), _sqlExpressionFactory.Constant(_fmt) },
+                new[] { instance, _sqlExpressionFactory.Constant("day"), _sqlExpressionFactory.Constant(fmt) },
                 nullable: true,
                 argumentsPropagateNullability: new[] { true, false, false },
                 returnType,

--- a/src/Couchbase.EntityFrameworkCore/Storage/Internal/CouchbaseTypeMappingSource.cs
+++ b/src/Couchbase.EntityFrameworkCore/Storage/Internal/CouchbaseTypeMappingSource.cs
@@ -1,4 +1,5 @@
 using System.Data;
+using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Storage;
 using System.Text.Json.Nodes;
 
@@ -20,6 +21,14 @@ namespace Couchbase.EntityFrameworkCore.Storage.Internal;
 /// </remarks>
 public class CouchbaseTypeMappingSource : RelationalTypeMappingSource
 {
+    /// <summary>
+    /// Annotation key written by <see cref="Metadata.Conventions.DateTimeFormatConvention"/> (and
+    /// the <c>HasDateTimeFormat</c> fluent extension) to override the .NET custom
+    /// <see cref="DateTime"/> format string for a specific property, instead of the DbContext-wide
+    /// <see cref="Infrastructure.CouchbaseDbContextOptionsBuilder.DateTimeFormat"/> default.
+    /// </summary>
+    public const string DateTimeFormatAnnotation = "Couchbase:DateTimeFormat";
+
     private readonly Dictionary<Type, RelationalTypeMapping> _clrTypeMappings;
 
     public CouchbaseTypeMappingSource(
@@ -77,6 +86,28 @@ public class CouchbaseTypeMappingSource : RelationalTypeMappingSource
                     jsonValueReaderWriter: dependencies.JsonValueReaderWriterSource.FindReaderWriter(typeof(JsonArray)))
             }
         };
+    }
+
+    /// <inheritdoc />
+    /// <remarks>
+    /// Checked before the CLR-type-keyed dictionary lookup below, since a per-property
+    /// <see cref="DateTimeFormatAnnotation"/> override is only reachable here — by the time
+    /// <see cref="FindMapping(in RelationalTypeMappingInfo)"/> is called, the
+    /// <see cref="RelationalTypeMappingInfo"/> struct it receives no longer carries an
+    /// <see cref="IProperty"/>/annotation reference to check.
+    /// </remarks>
+    public override CoreTypeMapping? FindMapping(IProperty property)
+    {
+        if (property.ClrType == typeof(DateTime) || property.ClrType == typeof(DateTime?))
+        {
+            var format = property.FindAnnotation(DateTimeFormatAnnotation)?.Value as string;
+            if (format != null)
+            {
+                return new CouchbaseDateTimeTypeMapping(format);
+            }
+        }
+
+        return base.FindMapping(property);
     }
 
     protected override RelationalTypeMapping? FindMapping(in RelationalTypeMappingInfo mappingInfo)

--- a/tests/Couchbase.EntityFrameworkCore.IntegrationTests/Tests/DateTimePerPropertyFormatTests.cs
+++ b/tests/Couchbase.EntityFrameworkCore.IntegrationTests/Tests/DateTimePerPropertyFormatTests.cs
@@ -1,0 +1,134 @@
+using Couchbase.EntityFrameworkCode.IntegrationTests.Fixtures;
+using Couchbase.EntityFrameworkCore;
+using Couchbase.EntityFrameworkCore.Extensions;
+using Couchbase.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+
+namespace Couchbase.EntityFrameworkCode.IntegrationTests.Tests;
+
+/// <summary>
+/// Proves the per-property <see cref="DateTimeFormatAttribute"/> override round-trips against a
+/// real cluster, independently of the DbContext-wide <c>DateTimeFormat</c> default -- both formats
+/// are exercised on two different properties of the SAME document, proving neither cross-
+/// contaminates the other.
+/// </summary>
+[Collection(CouchbaseTestingCollection.Name)]
+public class DateTimePerPropertyFormatTests(BloggingFixture fixture) : IAsyncLifetime
+{
+    private static readonly string CollectionName = "dtppfmt" + Guid.NewGuid().ToString("N");
+
+    // Published uses the context-wide default format; ShipDate is anchored to a date-only value
+    // to make the per-property "yyyy-MM-dd" override meaningful (no time-of-day to lose).
+    private static readonly DateTime Published = new(DateTime.UtcNow.Year - 1, 3, 14, 9, 26, 53, 123, DateTimeKind.Utc);
+    private static readonly DateTime ShipDate = new(DateTime.UtcNow.Year - 1, 6, 1);
+
+    private MixedFormatDbContext _context = null!;
+
+    public async Task InitializeAsync()
+    {
+        var optionsBuilder = new DbContextOptionsBuilder<MixedFormatDbContext>();
+        optionsBuilder.UseCouchbase(
+            new global::Couchbase.ClusterOptions()
+                .WithConnectionString(fixture.Host)
+                .WithPasswordAuthentication(fixture.Username, fixture.Password),
+            o =>
+            {
+                o.Bucket = fixture.BucketName;
+                o.Scope = fixture.ScopeName;
+                o.AutoCreateIndexes = true;
+                o.ScanConsistency = global::Couchbase.Query.QueryScanConsistency.RequestPlus;
+                // DateTimeFormat deliberately left at its default -- Published uses it unchanged;
+                // only ShipDate gets a per-property override via [DateTimeFormat] on the entity.
+            });
+        optionsBuilder.ConfigureWarnings(w => w.Ignore(CoreEventId.ManyServiceProvidersCreatedWarning));
+
+        _context = new MixedFormatDbContext(optionsBuilder.Options, CollectionName);
+        await _context.Database.EnsureCreatedAsync();
+
+        // Written directly via the KV API, each field in its own convention, to prove the two
+        // formats are read back correctly independently rather than relying on this provider's
+        // own (format-consistent) write path to mask a translator that only worked by accident.
+        var clusterOptions = new global::Couchbase.ClusterOptions()
+            .WithConnectionString(fixture.Host)
+            .WithPasswordAuthentication(fixture.Username, fixture.Password)
+            .WithSerializer(global::Couchbase.Core.IO.Serializers.SystemTextJsonSerializer.Create());
+        using var cluster = await global::Couchbase.Cluster.ConnectAsync(clusterOptions);
+        var bucket = await cluster.BucketAsync(fixture.BucketName);
+        var scope = await bucket.ScopeAsync(fixture.ScopeName);
+        var collection = scope.Collection(CollectionName);
+        await collection.InsertAsync("1", new Dictionary<string, object>
+        {
+            ["Id"] = 1L,
+            ["Published"] = Published.ToString("yyyy-MM-ddTHH:mm:ss.FFFK"),
+            ["ShipDate"] = ShipDate.ToString("yyyy-MM-dd"),
+        });
+    }
+
+    [Fact]
+    public async Task Date_OnDefaultFormatProperty_MatchesFullPrecisionStoredString()
+    {
+        var expected = new DateTime(Published.Year, Published.Month, Published.Day, 0, 0, 0, DateTimeKind.Utc);
+        var result = await _context.Entities.Where(e => e.Published.Date == expected).ToListAsync();
+        Assert.Single(result);
+    }
+
+    [Fact]
+    public async Task Date_OnPerPropertyOverrideProperty_MatchesDateOnlyStoredString()
+    {
+        var result = await _context.Entities.Where(e => e.ShipDate.Date == ShipDate).ToListAsync();
+        Assert.Single(result);
+    }
+
+    [Fact]
+    public async Task Date_OnBothProperties_InOneQuery_UseTheirOwnFormatsIndependently()
+    {
+        // Proves the two formats don't cross-contaminate when both are evaluated together --
+        // if either translator picked up the wrong format, one side (or both) would fail to match.
+        var expectedPublished = new DateTime(Published.Year, Published.Month, Published.Day, 0, 0, 0, DateTimeKind.Utc);
+        var result = await _context.Entities
+            .Where(e => e.Published.Date == expectedPublished && e.ShipDate.Date == ShipDate)
+            .ToListAsync();
+
+        Assert.Single(result);
+    }
+
+    public async Task DisposeAsync()
+    {
+        await _context.DisposeAsync();
+
+        try
+        {
+            var clusterOptions = new global::Couchbase.ClusterOptions()
+                .WithConnectionString(fixture.Host)
+                .WithCredentials(fixture.Username, fixture.Password);
+            using var cluster = await global::Couchbase.Cluster.ConnectAsync(clusterOptions);
+            var bucket = await cluster.BucketAsync(fixture.BucketName);
+            await bucket.Collections.DropCollectionAsync(fixture.ScopeName, CollectionName);
+        }
+        catch (global::Couchbase.Management.Collections.CollectionNotFoundException)
+        {
+        }
+    }
+
+    public class MixedFormatEntity
+    {
+        public long Id { get; set; }
+        public DateTime Published { get; set; }
+
+        [DateTimeFormat("yyyy-MM-dd")]
+        public DateTime ShipDate { get; set; }
+    }
+
+    public class MixedFormatDbContext(DbContextOptions<MixedFormatDbContext> options, string collectionName)
+        : DbContext(options)
+    {
+        public DbSet<MixedFormatEntity> Entities { get; set; } = null!;
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            base.OnModelCreating(modelBuilder);
+            modelBuilder.Entity<MixedFormatEntity>().ToCouchbaseCollection(this, collectionName);
+        }
+    }
+}

--- a/tests/Couchbase.EntityFrameworkCore.UnitTests/Couchbase/EntityFrameworkCore/Extensions/CouchbasePropertyBuilderExtensionsTests.cs
+++ b/tests/Couchbase.EntityFrameworkCore.UnitTests/Couchbase/EntityFrameworkCore/Extensions/CouchbasePropertyBuilderExtensionsTests.cs
@@ -1,4 +1,5 @@
 using Couchbase.EntityFrameworkCore.Extensions;
+using Couchbase.EntityFrameworkCore.Storage.Internal;
 using Couchbase.EntityFrameworkCore.ValueGeneration;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Metadata;
@@ -694,6 +695,59 @@ public class CouchbasePropertyBuilderExtensionsTests
     }
 
     #endregion
+
+    #region HasDateTimeFormat Tests
+
+    [Fact]
+    public void HasDateTimeFormat_OnDateTimeProperty_SetsDateTimeFormatAnnotation()
+    {
+        var modelBuilder = new ModelBuilder();
+        var entityBuilder = modelBuilder.Entity<DateTimeEntity>();
+
+        entityBuilder.Property(e => e.ShipDate).HasDateTimeFormat("yyyy-MM-dd");
+
+        var property = modelBuilder.Model.FindEntityType(typeof(DateTimeEntity))!.FindProperty(nameof(DateTimeEntity.ShipDate));
+        var storedFormat = property!.FindAnnotation(CouchbaseTypeMappingSource.DateTimeFormatAnnotation)?.Value;
+        Assert.Equal("yyyy-MM-dd", storedFormat);
+    }
+
+    [Fact]
+    public void HasDateTimeFormat_OnNullableDateTimeProperty_SetsDateTimeFormatAnnotation()
+    {
+        var modelBuilder = new ModelBuilder();
+        var entityBuilder = modelBuilder.Entity<DateTimeEntity>();
+
+        entityBuilder.Property(e => e.OptionalShipDate).HasDateTimeFormat("yyyy-MM-dd");
+
+        var property = modelBuilder.Model.FindEntityType(typeof(DateTimeEntity))!.FindProperty(nameof(DateTimeEntity.OptionalShipDate));
+        var storedFormat = property!.FindAnnotation(CouchbaseTypeMappingSource.DateTimeFormatAnnotation)?.Value;
+        Assert.Equal("yyyy-MM-dd", storedFormat);
+    }
+
+    [Fact]
+    public void HasDateTimeFormat_OnNonDateTimeProperty_ThrowsInvalidOperationException()
+    {
+        // Prevents silently writing an annotation the type-mapping source would just ignore --
+        // the generic HasDateTimeFormat<TProperty> would otherwise compile fine on any property
+        // type, since TProperty is unconstrained.
+        var modelBuilder = new ModelBuilder();
+        var entityBuilder = modelBuilder.Entity<DateTimeEntity>();
+
+        var exception = Assert.Throws<InvalidOperationException>(() =>
+            entityBuilder.Property(e => e.Id).HasDateTimeFormat("yyyy-MM-dd"));
+
+        Assert.Contains("HasDateTimeFormat()", exception.Message);
+        Assert.Contains("DateTime", exception.Message);
+    }
+
+    #endregion
+
+    private class DateTimeEntity
+    {
+        public long Id { get; set; }
+        public DateTime ShipDate { get; set; }
+        public DateTime? OptionalShipDate { get; set; }
+    }
 
     private class TestEntity
     {

--- a/tests/Couchbase.EntityFrameworkCore.UnitTests/Couchbase/EntityFrameworkCore/Metadata/Conventions/DateTimeFormatConventionTests.cs
+++ b/tests/Couchbase.EntityFrameworkCore.UnitTests/Couchbase/EntityFrameworkCore/Metadata/Conventions/DateTimeFormatConventionTests.cs
@@ -1,0 +1,59 @@
+using Couchbase.EntityFrameworkCore.Extensions;
+using Couchbase.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore;
+using Xunit;
+
+namespace Couchbase.EntityFrameworkCore.UnitTests.Couchbase.EntityFrameworkCore.Metadata.Conventions;
+
+/// <summary>
+/// Verifies <see cref="Couchbase.EntityFrameworkCore.Metadata.Conventions.DateTimeFormatConvention"/>
+/// fails fast when <see cref="DateTimeFormatAttribute"/> is misapplied to a non-<see cref="DateTime"/>
+/// property, rather than silently writing an annotation
+/// <c>Couchbase.EntityFrameworkCore.Storage.Internal.CouchbaseTypeMappingSource</c> would just ignore.
+/// </summary>
+public class DateTimeFormatConventionTests
+{
+    [Fact]
+    public void DateTimeFormatAttribute_OnNonDateTimeProperty_ThrowsAtModelBuildTime()
+    {
+        using var ctx = CreateContext();
+
+        var exception = Assert.Throws<InvalidOperationException>(() => ctx.Model);
+
+        Assert.Contains("[DateTimeFormat]", exception.Message);
+        Assert.Contains("DateTime", exception.Message);
+    }
+
+    private static InvalidAttributeContext CreateContext()
+    {
+        var clusterOptions = new ClusterOptions()
+            .WithConnectionString("couchbase://localhost")
+            .WithPasswordAuthentication("Administrator", "password");
+
+        var builder = new DbContextOptionsBuilder<InvalidAttributeContext>();
+        builder.UseCouchbaseProvider(clusterOptions);
+        return new InvalidAttributeContext(builder.Options);
+    }
+
+    private class InvalidAttributeEntity
+    {
+        public int Id { get; set; }
+
+        [DateTimeFormat("yyyy-MM-dd")]
+        public int NotADateTime { get; set; }
+    }
+
+    private class InvalidAttributeContext(DbContextOptions<InvalidAttributeContext> options) : DbContext(options)
+    {
+        public DbSet<InvalidAttributeEntity> Entities { get; set; } = null!;
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            modelBuilder.Entity<InvalidAttributeEntity>(b =>
+            {
+                b.ToCouchbaseCollection("bucket", "scope", "invalidAttributePost");
+                b.HasKey(p => p.Id);
+            });
+        }
+    }
+}

--- a/tests/Couchbase.EntityFrameworkCore.UnitTests/Couchbase/EntityFrameworkCore/Query/CouchbaseDateTimePerPropertyFormatSqlGenerationTests.cs
+++ b/tests/Couchbase.EntityFrameworkCore.UnitTests/Couchbase/EntityFrameworkCore/Query/CouchbaseDateTimePerPropertyFormatSqlGenerationTests.cs
@@ -1,0 +1,113 @@
+using Couchbase.EntityFrameworkCore.Extensions;
+using Couchbase.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore;
+using Xunit;
+
+namespace Couchbase.EntityFrameworkCore.UnitTests.Couchbase.EntityFrameworkCore.Query;
+
+/// <summary>
+/// Verifies the per-property <see cref="DateTimeFormatAttribute"/>/<c>HasDateTimeFormat</c>
+/// override: a property configured with its own format must use that format's Go layout in
+/// generated SQL++, independently of both the context-wide <c>DateTimeFormat</c> default and any
+/// other property on the same entity.
+/// </summary>
+public class CouchbaseDateTimePerPropertyFormatSqlGenerationTests
+{
+    [Fact]
+    public void Date_WithAttributeOverride_UsesOwnFormat_NotContextDefault()
+    {
+        using var ctx = CreateAttributeContext();
+        var stamp = new DateTime(2026, 1, 1);
+
+        var overriddenSql = ctx.Entities.Where(e => e.ShipDate.Date == stamp).ToQueryString();
+        var defaultSql = ctx.Entities.Where(e => e.Published.Date == stamp).ToQueryString();
+
+        Assert.Contains("2006-01-02", overriddenSql);
+        Assert.DoesNotContain("2006-01-02T15:04:05.999Z07:00", overriddenSql);
+
+        Assert.Contains("2006-01-02T15:04:05.999Z07:00", defaultSql);
+    }
+
+    [Fact]
+    public void Date_WithFluentOverride_UsesOwnFormat_NotContextDefault()
+    {
+        using var ctx = CreateFluentContext();
+        var stamp = new DateTime(2026, 1, 1);
+
+        var overriddenSql = ctx.Entities.Where(e => e.ShipDate.Date == stamp).ToQueryString();
+        var defaultSql = ctx.Entities.Where(e => e.Published.Date == stamp).ToQueryString();
+
+        Assert.Contains("2006-01-02", overriddenSql);
+        Assert.DoesNotContain("2006-01-02T15:04:05.999Z07:00", overriddenSql);
+
+        Assert.Contains("2006-01-02T15:04:05.999Z07:00", defaultSql);
+    }
+
+    private static AttributeContext CreateAttributeContext()
+    {
+        var clusterOptions = new ClusterOptions()
+            .WithConnectionString("couchbase://localhost")
+            .WithPasswordAuthentication("Administrator", "password");
+
+        var builder = new DbContextOptionsBuilder<AttributeContext>();
+        builder.UseCouchbaseProvider(clusterOptions);
+        return new AttributeContext(builder.Options);
+    }
+
+    private static FluentContext CreateFluentContext()
+    {
+        var clusterOptions = new ClusterOptions()
+            .WithConnectionString("couchbase://localhost")
+            .WithPasswordAuthentication("Administrator", "password");
+
+        var builder = new DbContextOptionsBuilder<FluentContext>();
+        builder.UseCouchbaseProvider(clusterOptions);
+        return new FluentContext(builder.Options);
+    }
+
+    private class AttributeEntity
+    {
+        public int Id { get; set; }
+
+        [DateTimeFormat("yyyy-MM-dd")]
+        public DateTime ShipDate { get; set; }
+
+        public DateTime Published { get; set; }
+    }
+
+    private class AttributeContext(DbContextOptions<AttributeContext> options) : DbContext(options)
+    {
+        public DbSet<AttributeEntity> Entities { get; set; } = null!;
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            modelBuilder.Entity<AttributeEntity>(b =>
+            {
+                b.ToCouchbaseCollection("bucket", "scope", "attributePost");
+                b.HasKey(p => p.Id);
+            });
+        }
+    }
+
+    private class FluentEntity
+    {
+        public int Id { get; set; }
+        public DateTime ShipDate { get; set; }
+        public DateTime Published { get; set; }
+    }
+
+    private class FluentContext(DbContextOptions<FluentContext> options) : DbContext(options)
+    {
+        public DbSet<FluentEntity> Entities { get; set; } = null!;
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            modelBuilder.Entity<FluentEntity>(b =>
+            {
+                b.ToCouchbaseCollection("bucket", "scope", "fluentPost");
+                b.HasKey(p => p.Id);
+                b.Property(p => p.ShipDate).HasDateTimeFormat("yyyy-MM-dd");
+            });
+        }
+    }
+}

--- a/tests/Couchbase.EntityFrameworkCore.UnitTests/Couchbase/EntityFrameworkCore/Storage/Internal/CouchbaseTypeMappingSourceTests.cs
+++ b/tests/Couchbase.EntityFrameworkCore.UnitTests/Couchbase/EntityFrameworkCore/Storage/Internal/CouchbaseTypeMappingSourceTests.cs
@@ -1,5 +1,6 @@
 using System.Text.Json.Nodes;
 using Couchbase.EntityFrameworkCore.Storage.Internal;
+using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Storage;
 using Microsoft.EntityFrameworkCore.Storage.Json;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
@@ -717,6 +718,43 @@ public class CouchbaseTypeMappingSourceTests
         var decodedBytes = Convert.FromBase64String(base64);
         Assert.Equal(originalBytes, decodedBytes);
     }
+
+    #endregion
+
+    #region FindMapping(IProperty) -- Per-Property DateTimeFormat Override
+
+    private class DateTimeFormatOverrideEntity
+    {
+        public int Id { get; set; }
+        public DateTime Ship { get; set; }
+    }
+
+    [Fact]
+    public void FindMappingByProperty_WithDateTimeFormatAnnotation_UsesPropertyFormat_NotContextDefault()
+    {
+        var modelBuilder = new ModelBuilder();
+        modelBuilder.Entity<DateTimeFormatOverrideEntity>()
+            .Property(e => e.Ship)
+            .HasAnnotation(CouchbaseTypeMappingSource.DateTimeFormatAnnotation, "yyyy-MM-dd");
+        var model = modelBuilder.FinalizeModel();
+        var property = model.FindEntityType(typeof(DateTimeFormatOverrideEntity))!.FindProperty(nameof(DateTimeFormatOverrideEntity.Ship))!;
+
+        var mapping = _typeMappingSource.FindMapping(property);
+
+        var dateTimeMapping = Assert.IsType<CouchbaseDateTimeTypeMapping>(mapping);
+        Assert.Equal("2006-01-02", dateTimeMapping.GoDateTimeFormat);
+
+        var literal = dateTimeMapping.GenerateSqlLiteral(new DateTime(2026, 3, 14));
+        Assert.Equal("'2026-03-14'", literal);
+    }
+
+    // The no-annotation fallback path (falling through to base.FindMapping(property), then the
+    // CLR-type-keyed dictionary) isn't unit-tested here in isolation -- it requires satisfying
+    // EF Core's own internal FindMapping(IProperty) dependency chain, which this file's minimal
+    // mocked TypeMappingSourceDependencies/RelationalTypeMappingSourceDependencies don't fully
+    // support. That fallback is already proven correct end-to-end, against a real DI-built
+    // CouchbaseTypeMappingSource, by CouchbaseDateTimePerPropertyFormatSqlGenerationTests's
+    // `Published` property (no override) asserting on the context-default Go layout.
 
     #endregion
 }


### PR DESCRIPTION
DateTimeFormat was context-wide only, but customer feedback flagged that different properties in the same model can legitimately use different DateTime string conventions. Adds a [DateTimeFormat] attribute and a HasDateTimeFormat fluent API to override the format on a single property, independent of the context-wide default.

Wired through a new CouchbaseTypeMappingSource.FindMapping(IProperty) override -- the only point that still has property/annotation access before EF Core's type-mapping-info struct loses it -- and read back in CouchbaseDateTimeMemberTranslator's .Date branch directly off the property's own resolved CouchbaseDateTimeTypeMapping, with no DI wiring needed. The static .Now/.UtcNow/.Today translators have no associated property and still use the context-wide default only; documented as a structural limit, not an oversight.