### PR TITLE
Add N1QL META() support and CAS-based optimistic concurrency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ and this project aims to follow [Semantic Versioning](https://semver.org/spec/v2
 
 ### Added
 
+- **N1QL `META()` support: document metadata fields and CAS-based optimistic concurrency.**
+  `[CouchbaseMeta(CouchbaseMetaField)]`/`HasCouchbaseMeta(...)` sources a property's value from
+  `META(alias).id`/`.cas`/`.expiration` instead of a document field. Combined with EF Core's own
+  `.IsConcurrencyToken()`, a `ulong` CAS property becomes a real optimistic-concurrency token:
+  `SaveChangesAsync` sends the CAS on update/delete and throws `DbUpdateConcurrencyException` on a
+  mismatch, closing a real gap where concurrent writes to the same document previously overwrote
+  each other silently with no error. `Id`/`Expiration` are read-only. See
+  [Optimistic concurrency](docs/concurrency.md).
+
 - **`AutoCreateIndexes` option.** When enabled, `EnsureCreatedAsync` creates a primary index on
   every collection it creates or already owns, and waits for each one to come online before
   returning — closing the gap where a query issued immediately after `EnsureCreatedAsync` could

--- a/docs/concurrency.md
+++ b/docs/concurrency.md
@@ -1,0 +1,86 @@
+# Optimistic concurrency and document metadata
+
+Couchbase's KV API tracks a CAS (compare-and-swap) value on every document — an opaque value that
+changes on every mutation, the Couchbase equivalent of a SQL rowversion. N1QL exposes this and
+other per-document metadata through the `META()` function
+([reference](https://docs.couchbase.com/server/current/n1ql/n1ql-language-reference/indexing-meta-info.html)).
+The provider maps `META()` fields onto ordinary shadow properties via `[CouchbaseMeta]`/
+`HasCouchbaseMeta`, most importantly CAS as an EF Core optimistic-concurrency token.
+
+Without a CAS-backed concurrency token, `SaveChangesAsync` performs an unconditional write —
+two concurrent updates to the same document silently overwrite each other, with no error and no
+way for either caller to detect it. Opting into CAS-based concurrency closes that gap.
+
+## CAS as a concurrency token
+
+Add a `ulong` property, mark it with `[CouchbaseMeta(CouchbaseMetaField.Cas)]` **and** EF Core's
+own `.IsConcurrencyToken()` — both are required together, so calling `.IsConcurrencyToken()` on
+an unrelated property never silently starts sending CAS checks:
+
+```
+public class Order
+{
+    public int Id { get; set; }
+    public string CustomerName { get; set; } = string.Empty;
+
+    [CouchbaseMeta(CouchbaseMetaField.Cas)]
+    public ulong Cas { get; set; }
+}
+```
+
+```
+modelBuilder.Entity<Order>()
+    .Property(e => e.Cas)
+    .IsConcurrencyToken();
+```
+
+The property is populated automatically — never set it yourself:
+
+* After `SaveChangesAsync` inserts or updates the entity, `Cas` is refreshed with the document's
+  new CAS, so a later `SaveChangesAsync` against the same tracked instance checks against the
+  correct value.
+* Any query that reads the entity also reads its current CAS via `META(alias).cas`.
+
+When `SaveChangesAsync` sends an update or delete for an entity with a CAS-backed concurrency
+token, it includes the CAS value it last read. If the document was modified or deleted by another
+process in the meantime, Couchbase's compare-and-swap check fails and the provider throws EF
+Core's own `DbUpdateConcurrencyException` — the same exception type and handling pattern (reload,
+merge, retry) EF Core applications already use for any other provider:
+
+```
+try
+{
+    await context.SaveChangesAsync();
+}
+catch (DbUpdateConcurrencyException)
+{
+    // Reload the entity (and its Cas) and retry, or surface the conflict to the caller.
+}
+```
+
+## Reading other META() fields
+
+`[CouchbaseMeta(CouchbaseMetaField.Id)]` (a `string` property) and
+`[CouchbaseMeta(CouchbaseMetaField.Expiration)]` (a `long` property, Unix epoch seconds — `0`
+means no expiration) work the same way, but are read-only: the provider has no API for setting a
+document's key or TTL on write.
+
+```
+public class Order
+{
+    public int Id { get; set; }
+
+    [CouchbaseMeta(CouchbaseMetaField.Id)]
+    public string DocumentId { get; set; } = string.Empty;
+
+    [CouchbaseMeta(CouchbaseMetaField.Expiration)]
+    public long ExpiresAt { get; set; }
+}
+```
+
+A `[CouchbaseMeta]` property must be the exact CLR type its field requires (`ulong` for `Cas`,
+`string` for `Id`, `long` for `Expiration`) — applying it to any other type throws
+`InvalidOperationException` at model-build time, and the fluent `HasCouchbaseMeta(...)` form
+throws the same way.
+
+Not supported: `META().xattrs` (extended attributes).

--- a/docs/crud.md
+++ b/docs/crud.md
@@ -130,6 +130,11 @@ further writes and by the in-flight KV calls themselves:
 await context.SaveChangesAsync(cancellationToken);
 ```
 
+By default, an update or delete is an unconditional write — if two callers modify the same
+document concurrently, the second write silently overwrites the first with no error. To detect
+that instead, opt into CAS-based optimistic concurrency: see
+[Optimistic concurrency](concurrency.md).
+
 ## Saving Related Data
 In addition to isolated entities, you can also make use of the relationships defined in your model.
 

--- a/docs/limitations.md
+++ b/docs/limitations.md
@@ -91,6 +91,16 @@ See also [Querying](Queries.md) and [Configuration](configuration.md).
   as the base type to opt into TPH.
 * **Table-per-type (TPT) and table-per-concrete-type (TPC) are not supported.**
 
+## Optimistic concurrency and document metadata
+
+* **CAS-based optimistic concurrency is supported** via `[CouchbaseMeta(CouchbaseMetaField.Cas)]`
+  combined with EF Core's own `.IsConcurrencyToken()` — see
+  [Optimistic concurrency](concurrency.md). Without it, `SaveChangesAsync` performs an
+  unconditional write (today's default, unchanged behavior).
+* **`META().id`/`META().expiration` are readable** via the same `[CouchbaseMeta]` mechanism, but
+  read-only — the provider has no API for *setting* a document's TTL/expiration on write.
+* **`META().xattrs` (extended attributes) are not supported.**
+
 ## Value generation and keys
 * **Sequence-based value generation supports a fixed set of numeric types:** `int`, `long`,
   `short`, `byte`, `uint`, `ulong`, `ushort`, and `decimal`. Other CLR types throw at

--- a/src/Couchbase.EntityFrameworkCore/Extensions/CouchbasePropertyBuilderExtensions.cs
+++ b/src/Couchbase.EntityFrameworkCore/Extensions/CouchbasePropertyBuilderExtensions.cs
@@ -1,3 +1,4 @@
+using Couchbase.EntityFrameworkCore.Metadata;
 using Couchbase.EntityFrameworkCore.Storage.Internal;
 using Couchbase.EntityFrameworkCore.ValueGeneration;
 using Microsoft.EntityFrameworkCore;
@@ -486,6 +487,54 @@ public static class CouchbasePropertyBuilderExtensions
         }
 
         propertyBuilder.HasAnnotation(CouchbaseTypeMappingSource.DateTimeFormatAnnotation, format);
+
+        return propertyBuilder;
+    }
+
+    #endregion
+
+    #region META() Field Override
+
+    /// <summary>
+    /// Sources this property's value from N1QL's <c>META()</c> function instead of a JSON document
+    /// field. See <see cref="Couchbase.EntityFrameworkCore.Metadata.CouchbaseMetaField"/> for the
+    /// supported fields. Equivalent to applying
+    /// <see cref="Couchbase.EntityFrameworkCore.Metadata.CouchbaseMetaAttribute"/> to the property.
+    /// </summary>
+    /// <remarks>
+    /// For <see cref="Couchbase.EntityFrameworkCore.Metadata.CouchbaseMetaField.Cas"/>, also call
+    /// <c>.IsConcurrencyToken()</c> so EF Core treats it as an optimistic-concurrency token — the
+    /// two are required together deliberately, so this provider's CAS-specific write-path behavior
+    /// is never silently triggered just by adding <c>.IsConcurrencyToken()</c> to an unrelated
+    /// property.
+    /// </remarks>
+    /// <param name="propertyBuilder">The property builder.</param>
+    /// <param name="field">The document-metadata field this property is sourced from.</param>
+    /// <returns>The same property builder for method chaining.</returns>
+    /// <example>
+    /// <code>
+    /// modelBuilder.Entity&lt;Order&gt;()
+    ///     .Property(e => e.Cas)
+    ///     .HasCouchbaseMeta(CouchbaseMetaField.Cas)
+    ///     .IsConcurrencyToken();
+    /// </code>
+    /// </example>
+    public static PropertyBuilder<TProperty> HasCouchbaseMeta<TProperty>(
+        this PropertyBuilder<TProperty> propertyBuilder,
+        CouchbaseMetaField field)
+    {
+        var expectedClrType = CouchbaseMetaFieldClrTypes.Get(field);
+        var clrType = propertyBuilder.Metadata.ClrType;
+        if (clrType != expectedClrType)
+        {
+            throw new InvalidOperationException(
+                $"HasCouchbaseMeta({field}) can only be used on properties of type '{CouchbaseMetaFieldClrTypes.GetDisplayName(field)}', " +
+                $"but property '{propertyBuilder.Metadata.DeclaringType.ClrType.Name}.{propertyBuilder.Metadata.Name}' " +
+                $"is of type '{clrType.Name}'.");
+        }
+
+        propertyBuilder.HasAnnotation(CouchbaseMetaAnnotationNames.MetaField, field.ToString());
+        propertyBuilder.ValueGeneratedOnAddOrUpdate();
 
         return propertyBuilder;
     }

--- a/src/Couchbase.EntityFrameworkCore/Metadata/Conventions/CouchbaseConventionSetBuilder.cs
+++ b/src/Couchbase.EntityFrameworkCore/Metadata/Conventions/CouchbaseConventionSetBuilder.cs
@@ -19,6 +19,7 @@ public class CouchbaseConventionSetBuilder : RelationalConventionSetBuilder
         conventionSet.Add(new JsonPropertyNameConvention(Dependencies));
         conventionSet.Add(new JsonPropertyConvention(Dependencies));
         conventionSet.Add(new DateTimeFormatConvention(Dependencies));
+        conventionSet.Add(new CouchbaseMetaConvention(Dependencies));
         return conventionSet;
     }
 }

--- a/src/Couchbase.EntityFrameworkCore/Metadata/Conventions/CouchbaseMetaConvention.cs
+++ b/src/Couchbase.EntityFrameworkCore/Metadata/Conventions/CouchbaseMetaConvention.cs
@@ -1,0 +1,59 @@
+using System.Reflection;
+using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using Microsoft.EntityFrameworkCore.Metadata.Conventions;
+using Microsoft.EntityFrameworkCore.Metadata.Conventions.Infrastructure;
+
+namespace Couchbase.EntityFrameworkCore.Metadata.Conventions;
+
+/// <summary>
+/// A convention that processes <see cref="CouchbaseMetaAttribute"/> on properties and configures
+/// them to source their value from N1QL's <c>META()</c> function instead of a document field.
+/// </summary>
+public class CouchbaseMetaConvention : PropertyAttributeConventionBase<CouchbaseMetaAttribute>
+{
+    public CouchbaseMetaConvention(ProviderConventionSetBuilderDependencies dependencies)
+        : base(dependencies)
+    {
+    }
+
+    protected override void ProcessPropertyAdded(
+        IConventionPropertyBuilder propertyBuilder,
+        CouchbaseMetaAttribute attribute,
+        MemberInfo clrMember,
+        IConventionContext context)
+    {
+        var expectedClrType = CouchbaseMetaFieldClrTypes.Get(attribute.Field);
+        var clrType = propertyBuilder.Metadata.ClrType;
+        if (clrType != expectedClrType)
+        {
+            throw new InvalidOperationException(
+                $"[CouchbaseMeta({attribute.Field})] can only be applied to properties of type " +
+                $"'{CouchbaseMetaFieldClrTypes.GetDisplayName(attribute.Field)}', but property " +
+                $"'{propertyBuilder.Metadata.DeclaringType.ClrType.Name}.{propertyBuilder.Metadata.Name}' " +
+                $"is of type '{clrType.Name}'.");
+        }
+
+        propertyBuilder.HasAnnotation(CouchbaseMetaAnnotationNames.MetaField, attribute.Field.ToString());
+        propertyBuilder.ValueGenerated(ValueGenerated.OnAddOrUpdate);
+    }
+}
+
+/* ************************************************************
+ *
+ *    @author Couchbase <info@couchbase.com>
+ *    @copyright 2025 Couchbase, Inc.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ *
+ * ************************************************************/

--- a/src/Couchbase.EntityFrameworkCore/Metadata/CouchbaseMetaAnnotationNames.cs
+++ b/src/Couchbase.EntityFrameworkCore/Metadata/CouchbaseMetaAnnotationNames.cs
@@ -1,0 +1,15 @@
+namespace Couchbase.EntityFrameworkCore.Metadata;
+
+/// <summary>
+/// Annotation names used by the <see cref="CouchbaseMetaAttribute"/>/<c>HasCouchbaseMeta</c>
+/// META-field mechanism. Shared across the write path (skip in the document body), the read path
+/// (render <c>META(alias).field</c> in generated SQL++), and the CAS-specific concurrency wiring.
+/// </summary>
+public static class CouchbaseMetaAnnotationNames
+{
+    /// <summary>
+    /// The <see cref="CouchbaseMetaField"/> a property is sourced from, stored as its
+    /// <see cref="string"/> name (e.g. <c>"Cas"</c>).
+    /// </summary>
+    public const string MetaField = "Couchbase:MetaField";
+}

--- a/src/Couchbase.EntityFrameworkCore/Metadata/CouchbaseMetaAttribute.cs
+++ b/src/Couchbase.EntityFrameworkCore/Metadata/CouchbaseMetaAttribute.cs
@@ -1,0 +1,45 @@
+namespace Couchbase.EntityFrameworkCore.Metadata;
+
+/// <summary>
+/// Sources this property's value from N1QL's <c>META()</c> function instead of a JSON document
+/// field — see <see cref="CouchbaseMetaField"/> for the supported fields.
+/// </summary>
+/// <remarks>
+/// The property becomes a server-computed shadow-style value: it is never written into the
+/// document body, and its value is populated by the query engine (via <c>META(alias).field</c>)
+/// whenever it's read. For <see cref="CouchbaseMetaField.Cas"/>, also call
+/// <c>.IsConcurrencyToken()</c> (or apply <see cref="System.ComponentModel.DataAnnotations.ConcurrencyCheckAttribute"/>)
+/// so EF Core treats it as an optimistic-concurrency token — the two are required together
+/// deliberately, so this provider's CAS-specific write-path behavior (sending the value on
+/// update/delete, translating a mismatch to <see cref="Microsoft.EntityFrameworkCore.DbUpdateConcurrencyException"/>)
+/// is never silently triggered just by adding <c>.IsConcurrencyToken()</c> to an unrelated property.
+/// </remarks>
+/// <example>
+/// <code>
+/// public class Order
+/// {
+///     public int Id { get; set; }
+///
+///     [CouchbaseMeta(CouchbaseMetaField.Cas)]
+///     [ConcurrencyCheck]
+///     public ulong Cas { get; set; }
+/// }
+/// </code>
+/// </example>
+[AttributeUsage(AttributeTargets.Property)]
+public class CouchbaseMetaAttribute : Attribute
+{
+    /// <summary>
+    /// Initializes a new instance for the specified metadata field.
+    /// </summary>
+    /// <param name="field">The document-metadata field this property is sourced from.</param>
+    public CouchbaseMetaAttribute(CouchbaseMetaField field)
+    {
+        Field = field;
+    }
+
+    /// <summary>
+    /// Gets the document-metadata field this property is sourced from.
+    /// </summary>
+    public CouchbaseMetaField Field { get; }
+}

--- a/src/Couchbase.EntityFrameworkCore/Metadata/CouchbaseMetaField.cs
+++ b/src/Couchbase.EntityFrameworkCore/Metadata/CouchbaseMetaField.cs
@@ -1,0 +1,57 @@
+namespace Couchbase.EntityFrameworkCore.Metadata;
+
+/// <summary>
+/// A document-metadata field exposed by N1QL's <c>META()</c> function
+/// (<see href="https://docs.couchbase.com/server/current/n1ql/n1ql-language-reference/indexing-meta-info.html"/>),
+/// for use with <see cref="CouchbaseMetaAttribute"/> and the <c>HasCouchbaseMeta</c> fluent API.
+/// </summary>
+public enum CouchbaseMetaField
+{
+    /// <summary>
+    /// The document's key (<c>META(alias).id</c>). Read-only. Maps to a <see cref="string"/> property.
+    /// </summary>
+    Id,
+
+    /// <summary>
+    /// The document's CAS (compare-and-swap) value (<c>META(alias).cas</c>) — an opaque value that
+    /// changes on every mutation, Couchbase's equivalent of a SQL rowversion. Maps to a
+    /// <see cref="ulong"/> property. Combine with EF Core's own <c>.IsConcurrencyToken()</c> to use
+    /// it as an optimistic-concurrency token.
+    /// </summary>
+    Cas,
+
+    /// <summary>
+    /// The document's expiration (TTL), as Unix epoch seconds (<c>META(alias).expiration</c>) — 0
+    /// means no expiration. Read-only: this provider does not currently support setting a TTL on
+    /// write. Maps to a <see cref="long"/> property.
+    /// </summary>
+    Expiration,
+}
+
+/// <summary>
+/// The expected CLR type for each <see cref="CouchbaseMetaField"/>, shared between
+/// <see cref="Conventions.CouchbaseMetaConvention"/> and the <c>HasCouchbaseMeta</c> fluent API so
+/// both enforce the exact same validation.
+/// </summary>
+internal static class CouchbaseMetaFieldClrTypes
+{
+    public static Type Get(CouchbaseMetaField field) => field switch
+    {
+        CouchbaseMetaField.Id => typeof(string),
+        CouchbaseMetaField.Cas => typeof(ulong),
+        CouchbaseMetaField.Expiration => typeof(long),
+        _ => throw new ArgumentOutOfRangeException(nameof(field), field, "Unknown CouchbaseMetaField."),
+    };
+
+    /// <summary>
+    /// The C# keyword name for <see cref="Get"/>'s result (e.g. <c>"ulong"</c>, not <c>Type.Name</c>'s
+    /// <c>"UInt64"</c>), for clearer error messages.
+    /// </summary>
+    public static string GetDisplayName(CouchbaseMetaField field) => field switch
+    {
+        CouchbaseMetaField.Id => "string",
+        CouchbaseMetaField.Cas => "ulong",
+        CouchbaseMetaField.Expiration => "long",
+        _ => throw new ArgumentOutOfRangeException(nameof(field), field, "Unknown CouchbaseMetaField."),
+    };
+}

--- a/src/Couchbase.EntityFrameworkCore/Query/Internal/CouchbaseProjectionAliases.cs
+++ b/src/Couchbase.EntityFrameworkCore/Query/Internal/CouchbaseProjectionAliases.cs
@@ -1,5 +1,7 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
+using Couchbase.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Query.SqlExpressions;
 
@@ -40,8 +42,27 @@ internal static class CouchbaseProjectionAliases
         => navigation.DeclaringEntityType.ClrType.FullName + "." + navigation.Name;
 
     /// <summary>
+    /// The <see cref="CouchbaseMetaField"/> name (e.g. <c>"Cas"</c>) a column is sourced from via
+    /// <c>[CouchbaseMeta]</c>/<c>HasCouchbaseMeta</c>, or <see langword="null"/> if it's a normal
+    /// document field. <see cref="ColumnExpression.Column"/> exposes a live <see cref="IProperty"/>
+    /// reference (via <c>PropertyMappings</c>) back to the property that produced this column --
+    /// including shadow properties -- so this works without any change to how EF Core builds the
+    /// projection itself. Shared between <see cref="EffectiveAlias"/> (so the alias-uniquification
+    /// pass knows a META column's *actual* N1QL-implicit name is the lowercase field name, not the
+    /// property's own name) and <see cref="CouchbaseQuerySqlGenerator"/>'s rendering of the column
+    /// itself.
+    /// </summary>
+    public static string? GetMetaField(ColumnExpression columnExpression)
+        => columnExpression.Column?.PropertyMappings
+            .Select(m => m.Property.FindAnnotation(CouchbaseMetaAnnotationNames.MetaField)?.Value as string)
+            .FirstOrDefault(f => f != null);
+
+    /// <summary>
     /// The N1QL response key for a single projection when no uniquification is applied:
-    /// the explicit <c>AS</c> alias if present, otherwise the underlying column name.
+    /// the explicit <c>AS</c> alias if present, otherwise the underlying column name. This is the
+    /// *desired* key (what the reader expects), which for a <c>META(alias).field</c> projection is
+    /// still the property's own name (e.g. <c>"DocId"</c>) -- see <see cref="NeedsExplicitAlias"/>
+    /// for why such a projection can never rely on N1QL's own implicit naming to produce that key.
     /// </summary>
     public static string EffectiveAlias(ProjectionExpression projection)
         => projection.Alias != string.Empty
@@ -49,6 +70,18 @@ internal static class CouchbaseProjectionAliases
             : projection.Expression is ColumnExpression c
                 ? c.Name
                 : string.Empty;
+
+    /// <summary>
+    /// Whether a projection must get an explicit <c>AS &lt;alias&gt;</c> regardless of what the
+    /// collision-avoidance pass in <see cref="ComputeUnique"/> decided -- true for any
+    /// <c>META(alias).field</c> projection, since N1QL's own implicit-naming behavior for a
+    /// function-call-based expression doesn't reliably (or ever, empirically) produce the
+    /// property's own name (e.g. <c>META(d).id</c> does not implicitly come back keyed
+    /// <c>"DocId"</c>, or even reliably <c>"id"</c>) the way a bare <c>alias.field</c> reference's
+    /// implicit name always matches its own column name.
+    /// </summary>
+    public static bool NeedsExplicitAlias(ProjectionExpression projection)
+        => projection.Expression is ColumnExpression c && GetMetaField(c) != null;
 
     /// <summary>
     /// Computes a collision-free alias for every projection, in projection order.  The first

--- a/src/Couchbase.EntityFrameworkCore/Query/Internal/CouchbaseQuerySqlGenerator.cs
+++ b/src/Couchbase.EntityFrameworkCore/Query/Internal/CouchbaseQuerySqlGenerator.cs
@@ -516,9 +516,13 @@ public class CouchbaseQuerySqlGenerator : QuerySqlGenerator
 
                     GenerateList(emitted, e =>
                     {
-                        // Only append AS when the unique alias differs from what the projection
-                        // would emit on its own — keeps non-colliding queries byte-identical.
-                        if (e.Alias != CouchbaseProjectionAliases.EffectiveAlias(e.Projection))
+                        // Append AS when the unique alias differs from what the projection would
+                        // emit on its own (keeps non-colliding queries byte-identical), OR when the
+                        // projection is a META(alias).field column -- N1QL's own implicit naming
+                        // for that shape doesn't reliably produce the desired key (see
+                        // CouchbaseProjectionAliases.NeedsExplicitAlias).
+                        if (e.Alias != CouchbaseProjectionAliases.EffectiveAlias(e.Projection)
+                            || CouchbaseProjectionAliases.NeedsExplicitAlias(e.Projection))
                         {
                             Visit(e.Projection.Expression);
                             Sql.Append(AliasSeparator)
@@ -646,6 +650,22 @@ public class CouchbaseQuerySqlGenerator : QuerySqlGenerator
     protected override Expression VisitColumn(ColumnExpression columnExpression)
     {
         var helper = Dependencies.SqlGenerationHelper;
+        var metaField = CouchbaseProjectionAliases.GetMetaField(columnExpression);
+        if (metaField != null)
+        {
+            // META() takes no keyspace parameter when the alias is the one being indexed/queried --
+            // https://docs.couchbase.com/server/current/n1ql/n1ql-language-reference/indexing-meta-info.html
+            // Deliberately no alias appended here -- CouchbaseProjectionAliases.EffectiveAlias
+            // already knows this renders as the lowercase field name (e.g. "id"), not the
+            // property's own name, so the outer projection-list loop in VisitSelect adds an
+            // explicit AS whenever the property name differs, exactly like any other projection.
+            Sql.Append("META(")
+                .Append(helper.DelimitIdentifier(columnExpression.TableAlias))
+                .Append(").")
+                .Append(metaField.ToLowerInvariant());
+            return columnExpression;
+        }
+
         Sql.Append(helper.DelimitIdentifier(columnExpression.TableAlias))
             .Append(".")
             .Append(helper.DelimitIdentifier(columnExpression.Name));

--- a/src/Couchbase.EntityFrameworkCore/Storage/Internal/CouchbaseClientWrapper.cs
+++ b/src/Couchbase.EntityFrameworkCore/Storage/Internal/CouchbaseClientWrapper.cs
@@ -34,18 +34,26 @@ public class CouchbaseClientWrapper : ICouchbaseClientWrapper
 
     public string BucketName => _couchbaseDbContextOptionsBuilder.Bucket;
 
-    public async Task<bool> DeleteDocument(string id, string keyspace, CancellationToken cancellationToken = default)
+    public async Task<bool> DeleteDocument(string id, string keyspace, ulong? cas = null, CancellationToken cancellationToken = default)
     {
-        bool success;
         try
         {
             var collection = await GetCollection(keyspace, cancellationToken).ConfigureAwait(false);
-            await collection.RemoveAsync(id, new RemoveOptions().CancellationToken(cancellationToken)).ConfigureAwait(false);
-            success = true;
+            var options = new RemoveOptions().CancellationToken(cancellationToken);
+            if (cas.HasValue)
+            {
+                options = options.Cas(cas.Value);
+            }
+            await collection.RemoveAsync(id, options).ConfigureAwait(false);
+            return true;
         }
         catch (OperationCanceledException)
         {
             throw; // Surface cancellation as-is rather than masking it as a DbUpdateException.
+        }
+        catch (Couchbase.Core.Exceptions.CasMismatchException)
+        {
+            throw; // Surface as-is so the caller can translate it to DbUpdateConcurrencyException.
         }
         catch (Exception e)
         {
@@ -55,18 +63,15 @@ public class CouchbaseClientWrapper : ICouchbaseClientWrapper
             throw new DbUpdateException(
                 $"Delete failed for key {id} in keyspace {keyspace}", e);
         }
-
-        return success;
     }
 
-    public async Task<bool> CreateDocument<TEntity>(string id, string keyspace, TEntity entity, CancellationToken cancellationToken = default)
+    public async Task<ulong> CreateDocument<TEntity>(string id, string keyspace, TEntity entity, CancellationToken cancellationToken = default)
     {
-        bool success;
         try
         {
             var collection = await GetCollection(keyspace, cancellationToken).ConfigureAwait(false);
-            await collection.InsertAsync(id, entity, new InsertOptions().CancellationToken(cancellationToken)).ConfigureAwait(false);
-            success = true;
+            var result = await collection.InsertAsync(id, entity, new InsertOptions().CancellationToken(cancellationToken)).ConfigureAwait(false);
+            return result.Cas;
         }
         catch (OperationCanceledException)
         {
@@ -80,22 +85,35 @@ public class CouchbaseClientWrapper : ICouchbaseClientWrapper
             throw new DbUpdateException(
                 $"Insert failed for key {id} in keyspace {keyspace}", e);
         }
-
-        return success;
     }
 
-    public async Task<bool> UpdateDocument<TEntity>(string id, string keyspace, TEntity entity, CancellationToken cancellationToken = default)
+    public async Task<ulong> UpdateDocument<TEntity>(string id, string keyspace, TEntity entity, ulong? cas = null, CancellationToken cancellationToken = default)
     {
-        bool success;
         try
         {
             var collection = await GetCollection(keyspace, cancellationToken).ConfigureAwait(false);
-            await collection.UpsertAsync(id, entity, new UpsertOptions().CancellationToken(cancellationToken)).ConfigureAwait(false);
-            success = true;
+
+            // A CAS-checked write must use Replace (Upsert has no Cas option at all, and would
+            // silently create-or-overwrite regardless of whether the document changed underneath
+            // us) -- only take this path when the caller actually wants concurrency enforcement,
+            // to keep today's unconditional-upsert behavior unchanged for everyone else.
+            if (cas.HasValue)
+            {
+                var replaceResult = await collection.ReplaceAsync(
+                    id, entity, new ReplaceOptions().Cas(cas.Value).CancellationToken(cancellationToken)).ConfigureAwait(false);
+                return replaceResult.Cas;
+            }
+
+            var upsertResult = await collection.UpsertAsync(id, entity, new UpsertOptions().CancellationToken(cancellationToken)).ConfigureAwait(false);
+            return upsertResult.Cas;
         }
         catch (OperationCanceledException)
         {
             throw; // Surface cancellation as-is rather than masking it as a DbUpdateException.
+        }
+        catch (Couchbase.Core.Exceptions.CasMismatchException)
+        {
+            throw; // Surface as-is so the caller can translate it to DbUpdateConcurrencyException.
         }
         catch (Exception e)
         {
@@ -105,8 +123,6 @@ public class CouchbaseClientWrapper : ICouchbaseClientWrapper
             throw new DbUpdateException(
                 $"Update failed for key {id} in keyspace {keyspace}", e);
         }
-
-        return success;
     }
 
     public async Task<ICouchbaseCollection> GetCollectionAsync(string keyspace, CancellationToken cancellationToken = default)

--- a/src/Couchbase.EntityFrameworkCore/Storage/Internal/CouchbaseDatabaseWrapper.cs
+++ b/src/Couchbase.EntityFrameworkCore/Storage/Internal/CouchbaseDatabaseWrapper.cs
@@ -3,6 +3,7 @@ using System.Text.Json;
 using Couchbase.EntityFrameworkCore.Extensions;
 using Couchbase.EntityFrameworkCore.Infrastructure;
 using Couchbase.EntityFrameworkCore.Internal;
+using Couchbase.EntityFrameworkCore.Metadata;
 using Couchbase.EntityFrameworkCore.Utils;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.ChangeTracking.Internal;
@@ -101,6 +102,8 @@ public class CouchbaseDatabaseWrapper : Database
                     $"Entity type '{entityType.ClrType.Name}' has no mapped table name. " +
                     "Ensure the entity is mapped to a Couchbase collection via ToCouchbaseCollection().");
 
+            var casProperty = GetCasProperty(entityType);
+
             switch (updateEntry.EntityState)
             {
                 case EntityState.Detached:
@@ -112,19 +115,22 @@ public class CouchbaseDatabaseWrapper : Database
                 case EntityState.Deleted:
                     // Add to writtenRoots so the deferred pass doesn't upsert a just-deleted doc.
                     writtenRoots.Add($"{entityType.ClrType.Name}:{primaryKey}");
-                    pendingWrites.Add(new PendingWrite(CouchbaseWriteKind.Delete, primaryKey, keyspace, null));
+                    pendingWrites.Add(new PendingWrite(CouchbaseWriteKind.Delete, primaryKey, keyspace, null,
+                        updateEntry, null, GetCasCheckValue(casProperty, updateEntry)));
                     break;
 
                 case EntityState.Modified:
                     writtenRoots.Add($"{entityType.ClrType.Name}:{primaryKey}");
                     pendingWrites.Add(new PendingWrite(CouchbaseWriteKind.Upsert, primaryKey, keyspace,
-                        HydrateObjectFromEntity(updateEntry, _fieldNamingPolicy)));
+                        HydrateObjectFromEntity(updateEntry, _fieldNamingPolicy),
+                        updateEntry, casProperty, GetCasCheckValue(casProperty, updateEntry)));
                     break;
 
                 case EntityState.Added:
                     writtenRoots.Add($"{entityType.ClrType.Name}:{primaryKey}");
                     pendingWrites.Add(new PendingWrite(CouchbaseWriteKind.Insert, primaryKey, keyspace,
-                        HydrateObjectFromEntity(updateEntry, _fieldNamingPolicy)));
+                        HydrateObjectFromEntity(updateEntry, _fieldNamingPolicy),
+                        updateEntry, casProperty, null));
                     break;
 
                 default:
@@ -185,16 +191,43 @@ public class CouchbaseDatabaseWrapper : Database
                     "Ensure the entity is mapped to a Couchbase collection via ToCouchbaseCollection().");
 
             var ownerDocument = HydrateObjectFromEntity(rootInternalEntry, _fieldNamingPolicy);
-            pendingWrites.Add(new PendingWrite(CouchbaseWriteKind.Upsert, ownerPrimaryKey, ownerKeyspace, ownerDocument));
+            var ownerCasProperty = GetCasProperty(rootEntityType);
+            pendingWrites.Add(new PendingWrite(CouchbaseWriteKind.Upsert, ownerPrimaryKey, ownerKeyspace, ownerDocument,
+                rootInternalEntry, ownerCasProperty, GetCasCheckValue(ownerCasProperty, rootInternalEntry)));
         }
 
         return await ExecutePendingWritesAsync(pendingWrites, transaction, cancellationToken).ConfigureAwait(false);
     }
 
+    // A [CouchbaseMeta(Cas)]-annotated property, refreshed with the resulting CAS after every
+    // successful insert/update regardless of whether it's also a concurrency token (harmless and
+    // keeps the property useful for inspection even without concurrency enforcement).
+    private static IProperty? GetCasProperty(IEntityType entityType)
+        => entityType.GetProperties().FirstOrDefault(p =>
+            p.FindAnnotation(CouchbaseMetaAnnotationNames.MetaField)?.Value as string == nameof(CouchbaseMetaField.Cas));
+
+    // Only pass a CAS as an input check (enforcing optimistic concurrency) when the property is
+    // ALSO marked .IsConcurrencyToken() -- required together deliberately, so adding
+    // [CouchbaseMeta(Cas)] alone never silently starts throwing DbUpdateConcurrencyException.
+    //
+    // Uses GetOriginalValue, not GetCurrentValue: EF Core's documented DbUpdateConcurrencyException
+    // resolution pattern is `entry.OriginalValues.SetValues(databaseValues)` before retrying
+    // SaveChanges -- that call updates OriginalValues only, never CurrentValues. Reading
+    // GetCurrentValue here would keep sending the stale, already-rejected CAS on every retry (an
+    // infinite failure loop) even though the app followed EF Core's own recommended pattern
+    // exactly. OriginalValues is also the semantically correct source for a concurrency check
+    // regardless: it represents "what this entry believes is currently in the database," which is
+    // exactly the value Couchbase's compare-and-swap needs to test against.
+    private static ulong? GetCasCheckValue(IProperty? casProperty, IUpdateEntry updateEntry)
+        => casProperty is { IsConcurrencyToken: true }
+            ? (ulong)updateEntry.GetOriginalValue(casProperty)!
+            : null;
+
     private enum CouchbaseWriteKind { Insert, Upsert, Delete }
 
     private readonly record struct PendingWrite(
-        CouchbaseWriteKind Kind, string Key, string Keyspace, object? Document);
+        CouchbaseWriteKind Kind, string Key, string Keyspace, object? Document,
+        IUpdateEntry? UpdateEntry, IProperty? CasProperty, ulong? Cas);
 
     // Upper bound on concurrent KV writes for a single SaveChanges so a very large change set
     // doesn't flood the SDK's connection pool. KV ops are I/O-bound, so this is well above core count.
@@ -255,25 +288,61 @@ public class CouchbaseDatabaseWrapper : Database
             new ParallelOptions { MaxDegreeOfParallelism = MaxWriteConcurrency, CancellationToken = cancellationToken },
             async (write, _) =>
             {
-                var written = write.Kind switch
+                try
                 {
-                    CouchbaseWriteKind.Delete => await _couchbaseClient.DeleteDocument(write.Key, write.Keyspace, cancellationToken).ConfigureAwait(false),
-                    CouchbaseWriteKind.Upsert => await _couchbaseClient.UpdateDocument(write.Key, write.Keyspace, write.Document!, cancellationToken).ConfigureAwait(false),
-                    CouchbaseWriteKind.Insert => await _couchbaseClient.CreateDocument(write.Key, write.Keyspace, write.Document!, cancellationToken).ConfigureAwait(false),
-                    _ => false
-                };
-                if (written)
-                {
-                    Interlocked.Increment(ref successCount);
+                    switch (write.Kind)
+                    {
+                        case CouchbaseWriteKind.Delete:
+                            await _couchbaseClient.DeleteDocument(write.Key, write.Keyspace, write.Cas, cancellationToken).ConfigureAwait(false);
+                            break;
+
+                        case CouchbaseWriteKind.Upsert:
+                        {
+                            var newCas = await _couchbaseClient.UpdateDocument(write.Key, write.Keyspace, write.Document!, write.Cas, cancellationToken).ConfigureAwait(false);
+                            RefreshCasProperty(write, newCas);
+                            break;
+                        }
+
+                        case CouchbaseWriteKind.Insert:
+                        {
+                            var newCas = await _couchbaseClient.CreateDocument(write.Key, write.Keyspace, write.Document!, cancellationToken).ConfigureAwait(false);
+                            RefreshCasProperty(write, newCas);
+                            break;
+                        }
+                    }
                 }
+                catch (Couchbase.Core.Exceptions.CasMismatchException ex)
+                {
+                    // Translated to EF Core's own concurrency-conflict exception -- the same type
+                    // applications already catch/retry against for any other provider, so CAS
+                    // concurrency support needs no new app-facing exception-handling API.
+                    throw new DbUpdateConcurrencyException(
+                        $"The document '{write.Key}' in keyspace '{write.Keyspace}' was modified or " +
+                        "deleted by another process since it was read (CAS mismatch).",
+                        ex,
+                        write.UpdateEntry != null ? [write.UpdateEntry] : []);
+                }
+
+                Interlocked.Increment(ref successCount);
             }).ConfigureAwait(false);
         return successCount;
+    }
+
+    // Writes the fresh, post-write CAS back onto the tracked entry so a subsequent SaveChanges
+    // against the same entity has the correct up-to-date value to check against -- mirrors how
+    // any other database-generated value (e.g. an identity column) is reflected back after a save.
+    private static void RefreshCasProperty(PendingWrite write, ulong newCas)
+    {
+        if (write.CasProperty != null && write.UpdateEntry != null)
+        {
+            write.UpdateEntry.SetStoreGeneratedValue(write.CasProperty, newCas, setModified: false);
+        }
     }
 
     // Internal seam so the null-nav behaviour can be verified without a live DbContext.
     internal static void FillOwnsOneIntoDoc(Dictionary<string, object?> doc, INavigation nav, object? navValue)
     {
-        foreach (var p in nav.TargetEntityType.GetProperties().Where(p => !p.IsShadowProperty()))
+        foreach (var p in nav.TargetEntityType.GetProperties().Where(p => !p.IsShadowProperty() && !IsMetaBacked(p)))
         {
             // When the entire navigation is null every flattened column must be written as
             // null unconditionally — do NOT call ApplyConverter here.  A converter with
@@ -301,6 +370,13 @@ public class CouchbaseDatabaseWrapper : Database
         }
         return null;
     }
+
+    // A [CouchbaseMeta]/HasCouchbaseMeta-annotated property (e.g. Cas, sourced from META()) has no
+    // document-body field at all -- it must never be written, regardless of whether it happens to
+    // be a shadow property or a real CLR property (the documented usage is a real property, e.g.
+    // `public ulong Cas { get; set; }`, so IsShadowProperty() alone would not catch it).
+    private static bool IsMetaBacked(IProperty property)
+        => property.FindAnnotation(CouchbaseMetaAnnotationNames.MetaField) != null;
 
     internal static object HydrateObjectFromEntity(IUpdateEntry updateEntry, JsonNamingPolicy? fieldNamingPolicy = null)
     {
@@ -333,6 +409,7 @@ public class CouchbaseDatabaseWrapper : Database
                 var joinDoc = new Dictionary<string, object?>();
                 foreach (var property in entityType.GetProperties())
                 {
+                    if (IsMetaBacked(property)) continue;
                     // Use GetColumnName() verbatim — do NOT apply fieldNamingPolicy here.
                     // The SQL generation path projects these columns by their exact column
                     // name (e.g. "PostsPostId", "TagsTagId"), so the written document keys
@@ -350,6 +427,7 @@ public class CouchbaseDatabaseWrapper : Database
             foreach (var property in entityType.GetProperties())
             {
                 if (property.IsShadowProperty() && property != discriminator) continue;
+                if (IsMetaBacked(property)) continue;
                 var rawValue = updateEntry.GetCurrentValue(property);
                 regularDoc[property.GetColumnName()] = ApplyConverter(property, rawValue);
             }
@@ -376,6 +454,7 @@ public class CouchbaseDatabaseWrapper : Database
         foreach (var property in entityType.GetProperties())
         {
             if (property.IsShadowProperty() && property != discriminator) continue;
+            if (IsMetaBacked(property)) continue;
             var rawDocValue = updateEntry.GetCurrentValue(property);
             doc[property.GetColumnName()] = ApplyConverter(property, rawDocValue);
         }
@@ -446,6 +525,7 @@ public class CouchbaseDatabaseWrapper : Database
         foreach (var p in entityType.GetProperties())
         {
             if (p.IsShadowProperty()) continue;
+            if (IsMetaBacked(p)) continue;
             // Read via PropertyInfo → FieldInfo fallback (field-access support).
             var rawValue = p.PropertyInfo != null
                 ? p.PropertyInfo.GetValue(item)

--- a/src/Couchbase.EntityFrameworkCore/Storage/Internal/ICouchbaseClientWrapper.cs
+++ b/src/Couchbase.EntityFrameworkCore/Storage/Internal/ICouchbaseClientWrapper.cs
@@ -4,11 +4,27 @@ namespace Couchbase.EntityFrameworkCore.Storage.Internal;
 
 public interface ICouchbaseClientWrapper
 {
-    Task<bool> DeleteDocument(string id, string keyspace, CancellationToken cancellationToken = default);
+    /// <summary>
+    /// Deletes a document. If <paramref name="cas"/> is supplied, the delete is conditioned on it
+    /// (via the SDK's <c>RemoveOptions.Cas</c>) and throws
+    /// <see cref="Couchbase.Core.Exceptions.CasMismatchException"/> if the document was modified
+    /// since that CAS was read; when <see langword="null"/>, the delete is unconditional.
+    /// </summary>
+    Task<bool> DeleteDocument(string id, string keyspace, ulong? cas = null, CancellationToken cancellationToken = default);
 
-    Task<bool> CreateDocument<TEntity>(string id, string keyspace, TEntity entity, CancellationToken cancellationToken = default);
+    /// <summary>
+    /// Inserts a new document and returns its resulting CAS.
+    /// </summary>
+    Task<ulong> CreateDocument<TEntity>(string id, string keyspace, TEntity entity, CancellationToken cancellationToken = default);
 
-    Task<bool> UpdateDocument<TEntity>(string id, string keyspace, TEntity entity, CancellationToken cancellationToken = default);
+    /// <summary>
+    /// Writes a document and returns its resulting CAS. If <paramref name="cas"/> is supplied, this
+    /// uses a CAS-checked replace (via the SDK's <c>ReplaceOptions.Cas</c>) and throws
+    /// <see cref="Couchbase.Core.Exceptions.CasMismatchException"/> if the document was modified
+    /// since that CAS was read; when <see langword="null"/>, this is an unconditional upsert
+    /// (create-or-replace), matching this method's original behavior.
+    /// </summary>
+    Task<ulong> UpdateDocument<TEntity>(string id, string keyspace, TEntity entity, ulong? cas = null, CancellationToken cancellationToken = default);
 
     string BucketName { get; }
 

--- a/tests/Couchbase.EntityFrameworkCore.IntegrationTests/Tests/CouchbaseMetaTests.cs
+++ b/tests/Couchbase.EntityFrameworkCore.IntegrationTests/Tests/CouchbaseMetaTests.cs
@@ -1,0 +1,244 @@
+using Couchbase.EntityFrameworkCode.IntegrationTests.Fixtures;
+using Couchbase.EntityFrameworkCore;
+using Couchbase.EntityFrameworkCore.Extensions;
+using Couchbase.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+
+namespace Couchbase.EntityFrameworkCode.IntegrationTests.Tests;
+
+/// <summary>
+/// Proves N1QL <c>META()</c> support against a real cluster: <c>META().cas</c> as an EF Core
+/// optimistic-concurrency token (closing the previously-nonexistent concurrent-write detection
+/// gap), and read-only <c>META().id</c>/<c>META().expiration</c> access.
+/// </summary>
+[Collection(CouchbaseTestingCollection.Name)]
+public class CouchbaseMetaTests(BloggingFixture fixture) : IAsyncLifetime
+{
+    private static readonly string CollectionName = "meta" + Guid.NewGuid().ToString("N");
+
+    public Task InitializeAsync() => Task.CompletedTask;
+
+    private MetaDbContext CreateContext()
+    {
+        var optionsBuilder = new DbContextOptionsBuilder<MetaDbContext>();
+        optionsBuilder.UseCouchbase(
+            new global::Couchbase.ClusterOptions()
+                .WithConnectionString(fixture.Host)
+                .WithPasswordAuthentication(fixture.Username, fixture.Password),
+            o =>
+            {
+                o.Bucket = fixture.BucketName;
+                o.Scope = fixture.ScopeName;
+                o.AutoCreateIndexes = true;
+                o.ScanConsistency = global::Couchbase.Query.QueryScanConsistency.RequestPlus;
+            });
+        optionsBuilder.ConfigureWarnings(w => w.Ignore(CoreEventId.ManyServiceProvidersCreatedWarning));
+        return new MetaDbContext(optionsBuilder.Options, CollectionName);
+    }
+
+    [Fact]
+    public async Task Cas_RoundTrips_AfterInsertAndUpdate()
+    {
+        await using var ctx = CreateContext();
+        await ctx.Database.EnsureCreatedAsync();
+
+        var entity = new MetaEntity { Id = 1, Name = "original" };
+        ctx.Entities.Add(entity);
+        await ctx.SaveChangesAsync();
+
+        Assert.NotEqual(0UL, entity.Cas);
+        var casAfterInsert = entity.Cas;
+
+        entity.Name = "updated";
+        await ctx.SaveChangesAsync();
+
+        Assert.NotEqual(0UL, entity.Cas);
+        Assert.NotEqual(casAfterInsert, entity.Cas);
+    }
+
+    [Fact]
+    public async Task ConcurrentUpdate_WithStaleCas_ThrowsDbUpdateConcurrencyException()
+    {
+        await using var setupCtx = CreateContext();
+        await setupCtx.Database.EnsureCreatedAsync();
+        setupCtx.Entities.Add(new MetaEntity { Id = 2, Name = "original" });
+        await setupCtx.SaveChangesAsync();
+
+        // Two independent contexts each read the same document, capturing the same starting CAS.
+        await using var ctxA = CreateContext();
+        await using var ctxB = CreateContext();
+        var entityA = await ctxA.Entities.SingleAsync(e => e.Id == 2);
+        var entityB = await ctxB.Entities.SingleAsync(e => e.Id == 2);
+
+        // A writes first and succeeds, advancing the document's real CAS.
+        entityA.Name = "changed-by-a";
+        await ctxA.SaveChangesAsync();
+
+        // B still holds the pre-A CAS -- its write must be rejected, not silently overwrite A's change.
+        entityB.Name = "changed-by-b";
+        await Assert.ThrowsAsync<DbUpdateConcurrencyException>(() => ctxB.SaveChangesAsync());
+    }
+
+    [Fact]
+    public async Task ConcurrentUpdate_AfterStandardResolutionPattern_RetrySucceeds()
+    {
+        // EF Core's own documented DbUpdateConcurrencyException resolution pattern only refreshes
+        // OriginalValues, never CurrentValues -- if the CAS check read CurrentValue instead of
+        // OriginalValue, this exact, textbook-correct pattern would retry forever with the same
+        // stale CAS. Proves the fix, not just the initial throw (already covered above).
+        await using var setupCtx = CreateContext();
+        await setupCtx.Database.EnsureCreatedAsync();
+        setupCtx.Entities.Add(new MetaEntity { Id = 7, Name = "original" });
+        await setupCtx.SaveChangesAsync();
+
+        await using var ctxA = CreateContext();
+        await using var ctxB = CreateContext();
+        var entityA = await ctxA.Entities.SingleAsync(e => e.Id == 7);
+        var entityB = await ctxB.Entities.SingleAsync(e => e.Id == 7);
+
+        entityA.Name = "changed-by-a";
+        await ctxA.SaveChangesAsync();
+
+        entityB.Name = "changed-by-b";
+        var ex = await Assert.ThrowsAsync<DbUpdateConcurrencyException>(() => ctxB.SaveChangesAsync());
+
+        // EF Core's documented resolution: refresh OriginalValues from the database, then retry.
+        var entry = ex.Entries.Single();
+        var databaseValues = await entry.GetDatabaseValuesAsync();
+        entry.OriginalValues.SetValues(databaseValues!);
+
+        await ctxB.SaveChangesAsync();
+
+        await using var verifyCtx = CreateContext();
+        var finalEntity = await verifyCtx.Entities.SingleAsync(e => e.Id == 7);
+        Assert.Equal("changed-by-b", finalEntity.Name);
+    }
+
+    [Fact]
+    public async Task DeleteWithStaleCas_ThrowsDbUpdateConcurrencyException()
+    {
+        await using var setupCtx = CreateContext();
+        await setupCtx.Database.EnsureCreatedAsync();
+        setupCtx.Entities.Add(new MetaEntity { Id = 3, Name = "original" });
+        await setupCtx.SaveChangesAsync();
+
+        await using var ctxA = CreateContext();
+        await using var ctxB = CreateContext();
+        var entityA = await ctxA.Entities.SingleAsync(e => e.Id == 3);
+        var entityB = await ctxB.Entities.SingleAsync(e => e.Id == 3);
+
+        entityA.Name = "changed-by-a";
+        await ctxA.SaveChangesAsync();
+
+        ctxB.Entities.Remove(entityB);
+        await Assert.ThrowsAsync<DbUpdateConcurrencyException>(() => ctxB.SaveChangesAsync());
+    }
+
+    [Fact]
+    public async Task DocId_MatchesActualDocumentKey()
+    {
+        await using var ctx = CreateContext();
+        await ctx.Database.EnsureCreatedAsync();
+        ctx.Entities.Add(new MetaEntity { Id = 4, Name = "keyed" });
+        await ctx.SaveChangesAsync();
+
+        await using var readCtx = CreateContext();
+        var entity = await readCtx.Entities.SingleAsync(e => e.Id == 4);
+
+        Assert.Equal("4", entity.DocId);
+    }
+
+    [Fact]
+    public async Task Expiration_WithNoTtlSet_ReadsAsZero()
+    {
+        await using var ctx = CreateContext();
+        await ctx.Database.EnsureCreatedAsync();
+        ctx.Entities.Add(new MetaEntity { Id = 5, Name = "no-ttl" });
+        await ctx.SaveChangesAsync();
+
+        await using var readCtx = CreateContext();
+        var entity = await readCtx.Entities.SingleAsync(e => e.Id == 5);
+
+        Assert.Equal(0L, entity.Expiration);
+    }
+
+    [Fact]
+    public async Task Expiration_WithTtlSetViaRawKv_ReadsNonZeroEpochSeconds()
+    {
+        await using var ctx = CreateContext();
+        await ctx.Database.EnsureCreatedAsync();
+
+        // This provider has no write-side TTL API today -- simulate data written by another
+        // process/the SDK directly, exactly the scenario META().expiration exists to read back.
+        var clusterOptions = new global::Couchbase.ClusterOptions()
+            .WithConnectionString(fixture.Host)
+            .WithPasswordAuthentication(fixture.Username, fixture.Password)
+            .WithSerializer(global::Couchbase.Core.IO.Serializers.SystemTextJsonSerializer.Create());
+        using var cluster = await global::Couchbase.Cluster.ConnectAsync(clusterOptions);
+        var bucket = await cluster.BucketAsync(fixture.BucketName);
+        var scope = await bucket.ScopeAsync(fixture.ScopeName);
+        var collection = scope.Collection(CollectionName);
+        var beforeInsert = DateTimeOffset.UtcNow;
+        await collection.InsertAsync("6", new Dictionary<string, object>
+        {
+            ["Id"] = 6,
+            ["Name"] = "with-ttl",
+        }, new global::Couchbase.KeyValue.InsertOptions().Expiry(TimeSpan.FromMinutes(30)));
+
+        await using var readCtx = CreateContext();
+        var entity = await readCtx.Entities.SingleAsync(e => e.Id == 6);
+
+        Assert.True(entity.Expiration > 0, "Expiration should be a nonzero epoch-seconds value when a TTL is set.");
+        var expectedNoEarlierThan = beforeInsert.AddMinutes(30).ToUnixTimeSeconds();
+        var expectedNoLaterThan = DateTimeOffset.UtcNow.AddMinutes(30).AddMinutes(1).ToUnixTimeSeconds();
+        Assert.InRange(entity.Expiration, expectedNoEarlierThan, expectedNoLaterThan);
+    }
+
+    public async Task DisposeAsync()
+    {
+        try
+        {
+            var clusterOptions = new global::Couchbase.ClusterOptions()
+                .WithConnectionString(fixture.Host)
+                .WithCredentials(fixture.Username, fixture.Password);
+            using var cluster = await global::Couchbase.Cluster.ConnectAsync(clusterOptions);
+            var bucket = await cluster.BucketAsync(fixture.BucketName);
+            await bucket.Collections.DropCollectionAsync(fixture.ScopeName, CollectionName);
+        }
+        catch (global::Couchbase.Management.Collections.CollectionNotFoundException)
+        {
+        }
+    }
+
+    public class MetaEntity
+    {
+        public int Id { get; set; }
+        public string Name { get; set; } = string.Empty;
+
+        [CouchbaseMeta(CouchbaseMetaField.Cas)]
+        public ulong Cas { get; set; }
+
+        [CouchbaseMeta(CouchbaseMetaField.Id)]
+        public string DocId { get; set; } = string.Empty;
+
+        [CouchbaseMeta(CouchbaseMetaField.Expiration)]
+        public long Expiration { get; set; }
+    }
+
+    public class MetaDbContext(DbContextOptions<MetaDbContext> options, string collectionName)
+        : DbContext(options)
+    {
+        public DbSet<MetaEntity> Entities { get; set; } = null!;
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            base.OnModelCreating(modelBuilder);
+            modelBuilder.Entity<MetaEntity>(b =>
+            {
+                b.ToCouchbaseCollection(this, collectionName);
+                b.Property(e => e.Cas).IsConcurrencyToken();
+            });
+        }
+    }
+}

--- a/tests/Couchbase.EntityFrameworkCore.IntegrationTests/Tests/CrudTests.cs
+++ b/tests/Couchbase.EntityFrameworkCore.IntegrationTests/Tests/CrudTests.cs
@@ -476,7 +476,7 @@ public class CrudTests(
             cts.Cancel();
 
             await Assert.ThrowsAnyAsync<OperationCanceledException>(
-                () => wrapper.DeleteDocument(id, keyspace, cts.Token));
+                () => wrapper.DeleteDocument(id, keyspace, cancellationToken: cts.Token));
         }
         finally
         {

--- a/tests/Couchbase.EntityFrameworkCore.UnitTests/Couchbase/EntityFrameworkCore/Extensions/CouchbasePropertyBuilderExtensionsTests.cs
+++ b/tests/Couchbase.EntityFrameworkCore.UnitTests/Couchbase/EntityFrameworkCore/Extensions/CouchbasePropertyBuilderExtensionsTests.cs
@@ -1,4 +1,5 @@
 using Couchbase.EntityFrameworkCore.Extensions;
+using Couchbase.EntityFrameworkCore.Metadata;
 using Couchbase.EntityFrameworkCore.Storage.Internal;
 using Couchbase.EntityFrameworkCore.ValueGeneration;
 using Microsoft.EntityFrameworkCore;
@@ -742,11 +743,63 @@ public class CouchbasePropertyBuilderExtensionsTests
 
     #endregion
 
+    #region HasCouchbaseMeta Tests
+
+    [Fact]
+    public void HasCouchbaseMeta_CasOnUlongProperty_SetsAnnotationAndValueGenerated()
+    {
+        var modelBuilder = new ModelBuilder();
+        var entityBuilder = modelBuilder.Entity<MetaEntity>();
+
+        entityBuilder.Property(e => e.Cas).HasCouchbaseMeta(CouchbaseMetaField.Cas);
+
+        var property = modelBuilder.Model.FindEntityType(typeof(MetaEntity))!.FindProperty(nameof(MetaEntity.Cas));
+        Assert.Equal("Cas", property!.FindAnnotation(CouchbaseMetaAnnotationNames.MetaField)?.Value);
+        Assert.Equal(ValueGenerated.OnAddOrUpdate, property.ValueGenerated);
+    }
+
+    [Fact]
+    public void HasCouchbaseMeta_IdOnStringProperty_SetsAnnotation()
+    {
+        var modelBuilder = new ModelBuilder();
+        var entityBuilder = modelBuilder.Entity<MetaEntity>();
+
+        entityBuilder.Property(e => e.DocId).HasCouchbaseMeta(CouchbaseMetaField.Id);
+
+        var property = modelBuilder.Model.FindEntityType(typeof(MetaEntity))!.FindProperty(nameof(MetaEntity.DocId));
+        Assert.Equal("Id", property!.FindAnnotation(CouchbaseMetaAnnotationNames.MetaField)?.Value);
+    }
+
+    [Fact]
+    public void HasCouchbaseMeta_CasOnNonUlongProperty_ThrowsInvalidOperationException()
+    {
+        // Prevents silently writing an annotation CouchbaseQuerySqlGenerator would just ignore --
+        // the generic HasCouchbaseMeta<TProperty> would otherwise compile fine on any property
+        // type, since TProperty is unconstrained.
+        var modelBuilder = new ModelBuilder();
+        var entityBuilder = modelBuilder.Entity<MetaEntity>();
+
+        var exception = Assert.Throws<InvalidOperationException>(() =>
+            entityBuilder.Property(e => e.Id).HasCouchbaseMeta(CouchbaseMetaField.Cas));
+
+        Assert.Contains("HasCouchbaseMeta(Cas)", exception.Message);
+        Assert.Contains("ulong", exception.Message);
+    }
+
+    #endregion
+
     private class DateTimeEntity
     {
         public long Id { get; set; }
         public DateTime ShipDate { get; set; }
         public DateTime? OptionalShipDate { get; set; }
+    }
+
+    private class MetaEntity
+    {
+        public long Id { get; set; }
+        public ulong Cas { get; set; }
+        public string DocId { get; set; } = string.Empty;
     }
 
     private class TestEntity

--- a/tests/Couchbase.EntityFrameworkCore.UnitTests/Couchbase/EntityFrameworkCore/Metadata/Conventions/CouchbaseMetaConventionTests.cs
+++ b/tests/Couchbase.EntityFrameworkCore.UnitTests/Couchbase/EntityFrameworkCore/Metadata/Conventions/CouchbaseMetaConventionTests.cs
@@ -1,0 +1,103 @@
+using Couchbase.EntityFrameworkCore.Extensions;
+using Couchbase.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore;
+using Xunit;
+
+namespace Couchbase.EntityFrameworkCore.UnitTests.Couchbase.EntityFrameworkCore.Metadata.Conventions;
+
+/// <summary>
+/// Verifies <see cref="Couchbase.EntityFrameworkCore.Metadata.Conventions.CouchbaseMetaConvention"/>
+/// sets the <c>Couchbase:MetaField</c> annotation for a correctly-typed property and fails fast
+/// when <see cref="CouchbaseMetaAttribute"/> is misapplied to the wrong CLR type, rather than
+/// silently writing an annotation
+/// <c>Couchbase.EntityFrameworkCore.Query.Internal.CouchbaseQuerySqlGenerator</c> would just ignore.
+/// </summary>
+public class CouchbaseMetaConventionTests
+{
+    [Fact]
+    public void CasAttribute_OnUlongProperty_SetsAnnotationAndValueGenerated()
+    {
+        using var ctx = CreateContext();
+
+        var property = ctx.Model.FindEntityType(typeof(ValidEntity))!.FindProperty(nameof(ValidEntity.Cas))!;
+
+        Assert.Equal("Cas", property.FindAnnotation(CouchbaseMetaAnnotationNames.MetaField)?.Value);
+        Assert.Equal(Microsoft.EntityFrameworkCore.Metadata.ValueGenerated.OnAddOrUpdate, property.ValueGenerated);
+    }
+
+    [Fact]
+    public void CasAttribute_OnNonUlongProperty_ThrowsAtModelBuildTime()
+    {
+        using var ctx = CreateInvalidContext();
+
+        var exception = Assert.Throws<InvalidOperationException>(() => ctx.Model);
+
+        Assert.Contains("[CouchbaseMeta(Cas)]", exception.Message);
+        Assert.Contains("ulong", exception.Message);
+    }
+
+    private static ValidContext CreateContext()
+    {
+        var clusterOptions = new ClusterOptions()
+            .WithConnectionString("couchbase://localhost")
+            .WithPasswordAuthentication("Administrator", "password");
+        var builder = new DbContextOptionsBuilder<ValidContext>();
+        builder.UseCouchbaseProvider(clusterOptions);
+        return new ValidContext(builder.Options);
+    }
+
+    private static InvalidContext CreateInvalidContext()
+    {
+        var clusterOptions = new ClusterOptions()
+            .WithConnectionString("couchbase://localhost")
+            .WithPasswordAuthentication("Administrator", "password");
+        var builder = new DbContextOptionsBuilder<InvalidContext>();
+        builder.UseCouchbaseProvider(clusterOptions);
+        return new InvalidContext(builder.Options);
+    }
+
+    private class ValidEntity
+    {
+        public int Id { get; set; }
+
+        [CouchbaseMeta(CouchbaseMetaField.Cas)]
+        public ulong Cas { get; set; }
+    }
+
+    private class ValidContext(DbContextOptions<ValidContext> options) : DbContext(options)
+    {
+        public DbSet<ValidEntity> Entities { get; set; } = null!;
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            modelBuilder.Entity<ValidEntity>(b =>
+            {
+                b.ToCouchbaseCollection("bucket", "scope", "validMetaPost");
+                b.HasKey(p => p.Id);
+                b.Property(p => p.Cas).IsConcurrencyToken();
+            });
+        }
+    }
+
+    private class InvalidEntity
+    {
+        public int Id { get; set; }
+
+        [CouchbaseMeta(CouchbaseMetaField.Cas)]
+        public long NotAUlong { get; set; }
+    }
+
+    private class InvalidContext(DbContextOptions<InvalidContext> options) : DbContext(options)
+    {
+        public DbSet<InvalidEntity> Entities { get; set; } = null!;
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            modelBuilder.Entity<InvalidEntity>(b =>
+            {
+                b.ToCouchbaseCollection("bucket", "scope", "invalidMetaPost");
+                b.HasKey(p => p.Id);
+            });
+        }
+    }
+}

--- a/tests/Couchbase.EntityFrameworkCore.UnitTests/Couchbase/EntityFrameworkCore/Query/CouchbaseMetaSqlGenerationTests.cs
+++ b/tests/Couchbase.EntityFrameworkCore.UnitTests/Couchbase/EntityFrameworkCore/Query/CouchbaseMetaSqlGenerationTests.cs
@@ -1,0 +1,102 @@
+using Couchbase.EntityFrameworkCore.Extensions;
+using Couchbase.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Couchbase.EntityFrameworkCore.UnitTests.Couchbase.EntityFrameworkCore.Query;
+
+/// <summary>
+/// Verifies a <c>[CouchbaseMeta]</c>/<c>HasCouchbaseMeta</c>-annotated property is projected as
+/// <c>META(alias).field</c> in generated SQL++, instead of a normal document-field reference.
+/// </summary>
+public class CouchbaseMetaSqlGenerationTests(ITestOutputHelper output)
+{
+    [Fact]
+    public void Select_CasProperty_ProjectsAsMetaCasWithExplicitAlias()
+    {
+        // N1QL's own implicit result-key for META(alias).cas does not reliably match the
+        // property's real name -- without an explicit AS, the reader would look up the wrong
+        // key and silently materialize a default value instead of the real one (this is exactly
+        // the shape of a real bug this test guards against; see Select_IdProperty_* below for a
+        // case where the property name and META field name are NOT just a casing difference, so
+        // a case-insensitive substring match couldn't paper over a missing alias).
+        using var ctx = CreateContext();
+        var sql = ctx.Entities.Select(e => new { e.Id, e.Cas }).ToQueryString();
+        output.WriteLine("SQL: " + sql);
+
+        Assert.Contains("META(", sql);
+        Assert.Matches(@"META\([^)]+\)\.cas\s+AS\s+`Cas`", sql);
+    }
+
+    [Fact]
+    public void Select_IdProperty_ProjectsAsMetaIdWithExplicitAlias()
+    {
+        // Unlike Cas ("Cas" vs "cas" -- a casing difference the reader's case-insensitive alias
+        // lookup could coincidentally paper over), DocumentKey's property name and the "id" meta
+        // field name share no characters at all, so this only passes if the explicit alias is
+        // genuinely present -- the exact scenario that exposed the original aliasing bug
+        // (META(d).id materializing into a "DocId" property came back null without it).
+        using var ctx = CreateContext();
+        var sql = ctx.Entities.Select(e => new { e.Id, e.DocumentKey }).ToQueryString();
+        output.WriteLine("SQL: " + sql);
+
+        Assert.Contains("META(", sql);
+        Assert.Matches(@"META\([^)]+\)\.id\s+AS\s+`DocumentKey`", sql);
+    }
+
+    [Fact]
+    public void Select_NonMetaProperty_ProjectsAsNormalColumn()
+    {
+        using var ctx = CreateContext();
+        var sql = ctx.Entities.Select(e => e.Id).ToQueryString();
+
+        Assert.DoesNotContain("META(", sql);
+    }
+
+    [Fact]
+    public void Where_CasProperty_UsesMetaCasInPredicate()
+    {
+        using var ctx = CreateContext();
+        var sql = ctx.Entities.Where(e => e.Cas == 42ul).ToQueryString();
+
+        Assert.Contains("META(", sql);
+        Assert.Contains(").cas", sql, StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static MetaContext CreateContext()
+    {
+        var clusterOptions = new ClusterOptions()
+            .WithConnectionString("couchbase://localhost")
+            .WithPasswordAuthentication("Administrator", "password");
+        var builder = new DbContextOptionsBuilder<MetaContext>();
+        builder.UseCouchbaseProvider(clusterOptions);
+        return new MetaContext(builder.Options);
+    }
+
+    private class MetaEntity
+    {
+        public int Id { get; set; }
+
+        [CouchbaseMeta(CouchbaseMetaField.Cas)]
+        public ulong Cas { get; set; }
+
+        [CouchbaseMeta(CouchbaseMetaField.Id)]
+        public string DocumentKey { get; set; } = string.Empty;
+    }
+
+    private class MetaContext(DbContextOptions<MetaContext> options) : DbContext(options)
+    {
+        public DbSet<MetaEntity> Entities { get; set; } = null!;
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            modelBuilder.Entity<MetaEntity>(b =>
+            {
+                b.ToCouchbaseCollection("bucket", "scope", "metaPost");
+                b.HasKey(p => p.Id);
+                b.Property(p => p.Cas).IsConcurrencyToken();
+            });
+        }
+    }
+}


### PR DESCRIPTION
Closes a real correctness gap: SaveChangesAsync always did a blind upsert/remove with no CAS check at all, so two concurrent writes to the same document silently overwrote each other with no error. Adds [CouchbaseMeta(CouchbaseMetaField)]/HasCouchbaseMeta to source a property from META(alias).id/.cas/.expiration instead of a document field, and -- combined with EF Core's own .IsConcurrencyToken(), required together deliberately -- a ulong Cas property becomes a real optimistic-concurrency token: SaveChangesAsync sends it on update/delete and throws DbUpdateConcurrencyException on a mismatch, the same exception type and handling pattern EF Core apps already use for any other provider.

The read path turned out to need only a small change to CouchbaseQuerySqlGenerator.VisitColumn (ColumnExpression.Column exposes a live IProperty reference back to the originating property, including shadow properties) rather than a new expression/materialization pipeline, confirmed empirically before committing to the full implementation. Also fixes a related aliasing bug this surfaced: N1QL's implicit result-column name for META(d).id doesn't match the property's own name, so a META column now always gets an explicit AS.

ICouchbaseClientWrapper's Create/Update/Delete methods gained CAS parameters/return values -- a breaking change to that interface, matching this pre-GA provider's established pattern (see CompatibilitySuppressions.xml history). The suppression file itself needs regenerating with a real signing certificate (CI-only, not available in this environment) before release; not done as part of this commit.