### PR TITLE
Support `.Any(predicate)` over depth-1 OwnsMany navigations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ and this project aims to follow [Semantic Versioning](https://semver.org/spec/v2
 
 ### Added
 
+- **`.Any(predicate)`/`.Any()` over a depth-1 `OwnsMany` navigation.** Previously silently
+  produced invalid SQL++ (an `EXISTS` subquery with an empty `FROM` clause, since the owned
+  collection is a JSON array embedded in the parent document, not a real keyspace to correlate
+  against). Now translates to N1QL's `ANY x IN parentAlias.field SATISFIES ... END`. Nested owned
+  collections (reached through another owned navigation), `.All(predicate)`, `.Count(predicate)`,
+  and `.Contains()` over an owned collection are not yet supported. See
+  [Modeling — OwnsMany](docs/modeling.md#ownsmany).
 - **N1QL `META()` support: document metadata fields and CAS-based optimistic concurrency.**
   `[CouchbaseMeta(CouchbaseMetaField)]`/`HasCouchbaseMeta(...)` sources a property's value from
   `META(alias).id`/`.cas`/`.expiration` instead of a document field. Combined with EF Core's own

--- a/docs/limitations.md
+++ b/docs/limitations.md
@@ -69,6 +69,11 @@ The Couchbase SDK is asynchronous, so the synchronous EF Core code paths throw `
   persisted and queried only when configured as EF Core owned types (`OwnsOne` /
   `OwnsMany`) or as related entities. Plain CLR objects nested on an entity that are
   not mapped this way are ignored by EF Core.
+* **`.Any(predicate)` over an `OwnsMany` navigation is supported only one level deep**
+  (a collection declared directly on the entity being queried). `.Any(predicate)` over a
+  *nested* owned collection reached through another owned navigation, `.All(predicate)`,
+  `.Count(predicate)`, and `.Contains()` over an owned collection are not yet supported. See
+  [Modeling — OwnsMany](modeling.md#ownsmany).
 
 See also [Querying](Queries.md) and [Configuration](configuration.md).
 

--- a/docs/modeling.md
+++ b/docs/modeling.md
@@ -310,6 +310,22 @@ modelBuilder.Entity<Customer>().OwnsMany(c => c.ContactMethods, cm =>
 
 The collection property can be typed as `List<T>` or `HashSet<T>` — both are fully supported.
 
+`.Any(predicate)` and predicate-less `.Any()` are supported for a depth-1 `OwnsMany` navigation
+(a collection declared directly on the entity being queried), translating to N1QL's
+`ANY x IN parentAlias.field SATISFIES ... END` rather than a real `EXISTS` subquery, since the
+collection is a JSON array already embedded in the current document rather than a separate
+keyspace to correlate against:
+
+```csharp
+var withPhone = await context.Customers
+    .Where(c => c.ContactMethods.Any(m => m.Type == "phone"))
+    .ToListAsync();
+```
+
+`.Any(predicate)` over a *nested* owned collection (one reached through another owned navigation,
+e.g. `c.ContactMethods.Any(m => m.Tags.Any(...))`), `.All(predicate)`, `.Count(predicate)`, and
+`.Contains()` over an owned collection are not yet supported.
+
 ### Field-backed access
 
 If an owned type's properties are get-only (backed by a private field, with no public setter),

--- a/src/Couchbase.EntityFrameworkCore/Extensions/CouchbaseServiceCollectionExtensions.cs
+++ b/src/Couchbase.EntityFrameworkCore/Extensions/CouchbaseServiceCollectionExtensions.cs
@@ -61,13 +61,26 @@ public static class CouchbaseServiceCollectionExtensions
             sp.GetRequiredService<RelationalTypeMappingSourceDependencies>(),
             optionsExtension.DbContextOptionsBuilder.DateTimeFormat));
 
+        // Same captive-dependency concern as IRelationalTypeMappingSource above:
+        // IQuerySqlGeneratorFactory is Singleton-lifetime (EF Core's own registration), while
+        // ICouchbaseDbContextOptionsBuilder (which carries FieldNamingPolicy) is Scoped -- capture
+        // FieldNamingPolicy *by value* here instead. Must also come before TryAddCoreServices()
+        // for the same first-registration-wins reason.
+        // Same captive-dependency concern as IRelationalTypeMappingSource above:
+        // IQuerySqlGeneratorFactory is Singleton-lifetime (EF Core's own registration), while
+        // ICouchbaseDbContextOptionsBuilder (which carries FieldNamingPolicy) is Scoped -- capture
+        // FieldNamingPolicy *by value* here instead. Must also come before TryAddCoreServices()
+        // for the same first-registration-wins reason.
+        serviceCollection.TryAddSingleton<IQuerySqlGeneratorFactory>(sp => new CouchbaseQuerySqlGeneratorFactory(
+            sp.GetRequiredService<QuerySqlGeneratorDependencies>(),
+            optionsExtension.DbContextOptionsBuilder.FieldNamingPolicy));
+
         var builder = new EntityFrameworkRelationalServicesBuilder(serviceCollection)
             .TryAdd<IDatabaseProvider, DatabaseProvider<CouchbaseOptionsExtension>>()
             .TryAdd<LoggingDefinitions, CouchbaseLoggingDefinitions>()
             .TryAdd<IModificationCommandBatchFactory, CouchbaseModificationCommandBatchFactory>()
             .TryAdd<IUpdateSqlGenerator, CouchbaseUpdateSqlGenerator>()
             //.TryAdd<IAsyncQueryProvider, CouchbaseQueryProvider>()
-            .TryAdd<IQuerySqlGeneratorFactory, CouchbaseQuerySqlGeneratorFactory>()
             .TryAdd<ISqlGenerationHelper, CouchbaseSqlGenerationHelper>()
             .TryAdd<IShapedQueryCompilingExpressionVisitorFactory, CouchbaseShapedQueryCompilingExpressionVisitorFactory>()
             .TryAdd<IQueryableMethodTranslatingExpressionVisitorFactory, CouchbaseQueryableMethodTranslatingExpressionVisitorFactory>()

--- a/src/Couchbase.EntityFrameworkCore/Query/Internal/CouchbaseProjectionAliases.cs
+++ b/src/Couchbase.EntityFrameworkCore/Query/Internal/CouchbaseProjectionAliases.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Text.Json;
 using Couchbase.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Query.SqlExpressions;
@@ -40,6 +41,18 @@ internal static class CouchbaseProjectionAliases
     /// </summary>
     public static string NavigationKey(INavigation navigation)
         => navigation.DeclaringEntityType.ClrType.FullName + "." + navigation.Name;
+
+    /// <summary>
+    /// The JSON field name an owned-collection navigation is stored under, given the configured
+    /// <c>FieldNamingPolicy</c> — the raw CLR navigation name if no policy is configured (or the
+    /// policy leaves it unchanged), otherwise the policy-converted name (e.g. <c>"contactMethods"</c>
+    /// for a <c>ContactMethods</c> navigation under the default camelCase policy). Shared between
+    /// <see cref="Query.Internal.CouchbaseShapedQueryCompilingExpressionVisitor.AddOwnedNavigationColumnsToProjection"/>
+    /// (read-path projection) and <see cref="CouchbaseQuerySqlGenerator"/>'s <c>ANY...SATISFIES</c>
+    /// rendering for <c>.Any(predicate)</c> over an owned collection, so the two can never drift.
+    /// </summary>
+    public static string GetOwnedCollectionFieldName(INavigation navigation, JsonNamingPolicy? fieldNamingPolicy)
+        => fieldNamingPolicy?.ConvertName(navigation.Name) ?? navigation.Name;
 
     /// <summary>
     /// The <see cref="CouchbaseMetaField"/> name (e.g. <c>"Cas"</c>) a column is sourced from via

--- a/src/Couchbase.EntityFrameworkCore/Query/Internal/CouchbaseQuerySqlGenerator.cs
+++ b/src/Couchbase.EntityFrameworkCore/Query/Internal/CouchbaseQuerySqlGenerator.cs
@@ -10,6 +10,7 @@ using Couchbase.EntityFrameworkCore.Infrastructure;
 using Couchbase.EntityFrameworkCore.Metadata;
 using Couchbase.EntityFrameworkCore.Utils;
 using Couchbase.Extensions.DependencyInjection;
+using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Query;
@@ -23,9 +24,19 @@ namespace Couchbase.EntityFrameworkCore.Query.Internal;
 public class CouchbaseQuerySqlGenerator : QuerySqlGenerator
 {
     private readonly ConcurrentDictionary<string, CouchbaseKeyspace> _tableNameCache = new();
+    private readonly System.Text.Json.JsonNamingPolicy? _fieldNamingPolicy;
 
-    public CouchbaseQuerySqlGenerator(QuerySqlGeneratorDependencies dependencies) : base(dependencies)
+    // Set only while rendering the SATISFIES clause of an owned-collection ANY(...) expression
+    // (see GenerateExists/TryRenderOwnedCollectionAny) -- ColumnExpressions bound to this alias
+    // refer to properties of an array element embedded in JSON, which are written under the
+    // policy-converted name (e.g. "title", not "Title"), unlike every other column this generator
+    // renders. Saved/restored around the Visit() call rather than cleared, since a query can
+    // contain more than one such ANY(...) expression (e.g. `a.Xs.Any(...) || a.Ys.Any(...)`).
+    private string? _ownedAnyAlias;
+
+    public CouchbaseQuerySqlGenerator(QuerySqlGeneratorDependencies dependencies, System.Text.Json.JsonNamingPolicy? fieldNamingPolicy = null) : base(dependencies)
     {
+        _fieldNamingPolicy = fieldNamingPolicy;
     }
 
     /// <inheritdoc />
@@ -149,6 +160,34 @@ public class CouchbaseQuerySqlGenerator : QuerySqlGenerator
             any = true;
         }
         return any;
+    }
+
+    /// <summary>
+    /// Same check as <see cref="IsOwnedTable"/>, but also returns every owned <see cref="IEntityType"/>
+    /// mapped to the table — needed by <see cref="TryRenderOwnedCollectionAny"/> to resolve the
+    /// owning navigation via <see cref="IEntityType.FindOwnership"/>.
+    /// </summary>
+    /// <remarks>
+    /// A table can carry more than one owned <see cref="IEntityType"/> when the OwnsMany item
+    /// type itself table-splits a nested <c>OwnsOne</c> (e.g. <c>ContactMethod</c> hosting its own
+    /// <c>Label</c>) — both mappings pass <see cref="IsOwnedTable"/>'s <c>All</c> check, but only
+    /// one of them (<c>ContactMethod</c>, not <c>Label</c>) is the collection's own item type whose
+    /// ownership correlates to the correct parent. There's no cheap way to tell which from the
+    /// table alone, so every candidate is returned and the caller tries each in turn.
+    /// </remarks>
+    private static bool TryGetOwnedEntityTypes(TableExpression tableExpression, out List<IEntityType> entityTypes)
+    {
+        entityTypes = new List<IEntityType>();
+        foreach (var mapping in tableExpression.Table.EntityTypeMappings)
+        {
+            if (mapping.TypeBase is not IEntityType et || !et.IsOwned())
+            {
+                entityTypes = new List<IEntityType>();
+                return false;
+            }
+            entityTypes.Add(et);
+        }
+        return entityTypes.Count > 0;
     }
 
     /// <summary>
@@ -605,6 +644,27 @@ public class CouchbaseQuerySqlGenerator : QuerySqlGenerator
 
     protected override void GenerateExists(ExistsExpression existsExpression, bool negated)
     {
+        // `.Any(predicate)`/`.Any()` over an OwnsMany navigation translates (via EF Core's own,
+        // unmodified RelationalQueryableMethodTranslatingExpressionVisitor.TranslateAny) into a
+        // correlated EXISTS subquery whose sole FROM table is the owned type's TableExpression --
+        // but VisitTable renders that table as nothing (it's embedded JSON, not a real keyspace),
+        // which would otherwise produce an empty-FROM-clause N1QL error. Render it instead as
+        // N1QL's ANY...SATISFIES...END over the parent document's array field directly.
+        if (existsExpression.Subquery.Tables is [TableExpression tableExpression]
+            && TryGetOwnedEntityTypes(tableExpression, out var ownedEntityTypes))
+        {
+            // A table can carry more than one owned entity type via table-splitting (see
+            // TryGetOwnedEntityTypes' remarks) -- try each until one's ownership actually matches
+            // this subquery's correlation predicate.
+            foreach (var candidate in ownedEntityTypes)
+            {
+                if (TryRenderOwnedCollectionAny(existsExpression, negated, tableExpression, candidate))
+                {
+                    return;
+                }
+            }
+        }
+
         if (negated)
         {
             Sql.Append("NOT ");
@@ -619,6 +679,206 @@ public class CouchbaseQuerySqlGenerator : QuerySqlGenerator
 
         Sql.Append(")");
     }
+
+    /// <summary>
+    /// Renders <c>ANY &lt;ownedAlias&gt; IN &lt;parentAlias&gt;.&lt;fieldName&gt; SATISFIES
+    /// &lt;predicate&gt; END</c> in place of the correlated <c>EXISTS</c> subquery EF Core built
+    /// for `.Any(predicate)`/`.Any()` over a depth-1 OwnsMany navigation. Returns
+    /// <see langword="false"/> (writing nothing) if the ownership/navigation can't be resolved, so
+    /// the caller falls through to the default (and, for this shape, broken) EXISTS rendering
+    /// rather than silently producing wrong SQL.
+    /// </summary>
+    private bool TryRenderOwnedCollectionAny(
+        ExistsExpression existsExpression, bool negated, TableExpression ownedTable, IEntityType ownedEntityType)
+    {
+        var ownership = ownedEntityType.FindOwnership();
+        if (ownership?.PrincipalToDependent == null)
+        {
+            return false;
+        }
+
+        if (!TryStripCorrelation(
+                existsExpression.Subquery.Predicate, ownedTable.Alias!, ownership,
+                out var residual, out var parentAlias))
+        {
+            return false;
+        }
+
+        var fieldName = CouchbaseProjectionAliases.GetOwnedCollectionFieldName(ownership.PrincipalToDependent, _fieldNamingPolicy);
+        var helper = Dependencies.SqlGenerationHelper;
+
+        if (negated)
+        {
+            Sql.Append("NOT (");
+        }
+
+        Sql.Append("ANY ")
+            .Append(helper.DelimitIdentifier(ownedTable.Alias!))
+            .Append(" IN ")
+            .Append(helper.DelimitIdentifier(parentAlias!))
+            .Append(".")
+            .Append(helper.DelimitIdentifier(fieldName))
+            .Append(" SATISFIES ");
+
+        if (residual == null)
+        {
+            Sql.Append("true");
+        }
+        else
+        {
+            var previous = _ownedAnyAlias;
+            _ownedAnyAlias = ownedTable.Alias;
+            try
+            {
+                Visit(residual);
+            }
+            finally
+            {
+                _ownedAnyAlias = previous;
+            }
+        }
+
+        Sql.Append(" END");
+
+        if (negated)
+        {
+            Sql.Append(")");
+        }
+
+        return true;
+    }
+
+    /// <summary>
+    /// Splits <paramref name="predicate"/> into the correlation conjunct(s) EF Core added when
+    /// expanding the owned-collection navigation (<c>child.FK = parent.PK</c>, or
+    /// <c>child.FK IS NOT NULL AND child.FK = parent.PK</c> per FK property when any FK/PK
+    /// property is nullable) and everything else (the user's original `.Any(predicate)`
+    /// condition, or <see langword="null"/> for predicate-less `.Any()`). Also recovers the
+    /// correlated outer query's alias as a side effect of removing the correlation conjunct(s) --
+    /// the surviving side of each stripped comparison, by construction, refers to it.
+    /// </summary>
+    private static bool TryStripCorrelation(
+        SqlExpression? predicate,
+        string ownedAlias,
+        IForeignKey ownership,
+        out SqlExpression? residual,
+        out string? parentAlias)
+    {
+        residual = null;
+        parentAlias = null;
+
+        if (predicate == null)
+        {
+            return false;
+        }
+
+        var conjuncts = new List<SqlExpression>();
+        FlattenAndAlso(predicate, conjuncts);
+
+        var fkProperties = ownership.Properties;
+        var pkProperties = ownership.PrincipalKey.Properties;
+
+        for (var i = 0; i < fkProperties.Count; i++)
+        {
+            var fkColumn = fkProperties[i].GetColumnName();
+            var pkColumn = pkProperties[i].GetColumnName();
+
+            // Plain shape: a single Equal comparing the FK column (owned side) against the PK
+            // column (outer/parent side) -- the common case (OwnsMany shadow FKs are non-nullable
+            // by convention).
+            var plainIndex = conjuncts.FindIndex(c => IsCorrelationEqual(c, ownedAlias, fkColumn, pkColumn, out _));
+            if (plainIndex >= 0)
+            {
+                IsCorrelationEqual(conjuncts[plainIndex], ownedAlias, fkColumn, pkColumn, out var foundAlias);
+                parentAlias ??= foundAlias;
+                conjuncts.RemoveAt(plainIndex);
+                continue;
+            }
+
+            // Null-guarded shape: a separate `fkColumn IS NOT NULL` conjunct alongside the Equal,
+            // for a nullable FK/PK property.
+            var notNullIndex = conjuncts.FindIndex(c => IsColumnNotNull(c, ownedAlias, fkColumn));
+            var equalIndex = conjuncts.FindIndex(c => IsCorrelationEqual(c, ownedAlias, fkColumn, pkColumn, out _));
+            if (notNullIndex >= 0 && equalIndex >= 0)
+            {
+                IsCorrelationEqual(conjuncts[equalIndex], ownedAlias, fkColumn, pkColumn, out var foundAlias);
+                parentAlias ??= foundAlias;
+                // Remove the higher index first so the lower index stays valid.
+                if (notNullIndex > equalIndex)
+                {
+                    conjuncts.RemoveAt(notNullIndex);
+                    conjuncts.RemoveAt(equalIndex);
+                }
+                else
+                {
+                    conjuncts.RemoveAt(equalIndex);
+                    conjuncts.RemoveAt(notNullIndex);
+                }
+                continue;
+            }
+
+            // A required FK/PK property pair's correlation conjunct wasn't found at all -- this
+            // isn't the shape we expect from ExpandOwnedNavigation, so don't guess.
+            return false;
+        }
+
+        if (parentAlias == null)
+        {
+            return false;
+        }
+
+        residual = conjuncts.Count == 0
+            ? null
+            : conjuncts.Aggregate((left, right) => new SqlBinaryExpression(
+                ExpressionType.AndAlso, left, right, typeof(bool), left.TypeMapping));
+
+        return true;
+    }
+
+    private static void FlattenAndAlso(SqlExpression expression, List<SqlExpression> conjuncts)
+    {
+        if (expression is SqlBinaryExpression { OperatorType: ExpressionType.AndAlso } binary)
+        {
+            FlattenAndAlso(binary.Left, conjuncts);
+            FlattenAndAlso(binary.Right, conjuncts);
+        }
+        else
+        {
+            conjuncts.Add(expression);
+        }
+    }
+
+    private static bool IsCorrelationEqual(
+        SqlExpression expression, string ownedAlias, string fkColumn, string pkColumn, out string? parentAlias)
+    {
+        parentAlias = null;
+        if (expression is not SqlBinaryExpression { OperatorType: ExpressionType.Equal } binary)
+        {
+            return false;
+        }
+
+        if (binary.Left is ColumnExpression left && binary.Right is ColumnExpression right)
+        {
+            if (left.TableAlias == ownedAlias && left.Name == fkColumn && right.TableAlias != ownedAlias && right.Name == pkColumn)
+            {
+                parentAlias = right.TableAlias;
+                return true;
+            }
+
+            if (right.TableAlias == ownedAlias && right.Name == fkColumn && left.TableAlias != ownedAlias && left.Name == pkColumn)
+            {
+                parentAlias = left.TableAlias;
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static bool IsColumnNotNull(SqlExpression expression, string ownedAlias, string columnName)
+        => expression is SqlBinaryExpression { OperatorType: ExpressionType.NotEqual } binary
+           && ((binary.Left is ColumnExpression lc && lc.TableAlias == ownedAlias && lc.Name == columnName && binary.Right is SqlConstantExpression { Value: null })
+               || (binary.Right is ColumnExpression rc && rc.TableAlias == ownedAlias && rc.Name == columnName && binary.Left is SqlConstantExpression { Value: null }));
 
     protected override Expression VisitTable(TableExpression tableExpression)
     {
@@ -666,9 +926,17 @@ public class CouchbaseQuerySqlGenerator : QuerySqlGenerator
             return columnExpression;
         }
 
+        // Inside an owned-collection ANY(...)'s SATISFIES clause (see
+        // TryRenderOwnedCollectionAny), a column bound to the owned alias refers to a property of
+        // an array element embedded in JSON -- those are written under the policy-converted name
+        // (e.g. "title", not "Title"), unlike every other column this generator renders.
+        var propertyName = columnExpression.TableAlias == _ownedAnyAlias
+            ? _fieldNamingPolicy?.ConvertName(columnExpression.Name) ?? columnExpression.Name
+            : columnExpression.Name;
+
         Sql.Append(helper.DelimitIdentifier(columnExpression.TableAlias))
             .Append(".")
-            .Append(helper.DelimitIdentifier(columnExpression.Name));
+            .Append(helper.DelimitIdentifier(propertyName));
 
         return columnExpression;
     }

--- a/src/Couchbase.EntityFrameworkCore/Query/Internal/CouchbaseQuerySqlGeneratorFactory.cs
+++ b/src/Couchbase.EntityFrameworkCore/Query/Internal/CouchbaseQuerySqlGeneratorFactory.cs
@@ -1,3 +1,4 @@
+using System.Text.Json;
 using Couchbase.EntityFrameworkCore.Infrastructure;
 using Couchbase.Extensions.DependencyInjection;
 using Microsoft.EntityFrameworkCore.Query;
@@ -8,16 +9,22 @@ namespace Couchbase.EntityFrameworkCore.Query.Internal;
 public class CouchbaseQuerySqlGeneratorFactory : IQuerySqlGeneratorFactory
 {
     private readonly QuerySqlGeneratorDependencies _dependencies;
+    private readonly JsonNamingPolicy? _fieldNamingPolicy;
 
-    public CouchbaseQuerySqlGeneratorFactory(QuerySqlGeneratorDependencies dependencies/*, ICouchbaseDbContextOptionsBuilder couchbaseDbContextOptionsBuilder*/)
+    // JsonNamingPolicy? is captured by value at DI-registration time (see
+    // CouchbaseServiceCollectionExtensions.AddEntityFrameworkCouchbase) rather than resolving
+    // ICouchbaseDbContextOptionsBuilder here directly -- IQuerySqlGeneratorFactory is
+    // Singleton-lifetime (EF Core's own registration), while ICouchbaseDbContextOptionsBuilder is
+    // Scoped, so constructor-injecting the latter would be a captive-dependency bug.
+    public CouchbaseQuerySqlGeneratorFactory(QuerySqlGeneratorDependencies dependencies, JsonNamingPolicy? fieldNamingPolicy)
     {
         _dependencies = dependencies;
-        //_couchbaseDbContextOptionsBuilder = couchbaseDbContextOptionsBuilder;
+        _fieldNamingPolicy = fieldNamingPolicy;
     }
-    
+
     public QuerySqlGenerator Create()
     {
-        return new CouchbaseQuerySqlGenerator(_dependencies/*, _couchbaseDbContextOptionsBuilder*/);
+        return new CouchbaseQuerySqlGenerator(_dependencies, _fieldNamingPolicy);
     }
 }
 

--- a/src/Couchbase.EntityFrameworkCore/Query/Internal/CouchbaseShapedQueryCompilingExpressionVisitor.cs
+++ b/src/Couchbase.EntityFrameworkCore/Query/Internal/CouchbaseShapedQueryCompilingExpressionVisitor.cs
@@ -374,7 +374,7 @@ public class CouchbaseShapedQueryCompilingExpressionVisitor : RelationalShapedQu
         var policy = _couchbaseDbContextOptionsBuilder.FieldNamingPolicy;
         foreach (var nav in ownedNavs)
         {
-            var fieldName = policy?.ConvertName(nav.Name) ?? nav.Name;
+            var fieldName = CouchbaseProjectionAliases.GetOwnedCollectionFieldName(nav, policy);
 
             if (innerSelect != null)
             {

--- a/tests/Couchbase.EntityFrameworkCore.IntegrationTests/Tests/AnySatisfiesMissingFieldSpikeTests.cs
+++ b/tests/Couchbase.EntityFrameworkCore.IntegrationTests/Tests/AnySatisfiesMissingFieldSpikeTests.cs
@@ -1,0 +1,122 @@
+using Couchbase.EntityFrameworkCode.IntegrationTests.Fixtures;
+using Xunit.Abstractions;
+
+namespace Couchbase.EntityFrameworkCode.IntegrationTests.Tests;
+
+/// <summary>
+/// Phase-0 empirical spike for the planned `.Any(predicate)`-over-`OwnsMany` fix: before writing
+/// the <c>ANY x IN parentAlias.field SATISFIES ... END</c> rendering, this proves -- against a
+/// real query engine, bypassing EF Core and this provider entirely (raw KV writes, raw N1QL via
+/// <see cref="global::Couchbase.Cluster.QueryAsync{T}"/>) -- how N1QL's <c>ANY...SATISFIES</c>
+/// behaves when the target array field is genuinely absent, present-but-empty, or present-but-
+/// explicit-JSON-null on a given document. `.Any()`'s expected semantics for all three cases is
+/// "no elements to match" == false, not an error.
+/// </summary>
+[Collection(CouchbaseTestingCollection.Name)]
+public class AnySatisfiesMissingFieldSpikeTests(BloggingFixture fixture, ITestOutputHelper outputHelper)
+{
+    [Fact]
+    public async Task AnySatisfies_OverAbsentEmptyNullAndPopulatedArray_EvaluatesFalsyNotError()
+    {
+        var collectionName = "anyspike" + Guid.NewGuid().ToString("N");
+        var bucketId = fixture.BucketName;
+        var scopeId = fixture.ScopeName;
+
+        var clusterOptions = new global::Couchbase.ClusterOptions()
+            .WithConnectionString(fixture.Host)
+            .WithPasswordAuthentication(fixture.Username, fixture.Password)
+            .WithSerializer(global::Couchbase.Core.IO.Serializers.SystemTextJsonSerializer.Create());
+        using var cluster = await global::Couchbase.Cluster.ConnectAsync(clusterOptions);
+        var bucket = await cluster.BucketAsync(fixture.BucketName);
+        var scope = await bucket.ScopeAsync(fixture.ScopeName);
+
+        try
+        {
+            await bucket.Collections.CreateCollectionAsync(
+                new global::Couchbase.Management.Collections.CollectionSpec(fixture.ScopeName, collectionName));
+            var collection = scope.Collection(collectionName);
+
+            // Id=1: Tags field is genuinely MISSING (key omitted entirely).
+            await collection.InsertAsync("1", new Dictionary<string, object> { ["Id"] = 1 });
+            // Id=2: Tags field is present but an empty array.
+            await collection.InsertAsync("2", new Dictionary<string, object> { ["Id"] = 2, ["Tags"] = new List<string>() });
+            // Id=3: Tags field is present but an explicit JSON null.
+            await collection.InsertAsync("3", new Dictionary<string, object?> { ["Id"] = 3, ["Tags"] = null });
+            // Id=4: Tags field is present with a non-matching element.
+            await collection.InsertAsync("4", new Dictionary<string, object> { ["Id"] = 4, ["Tags"] = new List<string> { "other" } });
+            // Id=5: Tags field is present with a matching element.
+            await collection.InsertAsync("5", new Dictionary<string, object> { ["Id"] = 5, ["Tags"] = new List<string> { "x" } });
+
+            // A collection just created via the management API isn't necessarily visible to the
+            // query service immediately -- retry the DDL itself (not just the online-wait below)
+            // until the keyspace is recognized, rather than assuming instant propagation.
+            var createIndexSql = $"CREATE PRIMARY INDEX IF NOT EXISTS ON `{bucketId}`.`{scopeId}`.`{collectionName}`";
+            var createIndexDeadline = DateTime.UtcNow.AddSeconds(30);
+            while (true)
+            {
+                try
+                {
+                    using var createIndexResult = await cluster.QueryAsync<dynamic>(createIndexSql);
+                    await foreach (var _ in createIndexResult.Rows) { }
+                    break;
+                }
+                catch (global::Couchbase.Core.Exceptions.IndexFailureException) when (DateTime.UtcNow < createIndexDeadline)
+                {
+                    await Task.Delay(500);
+                }
+            }
+
+            // Poll until the index is online -- mirrors this project's established
+            // AutoCreateIndexes wait pattern rather than a fixed sleep. A delay between polls
+            // avoids hammering the query service, and failing fast if the deadline passes without
+            // ever observing the index online turns a silent false-negative (querying against a
+            // not-yet-ready index) into a clear, diagnosable failure instead.
+            var deadline = DateTime.UtcNow.AddSeconds(60);
+            var indexOnline = false;
+            while (DateTime.UtcNow < deadline)
+            {
+                using var countResult = await cluster.QueryAsync<long>(
+                    "SELECT RAW COUNT(*) FROM system:indexes WHERE is_primary = true AND state = 'online' " +
+                    $"AND bucket_id = '{bucketId}' AND scope_id = '{scopeId}' AND keyspace_id = '{collectionName}'");
+                long count = 0;
+                await foreach (var row in countResult.Rows) { count = row; }
+                if (count > 0)
+                {
+                    indexOnline = true;
+                    break;
+                }
+
+                await Task.Delay(500);
+            }
+
+            Assert.True(indexOnline, $"Primary index on `{collectionName}` did not come online within the deadline.");
+
+            var sql = $"SELECT RAW Id FROM `{bucketId}`.`{scopeId}`.`{collectionName}` AS d " +
+                      "WHERE ANY v IN d.Tags SATISFIES v = 'x' END " +
+                      "ORDER BY Id";
+
+            using var result = await cluster.QueryAsync<long>(
+                sql,
+                new global::Couchbase.Query.QueryOptions().ScanConsistency(global::Couchbase.Query.QueryScanConsistency.RequestPlus));
+
+            var matchedIds = new List<long>();
+            await foreach (var row in result.Rows) { matchedIds.Add(row); }
+
+            outputHelper.WriteLine($"ANY...SATISFIES matched ids: [{string.Join(", ", matchedIds)}]");
+
+            // Absent (1), empty (2), explicit null (3), and non-matching (4) must all be excluded
+            // -- falsy, not an error -- and only the genuinely matching document (5) included.
+            Assert.Equal([5L], matchedIds);
+        }
+        finally
+        {
+            try
+            {
+                await bucket.Collections.DropCollectionAsync(fixture.ScopeName, collectionName);
+            }
+            catch (global::Couchbase.Management.Collections.CollectionNotFoundException)
+            {
+            }
+        }
+    }
+}

--- a/tests/Couchbase.EntityFrameworkCore.IntegrationTests/Tests/CouchbaseMetaTests.cs
+++ b/tests/Couchbase.EntityFrameworkCore.IntegrationTests/Tests/CouchbaseMetaTests.cs
@@ -190,7 +190,15 @@ public class CouchbaseMetaTests(BloggingFixture fixture) : IAsyncLifetime
         var entity = await readCtx.Entities.SingleAsync(e => e.Id == 6);
 
         Assert.True(entity.Expiration > 0, "Expiration should be a nonzero epoch-seconds value when a TTL is set.");
-        var expectedNoEarlierThan = beforeInsert.AddMinutes(30).ToUnixTimeSeconds();
+
+        // The expiration is computed from the *server's* clock at the moment it processes the
+        // write, not the client's -- ToUnixTimeSeconds() floors to whole seconds, and even small
+        // client/server clock skew (routine under Aspire's containerized cluster) can put the
+        // server's floored second one tick below the client's, independent of network latency.
+        // A few seconds of slack on the lower bound absorbs that without weakening the assertion's
+        // actual purpose (proving a real ~30-minute TTL was read back, not an exact-second match).
+        const int clockSkewSlack = 5;
+        var expectedNoEarlierThan = beforeInsert.AddMinutes(30).AddSeconds(-clockSkewSlack).ToUnixTimeSeconds();
         var expectedNoLaterThan = DateTimeOffset.UtcNow.AddMinutes(30).AddMinutes(1).ToUnixTimeSeconds();
         Assert.InRange(entity.Expiration, expectedNoEarlierThan, expectedNoLaterThan);
     }

--- a/tests/Couchbase.EntityFrameworkCore.IntegrationTests/Tests/OwnedTypeTests.cs
+++ b/tests/Couchbase.EntityFrameworkCore.IntegrationTests/Tests/OwnedTypeTests.cs
@@ -1145,4 +1145,92 @@ public class OwnedTypeTests(
 
         Assert.Equal(0, writes);
     }
+
+    // -------------------------------------------------------------------------
+    // .Any(predicate) / .Any() over a depth-1 OwnsMany navigation
+    //
+    // This provider maps OwnsMany collections as a JSON array embedded in the parent document --
+    // EF Core translates .Any(predicate) identically for owned and non-owned collections, as a
+    // correlated EXISTS subquery whose sole FROM table is the owned type's TableExpression, which
+    // this provider's owned-table JOIN suppression renders as nothing (an empty-FROM-clause N1QL
+    // error). CouchbaseQuerySqlGenerator.GenerateExists now recognizes this shape and renders N1QL's
+    // ANY...SATISFIES...END instead. Alice (1) and Carol (3) have a "phone" contact method; Bob (2)
+    // does not (email only) -- used throughout to prove real inclusion/exclusion, not just that the
+    // generated SQL text looks right.
+    // -------------------------------------------------------------------------
+
+    [Fact]
+    public async Task OwnsMany_Any_WithPredicate_ReturnsOnlyMatchingCustomers()
+    {
+        await using var ctx = fixture.GetDbContext();
+        var customers = await ctx.Customers
+            .Where(c => c.ContactMethods.Any(cm => cm.Type == "phone"))
+            .ToListAsync();
+
+        Assert.Equal(2, customers.Count);
+        Assert.Contains(customers, c => c.CustomerId == 1);
+        Assert.Contains(customers, c => c.CustomerId == 3);
+        Assert.DoesNotContain(customers, c => c.CustomerId == 2);
+    }
+
+    [Fact]
+    public async Task OwnsMany_Any_Negated_ReturnsOnlyNonMatchingCustomers()
+    {
+        await using var ctx = fixture.GetDbContext();
+        var customers = await ctx.Customers
+            .Where(c => !c.ContactMethods.Any(cm => cm.Type == "phone"))
+            .ToListAsync();
+
+        Assert.Single(customers);
+        Assert.Equal(2, customers[0].CustomerId);
+    }
+
+    [Fact]
+    public async Task OwnsMany_Any_NoPredicate_ExcludesCustomerWithEmptyCollection()
+    {
+        const int id = 700;
+        try
+        {
+            await using (var ctx = fixture.GetDbContext())
+            {
+                ctx.Update(new OwnedTypeFixture.Customer
+                {
+                    CustomerId = id,
+                    Name = "NoContacts",
+                    Address = new OwnedTypeFixture.Address { Street = "1 Empty Way", City = "Nowhere" },
+                    ContactMethods = []
+                });
+                await ctx.SaveChangesAsync();
+            }
+
+            await using (var ctx = fixture.GetDbContext())
+            {
+                var withAny = await ctx.Customers.Where(c => c.ContactMethods.Any()).ToListAsync();
+                Assert.DoesNotContain(withAny, c => c.CustomerId == id);
+                Assert.Contains(withAny, c => c.CustomerId == 1);
+
+                var withoutAny = await ctx.Customers.Where(c => !c.ContactMethods.Any()).ToListAsync();
+                Assert.Contains(withoutAny, c => c.CustomerId == id);
+                Assert.DoesNotContain(withoutAny, c => c.CustomerId == 1);
+            }
+        }
+        finally
+        {
+            await using var ctx = fixture.GetDbContext();
+            var customer = await ctx.Customers.FirstOrDefaultAsync(c => c.CustomerId == id);
+            if (customer != null) { ctx.Remove(customer); await ctx.SaveChangesAsync(); }
+        }
+    }
+
+    [Fact]
+    public async Task OwnsMany_Any_WithPredicate_CombinesWithOtherWhereConditions()
+    {
+        await using var ctx = fixture.GetDbContext();
+        var customers = await ctx.Customers
+            .Where(c => c.Name == "Alice" && c.ContactMethods.Any(cm => cm.Type == "phone"))
+            .ToListAsync();
+
+        Assert.Single(customers);
+        Assert.Equal(1, customers[0].CustomerId);
+    }
 }

--- a/tests/Couchbase.EntityFrameworkCore.UnitTests/Couchbase/EntityFrameworkCore/Query/CouchbaseQuerySqlGeneratorFactoryDiTests.cs
+++ b/tests/Couchbase.EntityFrameworkCore.UnitTests/Couchbase/EntityFrameworkCore/Query/CouchbaseQuerySqlGeneratorFactoryDiTests.cs
@@ -1,0 +1,103 @@
+using System.Text.Json;
+using Couchbase.EntityFrameworkCore.Extensions;
+using Couchbase.EntityFrameworkCore.Infrastructure.Internal;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Query;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace Couchbase.EntityFrameworkCore.UnitTests.Couchbase.EntityFrameworkCore.Query;
+
+/// <summary>
+/// <see cref="Couchbase.EntityFrameworkCore.Query.Internal.CouchbaseQuerySqlGeneratorFactory"/>
+/// used to have a commented-out, never-finished <c>ICouchbaseDbContextOptionsBuilder</c>
+/// constructor parameter -- constructor-injecting it directly would have been a captive-dependency
+/// bug, since <c>IQuerySqlGeneratorFactory</c> is Singleton-lifetime (EF Core's own registration)
+/// while <c>ICouchbaseDbContextOptionsBuilder</c> is Scoped. This guards the fix (capturing
+/// <c>FieldNamingPolicy</c> by value at DI-registration time instead).
+/// </summary>
+public class CouchbaseQuerySqlGeneratorFactoryDiTests
+{
+    private class Post
+    {
+        public int PostId { get; set; }
+        public string Title { get; set; } = "";
+    }
+
+    private class PostContext(DbContextOptions<PostContext> options) : DbContext(options)
+    {
+        public DbSet<Post> Posts { get; set; } = null!;
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            modelBuilder.Entity<Post>(b =>
+            {
+                b.ToCouchbaseCollection("bucket", "scope", "post");
+                b.HasKey(p => p.PostId);
+            });
+        }
+    }
+
+    private static DbContextOptionsBuilder<PostContext> CreateBuilder(JsonNamingPolicy? policy)
+    {
+        var clusterOptions = new ClusterOptions()
+            .WithConnectionString("couchbase://localhost")
+            .WithPasswordAuthentication("Administrator", "password");
+
+        var builder = new DbContextOptionsBuilder<PostContext>();
+        builder.UseCouchbaseProvider(clusterOptions, o => o.FieldNamingPolicy = policy);
+        return builder;
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("CamelCase")]
+    [InlineData("SnakeCaseLower")]
+    public void QueryCompiles_RegardlessOfConfiguredFieldNamingPolicy(string? policyName)
+    {
+        JsonNamingPolicy? policy = policyName switch
+        {
+            "CamelCase" => JsonNamingPolicy.CamelCase,
+            "SnakeCaseLower" => JsonNamingPolicy.SnakeCaseLower,
+            _ => null,
+        };
+
+        using var ctx = new PostContext(CreateBuilder(policy).Options);
+
+        var sql = ctx.Posts.Where(p => p.Title == "x").ToQueryString();
+
+        Assert.Contains("`b`.`Title` = 'x'", sql);
+    }
+
+    /// <summary>
+    /// EF Core builds its own internal service provider with <c>ValidateScopes</c>/
+    /// <c>ValidateOnBuild</c> both off (<c>ServiceProviderCache.BuildServiceProvider</c> calls the
+    /// parameterless <c>services.BuildServiceProvider()</c>), so exercising a query through a
+    /// normal <see cref="DbContext"/> — as <see cref="QueryCompiles_RegardlessOfConfiguredFieldNamingPolicy"/>
+    /// does — would silently succeed even if the captive-dependency bug were reintroduced; a real
+    /// captive-dependency exception only surfaces under explicit scope validation. This test builds
+    /// the exact same registrations
+    /// (<see cref="CouchbaseOptionsExtension.ApplyServices"/>, the same method EF Core's own
+    /// provider-building calls) into a fresh <see cref="ServiceCollection"/> and resolves
+    /// <see cref="IQuerySqlGeneratorFactory"/> from an explicitly scope-validating provider, so a
+    /// reintroduced constructor-injected <c>ICouchbaseDbContextOptionsBuilder</c> would fail this
+    /// test with <see cref="InvalidOperationException"/> rather than passing silently.
+    /// </summary>
+    [Fact]
+    public void QuerySqlGeneratorFactory_ResolvesUnderScopeValidation_WithoutCaptiveDependencyException()
+    {
+        var options = CreateBuilder(JsonNamingPolicy.CamelCase).Options;
+        var extension = options.FindExtension<CouchbaseOptionsExtension>();
+        Assert.NotNull(extension);
+
+        var services = new ServiceCollection();
+        extension.ApplyServices(services);
+
+        using var provider = services.BuildServiceProvider(new ServiceProviderOptions { ValidateScopes = true });
+        using var scope = provider.CreateScope();
+
+        var factory = scope.ServiceProvider.GetRequiredService<IQuerySqlGeneratorFactory>();
+
+        Assert.NotNull(factory);
+    }
+}

--- a/tests/Couchbase.EntityFrameworkCore.UnitTests/Couchbase/EntityFrameworkCore/Query/OwnedCollectionAnyTests.cs
+++ b/tests/Couchbase.EntityFrameworkCore.UnitTests/Couchbase/EntityFrameworkCore/Query/OwnedCollectionAnyTests.cs
@@ -1,0 +1,220 @@
+using System.Text.Json;
+using Couchbase.EntityFrameworkCore.Extensions;
+using Microsoft.EntityFrameworkCore;
+using Xunit;
+
+namespace Couchbase.EntityFrameworkCore.UnitTests.Couchbase.EntityFrameworkCore.Query;
+
+/// <summary>
+/// Verifies `.Any(predicate)`/`.Any()` over a depth-1 <c>OwnsMany</c> navigation translates to
+/// N1QL's <c>ANY x IN parentAlias.field SATISFIES ... END</c>, not the correlated <c>EXISTS</c>
+/// subquery EF Core builds by default -- which this provider's owned-table JOIN suppression
+/// (<c>VisitTable</c>/<c>IsOwnedTable</c>) would otherwise turn into an empty-FROM-clause N1QL
+/// error, since there's no real keyspace to correlate against (the collection is a JSON array
+/// field embedded in the parent document, already in scope).
+/// </summary>
+public class OwnedCollectionAnyTests
+{
+    private class Customer
+    {
+        public int CustomerId { get; set; }
+        public string Name { get; set; } = "";
+        public List<ContactMethod> ContactMethods { get; set; } = [];
+    }
+
+    private class ContactMethod
+    {
+        public int Id { get; set; }
+        public string Type { get; set; } = "";
+    }
+
+    private class Order
+    {
+        public int OrderId { get; set; }
+        public int CustomerId { get; set; }
+    }
+
+    private class CustomerContext(DbContextOptions<CustomerContext> options) : DbContext(options)
+    {
+        public DbSet<Customer> Customers { get; set; } = null!;
+        public DbSet<Order> Orders { get; set; } = null!;
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            modelBuilder.Entity<Customer>(b =>
+            {
+                b.ToCouchbaseCollection("bucket", "scope", "customer");
+                b.HasKey(c => c.CustomerId);
+                b.OwnsMany(c => c.ContactMethods, cm => cm.HasKey(m => m.Id));
+            });
+            modelBuilder.Entity<Order>(b =>
+            {
+                b.ToCouchbaseCollection("bucket", "scope", "order");
+                b.HasKey(o => o.OrderId);
+            });
+        }
+    }
+
+    private static CustomerContext CreateContext(JsonNamingPolicy? fieldNamingPolicy = null)
+    {
+        var clusterOptions = new global::Couchbase.ClusterOptions()
+            .WithConnectionString("couchbase://localhost")
+            .WithPasswordAuthentication("Administrator", "password");
+        var builder = new DbContextOptionsBuilder<CustomerContext>();
+        builder.UseCouchbaseProvider(clusterOptions, o =>
+        {
+            if (fieldNamingPolicy != null)
+            {
+                o.FieldNamingPolicy = fieldNamingPolicy;
+            }
+        });
+        return new CustomerContext(builder.Options);
+    }
+
+    [Fact]
+    public void WithPredicate_TranslatesToAnySatisfies_NotExists()
+    {
+        using var ctx = CreateContext();
+        var sql = ctx.Customers.Where(c => c.ContactMethods.Any(m => m.Type == "email")).ToQueryString();
+
+        Assert.Contains("ANY `c` IN `b`.`contactMethods` SATISFIES `c`.`type` = 'email' END", sql);
+        Assert.DoesNotContain("EXISTS", sql, StringComparison.OrdinalIgnoreCase);
+
+        // The correlation conjunct (CustomerId = CustomerId) must not leak into the WHERE clause
+        // -- CustomerId legitimately appears elsewhere (the outer SELECT list, ORDER BY).
+        var whereStart = sql.IndexOf("WHERE", StringComparison.Ordinal);
+        var orderByStart = sql.IndexOf("ORDER BY", StringComparison.Ordinal);
+        var whereClause = sql[whereStart..(orderByStart >= 0 ? orderByStart : sql.Length)];
+        Assert.DoesNotContain("CustomerId", whereClause, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void NoPredicate_TranslatesToAnySatisfiesTrue()
+    {
+        using var ctx = CreateContext();
+        var sql = ctx.Customers.Where(c => c.ContactMethods.Any()).ToQueryString();
+
+        Assert.Contains("ANY `c` IN `b`.`contactMethods` SATISFIES true END", sql);
+        Assert.DoesNotContain("EXISTS", sql, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void Negated_TranslatesToNotWrappedAnySatisfies()
+    {
+        using var ctx = CreateContext();
+        var sql = ctx.Customers.Where(c => !c.ContactMethods.Any(m => m.Type == "email")).ToQueryString();
+
+        Assert.Contains("NOT (ANY `c` IN `b`.`contactMethods` SATISFIES `c`.`type` = 'email' END)", sql);
+    }
+
+    [Fact]
+    public void NonDefaultFieldNamingPolicy_AppliesToArrayFieldAndPropertyName()
+    {
+        using var ctx = CreateContext(JsonNamingPolicy.SnakeCaseLower);
+        var sql = ctx.Customers.Where(c => c.ContactMethods.Any(m => m.Type == "email")).ToQueryString();
+
+        Assert.Contains("`b`.`contact_methods`", sql);
+        Assert.Contains("`c`.`type` = 'email'", sql);
+    }
+
+    [Fact]
+    public void WithPredicate_ParenthesesBalanced()
+    {
+        using var ctx = CreateContext();
+        var sql = ctx.Customers.Where(c => c.ContactMethods.Any(m => m.Type == "email")).ToQueryString();
+        Assert.Equal(sql.Count(c => c == '('), sql.Count(c => c == ')'));
+    }
+
+    [Fact]
+    public void CorrelatedAnyOverUnrelatedDbSet_StillUsesExists()
+    {
+        // Control case: a genuine correlated .Any() whose subquery's sole table is NOT an owned
+        // type (a manually-correlated subquery over an unrelated DbSet, not a navigation
+        // expansion) must still render as a normal EXISTS -- proving GenerateExists's owned-table
+        // detection doesn't over-fire and break this pre-existing, unrelated case.
+        using var ctx = CreateContext();
+        var sql = ctx.Customers.Where(c => ctx.Orders.Any(o => o.CustomerId == c.CustomerId)).ToQueryString();
+
+        Assert.Contains("EXISTS", sql, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("ANY ", sql);
+    }
+
+    // -------------------------------------------------------------------------
+    // Regression: OwnsMany item type that itself table-splits a nested OwnsOne (and/or hosts a
+    // further nested OwnsMany) -- e.g. ContactMethod owning its own Label. The table backing such
+    // an item type carries MORE THAN ONE owned IEntityType mapping (ContactMethod AND Label both
+    // pass IsOwnedTable's All-owned check), and picking the wrong one resolves the wrong
+    // ownership/FK, silently falling through to the broken default EXISTS rendering instead of
+    // throwing -- caught empirically via a live-shaped integration-test model, not by static
+    // reading alone.
+    // -------------------------------------------------------------------------
+
+    private class RichCustomer
+    {
+        public int CustomerId { get; set; }
+        public List<RichContactMethod> ContactMethods { get; set; } = [];
+    }
+
+    private class RichContactMethod
+    {
+        public int Id { get; set; }
+        public string Type { get; set; } = "";
+        public ContactLabel? Label { get; set; }
+    }
+
+    private class ContactLabel
+    {
+        public string? DisplayName { get; set; }
+    }
+
+    private class RichCustomerContext(DbContextOptions<RichCustomerContext> options) : DbContext(options)
+    {
+        public DbSet<RichCustomer> Customers { get; set; } = null!;
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            modelBuilder.Entity<RichCustomer>(b =>
+            {
+                b.ToCouchbaseCollection("bucket", "scope", "customer");
+                b.HasKey(c => c.CustomerId);
+                b.OwnsMany(c => c.ContactMethods, cm =>
+                {
+                    cm.HasKey(m => m.Id);
+                    cm.OwnsOne(m => m.Label);
+                });
+            });
+        }
+    }
+
+    private static RichCustomerContext CreateRichContext()
+    {
+        var clusterOptions = new global::Couchbase.ClusterOptions()
+            .WithConnectionString("couchbase://localhost")
+            .WithPasswordAuthentication("Administrator", "password");
+        var builder = new DbContextOptionsBuilder<RichCustomerContext>();
+        builder.UseCouchbaseProvider(clusterOptions);
+        return new RichCustomerContext(builder.Options);
+    }
+
+    [Fact]
+    public void ItemTypeWithNestedOwnsOne_StillTranslatesToAnySatisfies()
+    {
+        // Alias is `r` (from RichContactMethod), not `c` -- EF Core derives it from the CLR type
+        // name of the single navigation source in scope.
+        using var ctx = CreateRichContext();
+        var sql = ctx.Customers.Where(c => c.ContactMethods.Any(m => m.Type == "phone")).ToQueryString();
+
+        Assert.Contains("ANY `r` IN `b`.`contactMethods` SATISFIES `r`.`type` = 'phone' END", sql);
+        Assert.DoesNotContain("EXISTS", sql, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void ItemTypeWithNestedOwnsOne_NoPredicate_StillTranslatesToAnySatisfies()
+    {
+        using var ctx = CreateRichContext();
+        var sql = ctx.Customers.Where(c => c.ContactMethods.Any()).ToQueryString();
+
+        Assert.Contains("ANY `r` IN `b`.`contactMethods` SATISFIES true END", sql);
+        Assert.DoesNotContain("EXISTS", sql, StringComparison.OrdinalIgnoreCase);
+    }
+}


### PR DESCRIPTION
`.Any(predicate)`/`.Any()` over an OwnsMany collection previously produced an EXISTS subquery with an empty FROM clause -- the collection is a JSON array embedded in the parent document, not a real keyspace to correlate against. Now translates to N1QL's ANY x IN parentAlias.field SATISFIES ... END, implemented entirely in GenerateExists by recognizing and stripping the correlation predicate EF Core builds for the owned-navigation expansion.

Also fixes a real captive-dependency DI bug found along the way: CouchbaseQuerySqlGeneratorFactory had a commented-out, never-finished ICouchbaseDbContextOptionsBuilder parameter that would throw under DI scope validation (Singleton constructor-injecting a Scoped service). Threads FieldNamingPolicy through safely via a value-capturing factory lambda instead, mirroring the existing CouchbaseTypeMappingSource pattern.

Nested owned collections, .All(), .Count(predicate), and .Contains() over an owned collection remain unsupported.