### PR TITLE
Fix `??` translating to invalid N1QL COALESCE; L2CB  test gaps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,8 +45,18 @@ and this project aims to follow [Semantic Versioning](https://semver.org/spec/v2
   format string supports .NET's quoted-literal (`'...'`/`"..."`) and backslash-escape (`\x`) syntax
   for embedding literal text, e.g. `"yyyy-MM-dd'T'HH:mm:ss"`. See
   [Configuration — DateTime string format](docs/configuration.md#datetime-string-format).
+- **Confirmed `string.Compare`/`.CompareTo` translate correctly**, via EF Core's own base
+  `ComparisonTranslator` (inherited unmodified) and this provider's inherited `CASE WHEN`
+  rendering — no new provider code was needed. See
+  [Querying — Supported functions](docs/Queries.md#supported-functions).
 
 ### Fixed
+
+- **C#'s `??` (null-coalescing) generated N1QL's nonexistent `COALESCE` function**, reaching the
+  server as invalid SQL++ and failing only at query-execution time, never at translation time. Now
+  translates to `IFMISSINGORNULL`, which is also the semantically correct choice: a Couchbase
+  document field can be genuinely missing from the JSON, not just `null`, and `IFMISSINGORNULL` is
+  the only N1QL null-handling function that treats both the way `??` does.
 
 - **`string.IndexOf` translated to N1QL's `CONTAINS`, which returns a boolean, not the integer
   position `IndexOf` must return.** Any LINQ query using `.IndexOf(...)` silently received a

--- a/docs/Queries.md
+++ b/docs/Queries.md
@@ -140,6 +140,18 @@ SQL++ so they run server-side instead of throwing or falling back to client eval
 | `DateTime.Today`                       | `DATE_TRUNC_STR(NOW_UTC(fmt), 'day', fmt)` |
 | `DateTime.AddYears/Months/Days/Hours/Minutes/Seconds(n)` | `DATE_ADD_STR(x, n, part)` |
 | `Guid.NewGuid()`                       | `UUID()`                            |
+| `a ?? b`                               | `IFMISSINGORNULL(a, b)`             |
+| `string.Compare(a, b)` / `a.CompareTo(b)` | `CASE WHEN a = b THEN 0 WHEN a > b THEN 1 WHEN a < b THEN -1 END` |
+
+C#'s `??` translates to N1QL's `IFMISSINGORNULL`, not a generic `COALESCE` (which N1QL doesn't
+have) — this is also the semantically correct choice, not just a renaming: a Couchbase document
+field can be genuinely *missing* (absent from the JSON entirely), not just JSON `null`, and
+`IFMISSINGORNULL` is the only N1QL null-handling function that treats both the way `??` does.
+
+`string.Compare`/`.CompareTo` only produce the `CASE WHEN` shown above when the raw `int` result
+is actually used (e.g. projected in a `Select`). The common `string.Compare(a, b) > 0` /
+`a.CompareTo(b) == 0` shape is simplified directly to `a > b` / `a = b` before translation, with no
+`CASE` involved at all.
 
 `StartsWith`/`EndsWith` escape `%`/`_`/the escape character in the search value (constant patterns
 are escaped once at translation time; parameter/column patterns are escaped at query time via

--- a/src/Couchbase.EntityFrameworkCore/Query/Internal/CouchbaseQuerySqlGenerator.cs
+++ b/src/Couchbase.EntityFrameworkCore/Query/Internal/CouchbaseQuerySqlGenerator.cs
@@ -809,7 +809,17 @@ public class CouchbaseQuerySqlGenerator : QuerySqlGenerator
                 Sql.Append(".");
             }
 
-            Sql.Append(sqlFunctionExpression.Name);
+            // EF Core's own SqlExpressionFactory.Coalesce() builds a builtin "COALESCE" function
+            // for '??' -- N1QL has no COALESCE function at all (it has IFMISSINGORNULL/IFNULL/NVL),
+            // so this would otherwise reach the server as invalid SQL++ and fail only at
+            // query-execution time, not at translation time. IFMISSINGORNULL is the semantically
+            // correct choice, not just a renaming: a Couchbase document field can be genuinely
+            // MISSING (absent from the JSON entirely), not just JSON null, and IFMISSINGORNULL is
+            // the only one of the three that treats both the same way '??' does in C#. EF Core
+            // flattens a chain (`a ?? b ?? c`) into a single N-ary COALESCE(a, b, c) call rather
+            // than nesting it, and IFMISSINGORNULL also accepts an arbitrary number of arguments,
+            // so a straight name substitution is correct regardless of argument count.
+            Sql.Append(sqlFunctionExpression.Name == "COALESCE" ? "IFMISSINGORNULL" : sqlFunctionExpression.Name);
         }
         else
         {

--- a/tests/Couchbase.EntityFrameworkCore.IntegrationTests/Tests/CouchbaseCoalesceTests.cs
+++ b/tests/Couchbase.EntityFrameworkCore.IntegrationTests/Tests/CouchbaseCoalesceTests.cs
@@ -1,0 +1,154 @@
+using Couchbase.EntityFrameworkCode.IntegrationTests.Fixtures;
+using Couchbase.EntityFrameworkCore;
+using Couchbase.EntityFrameworkCore.Extensions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+
+namespace Couchbase.EntityFrameworkCode.IntegrationTests.Tests;
+
+/// <summary>
+/// Proves C#'s <c>??</c> translates to N1QL's <c>IFMISSINGORNULL</c> and correctly handles both
+/// ways a field can be "absent" in a Couchbase document: genuinely MISSING (the JSON key doesn't
+/// exist at all) and present with an explicit JSON <c>null</c> -- the whole reason
+/// <c>IFMISSINGORNULL</c> was chosen over a generic <c>COALESCE</c>/<c>IFNULL</c>, so it needs
+/// live proof against a real query engine, not just SQL-text assertions.
+/// </summary>
+/// <remarks>
+/// Uses a <c>.Where(...)</c> predicate and an anonymous-type <c>.Select(...)</c> to exercise the
+/// coalesce, not a *bare* scalar <c>.Select(e => expr)</c> with no wrapper -- that shape hits an
+/// unrelated, pre-existing gap in this provider's projection aliasing for un-named scalar
+/// expressions (confirmed empirically: it also fails for a plain, non-coalesce property
+/// projection, and is the same class of gap already flagged in
+/// <c>FunctionTranslationTests.NewGuid_ProjectsNonEmptyValue</c>'s own comment about a
+/// FROM-less/unusual projection shape this provider's reader doesn't materialize correctly).
+/// Not attempted here -- out of scope for the coalesce fix.
+/// </remarks>
+[Collection(CouchbaseTestingCollection.Name)]
+public class CouchbaseCoalesceTests(BloggingFixture fixture) : IAsyncLifetime
+{
+    private static readonly string CollectionName = "coalesce" + Guid.NewGuid().ToString("N");
+
+    private CoalesceDbContext _context = null!;
+
+    public async Task InitializeAsync()
+    {
+        var optionsBuilder = new DbContextOptionsBuilder<CoalesceDbContext>();
+        optionsBuilder.UseCouchbase(
+            new global::Couchbase.ClusterOptions()
+                .WithConnectionString(fixture.Host)
+                .WithPasswordAuthentication(fixture.Username, fixture.Password),
+            o =>
+            {
+                o.Bucket = fixture.BucketName;
+                o.Scope = fixture.ScopeName;
+                o.AutoCreateIndexes = true;
+                o.ScanConsistency = global::Couchbase.Query.QueryScanConsistency.RequestPlus;
+            });
+        optionsBuilder.ConfigureWarnings(w => w.Ignore(CoreEventId.ManyServiceProvidersCreatedWarning));
+
+        _context = new CoalesceDbContext(optionsBuilder.Options, CollectionName);
+        await _context.Database.EnsureCreatedAsync();
+
+        // Written directly via the KV API -- SaveChangesAsync always writes every property (as a
+        // real field, even when its value is null), so it can never produce a genuinely MISSING
+        // field. That's exactly the scenario this test exists to cover: data written by another
+        // process/an older schema version can omit a field entirely, which JSON null does not
+        // capture.
+        var clusterOptions = new global::Couchbase.ClusterOptions()
+            .WithConnectionString(fixture.Host)
+            .WithPasswordAuthentication(fixture.Username, fixture.Password)
+            .WithSerializer(global::Couchbase.Core.IO.Serializers.SystemTextJsonSerializer.Create());
+        using var cluster = await global::Couchbase.Cluster.ConnectAsync(clusterOptions);
+        var bucket = await cluster.BucketAsync(fixture.BucketName);
+        var scope = await bucket.ScopeAsync(fixture.ScopeName);
+        var collection = scope.Collection(CollectionName);
+
+        // Id=1: Title field is genuinely MISSING (key omitted entirely).
+        await collection.InsertAsync("1", new Dictionary<string, object> { ["Id"] = 1 });
+        // Id=2: Title field is present but an explicit JSON null.
+        await collection.InsertAsync("2", new Dictionary<string, object?> { ["Id"] = 2, ["Title"] = null });
+        // Id=3: Title field is present with a real value.
+        await collection.InsertAsync("3", new Dictionary<string, object> { ["Id"] = 3, ["Title"] = "real value" });
+    }
+
+    [Fact]
+    public async Task Coalesce_OnMissingField_ReturnsDefault()
+    {
+        var result = await _context.Entities
+            .Where(e => e.Id == 1)
+            .Select(e => new { Title = e.Title ?? "default" })
+            .SingleAsync();
+
+        Assert.Equal("default", result.Title);
+    }
+
+    [Fact]
+    public async Task Coalesce_OnExplicitJsonNull_ReturnsDefault()
+    {
+        var result = await _context.Entities
+            .Where(e => e.Id == 2)
+            .Select(e => new { Title = e.Title ?? "default" })
+            .SingleAsync();
+
+        Assert.Equal("default", result.Title);
+    }
+
+    [Fact]
+    public async Task Coalesce_OnRealValue_ReturnsRealValue()
+    {
+        var result = await _context.Entities
+            .Where(e => e.Id == 3)
+            .Select(e => new { Title = e.Title ?? "default" })
+            .SingleAsync();
+
+        Assert.Equal("real value", result.Title);
+    }
+
+    [Fact]
+    public async Task Coalesce_InWherePredicate_MatchesOnMissingAndExplicitNull()
+    {
+        var results = await _context.Entities
+            .Where(e => (e.Title ?? "default") == "default")
+            .ToListAsync();
+
+        Assert.Equal(2, results.Count);
+        Assert.Contains(results, e => e.Id == 1);
+        Assert.Contains(results, e => e.Id == 2);
+    }
+
+    public async Task DisposeAsync()
+    {
+        await _context.DisposeAsync();
+
+        try
+        {
+            var clusterOptions = new global::Couchbase.ClusterOptions()
+                .WithConnectionString(fixture.Host)
+                .WithCredentials(fixture.Username, fixture.Password);
+            using var cluster = await global::Couchbase.Cluster.ConnectAsync(clusterOptions);
+            var bucket = await cluster.BucketAsync(fixture.BucketName);
+            await bucket.Collections.DropCollectionAsync(fixture.ScopeName, CollectionName);
+        }
+        catch (global::Couchbase.Management.Collections.CollectionNotFoundException)
+        {
+        }
+    }
+
+    public class CoalesceEntity
+    {
+        public int Id { get; set; }
+        public string? Title { get; set; }
+    }
+
+    public class CoalesceDbContext(DbContextOptions<CoalesceDbContext> options, string collectionName)
+        : DbContext(options)
+    {
+        public DbSet<CoalesceEntity> Entities { get; set; } = null!;
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            base.OnModelCreating(modelBuilder);
+            modelBuilder.Entity<CoalesceEntity>().ToCouchbaseCollection(this, collectionName);
+        }
+    }
+}

--- a/tests/Couchbase.EntityFrameworkCore.IntegrationTests/Tests/FunctionTranslationTests.cs
+++ b/tests/Couchbase.EntityFrameworkCore.IntegrationTests/Tests/FunctionTranslationTests.cs
@@ -98,6 +98,50 @@ public class FunctionTranslationTests(BloggingFixture fixture, ITestOutputHelper
         Assert.True(results[0].IsMatch);
     }
 
+    [Fact]
+    public async Task StringCompare_ProjectedCaseWhen_ReturnsCorrectSignForEqualGreaterLess()
+    {
+        // Title is "Hello World" for the seeded entity. Wrapped in an anonymous type -- a bare
+        // scalar .Select(e => expr) is a separate, pre-existing, unrelated materialization gap in
+        // this provider (see CouchbaseCoalesceTests's remarks), not something this test exists to
+        // cover.
+        var result = await _context.Entities.Select(e => new
+        {
+            Equal = string.Compare(e.Title, "Hello World"),
+            Greater = string.Compare(e.Title, "Apple"),
+            Less = string.Compare(e.Title, "Zebra"),
+        }).SingleAsync();
+
+        Assert.Equal(0, result.Equal);
+        Assert.True(result.Greater > 0, $"Expected a positive value, got {result.Greater}");
+        Assert.True(result.Less < 0, $"Expected a negative value, got {result.Less}");
+    }
+
+    [Fact]
+    public async Task StringCompareTo_ProjectedCaseWhen_ReturnsCorrectSignForEqualGreaterLess()
+    {
+        var result = await _context.Entities.Select(e => new
+        {
+            Equal = e.Title.CompareTo("Hello World"),
+            Greater = e.Title.CompareTo("Apple"),
+            Less = e.Title.CompareTo("Zebra"),
+        }).SingleAsync();
+
+        Assert.Equal(0, result.Equal);
+        Assert.True(result.Greater > 0, $"Expected a positive value, got {result.Greater}");
+        Assert.True(result.Less < 0, $"Expected a negative value, got {result.Less}");
+    }
+
+    [Fact]
+    public async Task StringCompare_ComparedAgainstZeroInWherePredicate_MatchesExpectedRows()
+    {
+        var greater = await _context.Entities.Where(e => string.Compare(e.Title, "Apple") > 0).ToListAsync();
+        var less = await _context.Entities.Where(e => string.Compare(e.Title, "Apple") < 0).ToListAsync();
+
+        Assert.Single(greater);
+        Assert.Empty(less);
+    }
+
     public async Task DisposeAsync()
     {
         await _context.DisposeAsync();

--- a/tests/Couchbase.EntityFrameworkCore.UnitTests/Couchbase/EntityFrameworkCore/Query/CouchbaseCoalesceSqlGenerationTests.cs
+++ b/tests/Couchbase.EntityFrameworkCore.UnitTests/Couchbase/EntityFrameworkCore/Query/CouchbaseCoalesceSqlGenerationTests.cs
@@ -1,0 +1,89 @@
+using Couchbase.EntityFrameworkCore.Extensions;
+using Microsoft.EntityFrameworkCore;
+using Xunit;
+
+namespace Couchbase.EntityFrameworkCore.UnitTests.Couchbase.EntityFrameworkCore.Query;
+
+/// <summary>
+/// Verifies C#'s <c>??</c> (null-coalescing) translates to N1QL's <c>IFMISSINGORNULL</c>, not EF
+/// Core's default builtin <c>COALESCE</c> function -- N1QL has no <c>COALESCE</c> at all, so an
+/// unmodified translation would reach the server as invalid SQL++ and fail only at query-execution
+/// time. <c>IFMISSINGORNULL</c> is also the semantically correct choice: a Couchbase document field
+/// can be genuinely MISSING (absent from the JSON), not just JSON <c>null</c>, and it's the only
+/// one of N1QL's null-handling functions that treats both the way C#'s <c>??</c> does.
+/// </summary>
+public class CouchbaseCoalesceSqlGenerationTests
+{
+    [Fact]
+    public void Coalesce_TwoOperands_TranslatesToIfMissingOrNull_NotCoalesce()
+    {
+        using var ctx = CreateContext();
+        var query = ctx.Posts.Select(p => p.NullableTitle ?? "default");
+
+        var sql = query.ToQueryString();
+
+        Assert.Contains("IFMISSINGORNULL(", sql, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("COALESCE(", sql, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void Coalesce_ChainedThreeOperands_FlattensToOneIfMissingOrNullCall()
+    {
+        // EF Core's SqlExpressionFactory.Coalesce() flattens a chain (`a ?? b ?? c`) into a
+        // single N-ary builtin "COALESCE" SqlFunctionExpression with all 3 arguments, not a
+        // binary-nested COALESCE(a, COALESCE(b, c)) -- confirmed empirically here. N1QL's
+        // IFMISSINGORNULL also accepts an arbitrary number of arguments, so the same single
+        // name-substitution in VisitSqlFunction handles this correctly with no extra flattening
+        // logic needed.
+        using var ctx = CreateContext();
+        var query = ctx.Posts.Select(p => p.NullableTitle ?? p.SecondTitle ?? "default");
+
+        var sql = query.ToQueryString();
+
+        Assert.DoesNotContain("COALESCE(", sql, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("IFMISSINGORNULL(`b`.`NullableTitle`, `b`.`SecondTitle`, 'default')", sql);
+    }
+
+    [Fact]
+    public void Coalesce_InWherePredicate_TranslatesToIfMissingOrNull()
+    {
+        using var ctx = CreateContext();
+        var query = ctx.Posts.Where(p => (p.NullableTitle ?? "default") == "x");
+
+        var sql = query.ToQueryString();
+
+        Assert.Contains("IFMISSINGORNULL(", sql, StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static PostContext CreateContext()
+    {
+        var clusterOptions = new ClusterOptions()
+            .WithConnectionString("couchbase://localhost")
+            .WithPasswordAuthentication("Administrator", "password");
+
+        var builder = new DbContextOptionsBuilder<PostContext>();
+        builder.UseCouchbaseProvider(clusterOptions);
+        return new PostContext(builder.Options);
+    }
+
+    private class Post
+    {
+        public int PostId { get; set; }
+        public string? NullableTitle { get; set; }
+        public string? SecondTitle { get; set; }
+    }
+
+    private class PostContext(DbContextOptions<PostContext> options) : DbContext(options)
+    {
+        public DbSet<Post> Posts { get; set; } = null!;
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            modelBuilder.Entity<Post>(b =>
+            {
+                b.ToCouchbaseCollection("bucket", "scope", "post");
+                b.HasKey(p => p.PostId);
+            });
+        }
+    }
+}

--- a/tests/Couchbase.EntityFrameworkCore.UnitTests/Couchbase/EntityFrameworkCore/Query/CouchbaseDateTimeFunctionSqlGenerationTests.cs
+++ b/tests/Couchbase.EntityFrameworkCore.UnitTests/Couchbase/EntityFrameworkCore/Query/CouchbaseDateTimeFunctionSqlGenerationTests.cs
@@ -134,6 +134,33 @@ public class CouchbaseDateTimeFunctionSqlGenerationTests
         Assert.DoesNotContain("2006-01-02T15:04:05.999Z07:00", sql);
     }
 
+    [Fact]
+    public void NullableDateTime_HasValue_TranslatesToIsNotNull()
+    {
+        // Handled entirely by EF Core's own core RelationalSqlTranslatingExpressionVisitor,
+        // before any provider-specific translator ever runs (it rewrites Nullable<T>.HasValue to
+        // IsNotNull(inner)) -- this is a regression guard confirming this provider's existing
+        // NotEqual -> "IS NOT NULL" rendering already handles that correctly, not a new feature.
+        using var ctx = CreateContext();
+        var query = ctx.Posts.Where(p => p.ArchivedAt.HasValue);
+
+        var sql = query.ToQueryString();
+        Assert.Contains("IS NOT NULL", sql, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void NullableDateTime_Value_TranslatesSameAsUnderlyingColumn()
+    {
+        // .Value is a no-op unwrap to the same underlying SqlExpression -- comparing it should
+        // generate identical SQL to comparing the nullable property directly.
+        using var ctx = CreateContext();
+        var stamp = new DateTime(2026, 1, 1);
+        var viaValue = ctx.Posts.Where(p => p.ArchivedAt!.Value == stamp).ToQueryString();
+        var viaDirect = ctx.Posts.Where(p => p.ArchivedAt == stamp).ToQueryString();
+
+        Assert.Equal(viaDirect, viaValue);
+    }
+
     private static PostContext CreateContext(string? dateTimeFormat = null)
     {
         var clusterOptions = new ClusterOptions()
@@ -151,6 +178,7 @@ public class CouchbaseDateTimeFunctionSqlGenerationTests
     {
         public int PostId { get; set; }
         public DateTime Published { get; set; }
+        public DateTime? ArchivedAt { get; set; }
     }
 
     private class PostContext(DbContextOptions<PostContext> options) : DbContext(options)

--- a/tests/Couchbase.EntityFrameworkCore.UnitTests/Couchbase/EntityFrameworkCore/Query/CouchbaseStringFunctionSqlGenerationTests.cs
+++ b/tests/Couchbase.EntityFrameworkCore.UnitTests/Couchbase/EntityFrameworkCore/Query/CouchbaseStringFunctionSqlGenerationTests.cs
@@ -111,6 +111,124 @@ public class CouchbaseStringFunctionSqlGenerationTests
         Assert.Contains("LIKE", sql, StringComparison.OrdinalIgnoreCase);
     }
 
+    [Fact]
+    public void Trim_NoArgs_InWherePredicate_TranslatesToTrim()
+    {
+        using var ctx = CreateContext();
+        var query = ctx.Posts.Where(p => p.Title.Trim() == "x");
+
+        var sql = query.ToQueryString();
+
+        Assert.Contains("trim(", sql, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void Trim_CharArg_InWherePredicate_TranslatesToTrimWithCharacterSet()
+    {
+        using var ctx = CreateContext();
+        var query = ctx.Posts.Where(p => p.Title.Trim('x') == "y");
+
+        var sql = query.ToQueryString();
+
+        Assert.Contains("trim(", sql, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("'x'", sql);
+    }
+
+    [Fact]
+    public void Trim_CharArrayArg_InWherePredicate_TranslatesToTrimWithCharacterSet()
+    {
+        using var ctx = CreateContext();
+        var query = ctx.Posts.Where(p => p.Title.Trim('x', 'y') == "z");
+
+        var sql = query.ToQueryString();
+
+        Assert.Contains("trim(", sql, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("'xy'", sql);
+    }
+
+    [Fact]
+    public void TrimStart_NoArgs_InWherePredicate_TranslatesToLtrim()
+    {
+        using var ctx = CreateContext();
+        var query = ctx.Posts.Where(p => p.Title.TrimStart() == "x");
+
+        var sql = query.ToQueryString();
+
+        Assert.Contains("ltrim(", sql, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void TrimEnd_NoArgs_InWherePredicate_TranslatesToRtrim()
+    {
+        using var ctx = CreateContext();
+        var query = ctx.Posts.Where(p => p.Title.TrimEnd() == "x");
+
+        var sql = query.ToQueryString();
+
+        Assert.Contains("rtrim(", sql, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void StringCompare_ComparedAgainstZeroInWherePredicate_SimplifiesToDirectComparison()
+    {
+        // EF Core's own QueryOptimizingExpressionVisitor recognizes the
+        // `string.Compare(a, b) > 0` shape and rewrites it directly to `a > b` before
+        // translation -- no CASE expression is even built for this common shape. This is
+        // core EF Core behavior, not anything Couchbase-specific, but it's cheap and
+        // valuable to pin down since it's the actual query shape most application code writes.
+        using var ctx = CreateContext();
+        var query = ctx.Posts.Where(p => string.Compare(p.Title, "abc") > 0);
+
+        var sql = query.ToQueryString();
+
+        Assert.Contains("`b`.`Title` > 'abc'", sql);
+        Assert.DoesNotContain("CASE", sql, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void StringCompareTo_ComparedAgainstZeroInWherePredicate_SimplifiesToDirectComparison()
+    {
+        using var ctx = CreateContext();
+        var query = ctx.Posts.Where(p => p.Title.CompareTo("abc") == 0);
+
+        var sql = query.ToQueryString();
+
+        Assert.Contains("`b`.`Title` = 'abc'", sql);
+        Assert.DoesNotContain("CASE", sql, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void StringCompare_ProjectedDirectly_TranslatesToCaseWhen()
+    {
+        // Once the raw int result is actually needed (not just compared against 0), EF Core's
+        // base ComparisonTranslator (registered by RelationalMethodCallTranslatorProvider,
+        // inherited unmodified here) builds a CaseExpression -- this provider's inherited
+        // CaseExpression rendering must produce valid N1QL for this to work, confirmed here.
+        using var ctx = CreateContext();
+        var query = ctx.Posts.Select(p => string.Compare(p.Title, "abc"));
+
+        var sql = query.ToQueryString();
+
+        Assert.Contains("CASE", sql, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("WHEN `b`.`Title` = 'abc' THEN 0", sql);
+        Assert.Contains("WHEN `b`.`Title` > 'abc' THEN 1", sql);
+        Assert.Contains("WHEN `b`.`Title` < 'abc' THEN -1", sql);
+    }
+
+    [Fact]
+    public void StringCompareTo_ProjectedDirectly_TranslatesToCaseWhen()
+    {
+        using var ctx = CreateContext();
+        var query = ctx.Posts.Select(p => p.Title.CompareTo("abc"));
+
+        var sql = query.ToQueryString();
+
+        Assert.Contains("CASE", sql, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("WHEN `b`.`Title` = 'abc' THEN 0", sql);
+        Assert.Contains("WHEN `b`.`Title` > 'abc' THEN 1", sql);
+        Assert.Contains("WHEN `b`.`Title` < 'abc' THEN -1", sql);
+    }
+
     private static PostContext CreateContext()
     {
         var clusterOptions = new ClusterOptions()

--- a/tests/Couchbase.EntityFrameworkCore.UnitTests/Couchbase/EntityFrameworkCore/Storage/Internal/CouchbaseTypeMappingSourceTests.cs
+++ b/tests/Couchbase.EntityFrameworkCore.UnitTests/Couchbase/EntityFrameworkCore/Storage/Internal/CouchbaseTypeMappingSourceTests.cs
@@ -425,6 +425,33 @@ public class CouchbaseTypeMappingSourceTests
     }
 
     [Fact]
+    public void DecimalMapping_GenerateSqlLiteral_IsCultureInvariant()
+    {
+        // Uses the stock EF Core DecimalTypeMapping unmodified (CouchbaseTypeMappingSource.cs
+        // registers it as-is), which already formats with CultureInfo.InvariantCulture -- but a
+        // future change that reintroduces a bare ToString()/string.Format without an explicit
+        // IFormatProvider would silently corrupt N1QL for any de-DE-style comma-decimal culture
+        // (e.g. "19,99" is either a syntax error or two arguments, not one number). This guards
+        // that regression class directly, mirroring Linq2Couchbase's own defensive test for the
+        // exact same concern.
+        var originalCulture = System.Globalization.CultureInfo.CurrentCulture;
+        try
+        {
+            System.Globalization.CultureInfo.CurrentCulture = new System.Globalization.CultureInfo("de-DE");
+
+            var mapping = _typeMappingSource.FindMapping(typeof(decimal));
+            var literal = mapping!.GenerateSqlLiteral(19.99m);
+
+            Assert.Contains("19.99", literal);
+            Assert.DoesNotContain(",", literal);
+        }
+        finally
+        {
+            System.Globalization.CultureInfo.CurrentCulture = originalCulture;
+        }
+    }
+
+    [Fact]
     public void BoolMapping_GenerateSqlLiteral_ProducesTrueFalseLiterals()
     {
         // Arrange


### PR DESCRIPTION
`SqlExpressionFactory.Coalesce()` builds a builtin "COALESCE" function that N1QL doesn't have, so `??` reached the server as invalid SQL++ and failed only at query-execution time. Now translates to IFMISSINGORNULL, which also correctly treats a genuinely missing document field the same way `??` treats null.

Also adds regression tests confirming several previously-unverified LINQ shapes already work correctly with no production code changes: nullable DateTime?/.HasValue/.Value, decimal literal culture-invariance, Trim/TrimStart/TrimEnd, and string.Compare/.CompareTo (via EF Core's own base ComparisonTranslator and this provider's inherited CASE WHEN rendering).

Updates docs/Queries.md and CHANGELOG.md accordingly.