### PR TITLE
Add scalar primitive collection support (indexer, .Contains, .Count, …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ and this project aims to follow [Semantic Versioning](https://semver.org/spec/v2
 
 ### Added
 
+- **Scalar primitive collections (`List<T>`/`T[]`, not `OwnsMany`).** A `List<T>`/`T[]` property
+  of a scalar element type mapped directly on an entity is now stored as a native JSON array
+  (previously silently double-encoded as a JSON string via EF Core's default primitive-collection
+  converter, breaking any query against it) and supports indexer/`.ElementAt()` (N1QL's native
+  array-subscript syntax; behaves like `.ElementAtOrDefault()` — out-of-range/negative returns the
+  default value rather than throwing), `.Contains()`, `.Count`, and `.Any(predicate)` (a
+  correlated subquery over the array field). `.OrderBy(...).ElementAt(...)`/
+  `.Where(...).ElementAt(...)` compositions and reverse-`.Contains()` over a local in-memory
+  collection are not supported. See [Modeling — Primitive collections](docs/modeling.md#primitive-collections).
 - **`.Any(predicate)`/`.Any()` over a depth-1 `OwnsMany` navigation.** Previously silently
   produced invalid SQL++ (an `EXISTS` subquery with an empty `FROM` clause, since the owned
   collection is a JSON array embedded in the parent document, not a real keyspace to correlate

--- a/docs/Queries.md
+++ b/docs/Queries.md
@@ -171,6 +171,29 @@ argument, not two scalars — no array-literal expression support exists yet to 
 functions (`Sin`/`Cos`/`Tan`/...), and secondary-index support for EF Core's `HasIndex()` (see
 [Limitations](limitations.md)).
 
+## Primitive collections
+
+A scalar `List<T>`/`T[]` property mapped directly on an entity (not via `OwnsMany`) — see
+[Primitive collections](modeling.md#primitive-collections) — supports indexer/`.ElementAt()`,
+`.Contains()`, `.Count`, and `.Any(predicate)`:
+
+```
+context.Hotels.Where(h => h.PublicLikes[0] == "Alice");
+context.Hotels.Where(h => h.PublicLikes.Contains("Bob"));
+context.Hotels.Where(h => h.PublicLikes.Count == 3);
+context.Hotels.Where(h => h.PublicLikes.Any(n => n.StartsWith("Car")));
+```
+
+Indexer/`.ElementAt()` translates directly to N1QL's native array-subscript syntax
+(`field[index]`); `.Contains()`/`.Count`/`.Any(predicate)` translate to a correlated subquery over
+the array field. Indexer/`.ElementAt()` always behaves like `.ElementAtOrDefault()` — an
+out-of-range or negative index returns the element type's default rather than throwing, matching
+N1QL's own `MISSING`-for-out-of-range semantics.
+
+`.OrderBy(...).ElementAt(...)`/`.Where(...).ElementAt(...)` compositions and reverse-`.Contains()`
+over a local in-memory collection are not supported for a primitive collection source — see
+[Limitations](limitations.md).
+
 ## SQL queries
 
 > [!NOTE]

--- a/docs/limitations.md
+++ b/docs/limitations.md
@@ -74,6 +74,15 @@ The Couchbase SDK is asynchronous, so the synchronous EF Core code paths throw `
   *nested* owned collection reached through another owned navigation, `.All(predicate)`,
   `.Count(predicate)`, and `.Contains()` over an owned collection are not yet supported. See
   [Modeling — OwnsMany](modeling.md#ownsmany).
+* **Indexer/`.ElementAt()` over a scalar primitive collection (`List<T>`/`T[]`, not `OwnsMany`)
+  has no ordering guarantee beyond direct array position**, and always behaves like
+  `.ElementAtOrDefault()` (an out-of-range or negative index returns the default value rather than
+  throwing) — this Couchbase Server version has no N1QL syntax for a deterministic positional
+  binding over an unnested array. `.OrderBy(...).ElementAt(...)`/`.Where(...).ElementAt(...)`
+  compositions and reverse-`.Contains()` over a local in-memory collection are not supported for a
+  primitive collection source. Indexing into a scalar collection *inside* an `OwnsMany` navigation
+  (e.g. `customer.ContactMethods[0].Type`) is not yet supported at all. See
+  [Modeling — Primitive collections](modeling.md#primitive-collections).
 
 See also [Querying](Queries.md) and [Configuration](configuration.md).
 

--- a/docs/modeling.md
+++ b/docs/modeling.md
@@ -371,3 +371,42 @@ modelBuilder.Entity<Customer>().OwnsMany(c => c.Contacts, cm =>
 });
 ```
 
+## Primitive collections
+
+A `List<T>`/`T[]` property of a scalar element type (`string`, numeric types, `bool`, `Guid`,
+`DateTime`) mapped directly on an entity — not via `OwnsMany` — is stored as a native JSON array
+field, no configuration required:
+
+```
+public class Hotel
+{
+    public int Id { get; set; }
+    public List<string> PublicLikes { get; set; } = [];
+}
+```
+
+The following LINQ operators are supported over a primitive collection property:
+
+```
+// Indexer / .ElementAt()
+context.Hotels.Where(h => h.PublicLikes[0] == "Alice");
+
+// .Contains()
+context.Hotels.Where(h => h.PublicLikes.Contains("Bob"));
+
+// .Count
+context.Hotels.Where(h => h.PublicLikes.Count == 3);
+
+// .Any(predicate)
+context.Hotels.Where(h => h.PublicLikes.Any(n => n.StartsWith("Car")));
+```
+
+Indexer/`.ElementAt()` access always behaves like `.ElementAtOrDefault()` — an out-of-range or
+negative index returns the element type's default value rather than throwing, since N1QL's array
+subscript returns `MISSING` (falsy) for an out-of-range position instead of erroring.
+
+**Limitations**: there is no supported way to observe or rely on array position beyond direct
+indexing — `.OrderBy(...).ElementAt(...)` and `.Where(...).ElementAt(...)` compositions, and
+reverse-`.Contains()` over a local in-memory collection (`someList.Contains(h.SomeProperty)`), are
+not supported for a primitive collection source. See [limitations.md](limitations.md).
+

--- a/src/Couchbase.EntityFrameworkCore/Extensions/CouchbaseServiceCollectionExtensions.cs
+++ b/src/Couchbase.EntityFrameworkCore/Extensions/CouchbaseServiceCollectionExtensions.cs
@@ -84,6 +84,7 @@ public static class CouchbaseServiceCollectionExtensions
             .TryAdd<ISqlGenerationHelper, CouchbaseSqlGenerationHelper>()
             .TryAdd<IShapedQueryCompilingExpressionVisitorFactory, CouchbaseShapedQueryCompilingExpressionVisitorFactory>()
             .TryAdd<IQueryableMethodTranslatingExpressionVisitorFactory, CouchbaseQueryableMethodTranslatingExpressionVisitorFactory>()
+            .TryAdd<IRelationalParameterBasedSqlProcessorFactory, CouchbaseParameterBasedSqlProcessorFactory>()
             .TryAdd<IHistoryRepository, CouchbaseHistoryRepository>()//not used but required by ASP.NET
 
             //Found that this was necessary, because the default convention of determining a

--- a/src/Couchbase.EntityFrameworkCore/Query/Internal/CouchbaseArrayIndexExpression.cs
+++ b/src/Couchbase.EntityFrameworkCore/Query/Internal/CouchbaseArrayIndexExpression.cs
@@ -1,0 +1,77 @@
+using System.Linq.Expressions;
+using System.Reflection;
+using Microsoft.EntityFrameworkCore.Query;
+using Microsoft.EntityFrameworkCore.Query.SqlExpressions;
+using Microsoft.EntityFrameworkCore.Storage;
+
+namespace Couchbase.EntityFrameworkCore.Query.Internal;
+
+/// <summary>
+/// An expression representing N1QL's native array-subscript syntax (<c>arrayExpr[indexExpr]</c>)
+/// in a SQL tree -- used for <c>.ElementAt(i)</c>/indexer access over a scalar primitive-collection
+/// property. Confirmed via a live-cluster spike that this Couchbase Server version rejects
+/// <c>UNNEST ... AT posAlias</c> (no positional-ordinal syntax available), so unlike SQL Server's
+/// <c>JSON_VALUE(json, '$[i]')</c>/SQLite's <c>-&gt;&gt;</c> (both <em>optional</em> fast-path
+/// optimizations over an ordered rowset), direct array indexing is the ONLY mechanism this
+/// provider has for correct, deterministic element access -- see
+/// <see cref="CouchbaseQueryableMethodTranslatingExpressionVisitor"/>'s <c>TranslateElementAtOrDefault</c>
+/// override.
+/// </summary>
+public class CouchbaseArrayIndexExpression : SqlExpression
+{
+    private static ConstructorInfo? _quotingConstructor;
+
+    public virtual SqlExpression Array { get; }
+    public virtual SqlExpression Index { get; }
+
+    public CouchbaseArrayIndexExpression(
+        SqlExpression array,
+        SqlExpression index,
+        Type type,
+        RelationalTypeMapping? typeMapping)
+        : base(type, typeMapping)
+    {
+        Array = array;
+        Index = index;
+    }
+
+    protected override Expression VisitChildren(ExpressionVisitor visitor)
+    {
+        var newArray = (SqlExpression)visitor.Visit(Array);
+        var newIndex = (SqlExpression)visitor.Visit(Index);
+        return Update(newArray, newIndex);
+    }
+
+    public virtual CouchbaseArrayIndexExpression Update(SqlExpression array, SqlExpression index)
+        => array == Array && index == Index
+            ? this
+            : new CouchbaseArrayIndexExpression(array, index, Type, TypeMapping);
+
+#pragma warning disable EF9100 // RelationalExpressionQuotingUtilities is evaluation-purposes-only -- matches the same pattern EF Core's own SqlExpression subclasses (e.g. SqlUnaryExpression) use internally for this exact purpose.
+    public override Expression Quote()
+        => Expression.New(
+            _quotingConstructor ??= typeof(CouchbaseArrayIndexExpression).GetConstructor(
+                [typeof(SqlExpression), typeof(SqlExpression), typeof(Type), typeof(RelationalTypeMapping)])!,
+            Array.Quote(),
+            Index.Quote(),
+            Expression.Constant(Type),
+            RelationalExpressionQuotingUtilities.QuoteTypeMapping(TypeMapping));
+#pragma warning restore EF9100
+
+    protected override void Print(ExpressionPrinter expressionPrinter)
+    {
+        expressionPrinter.Visit(Array);
+        expressionPrinter.Append("[");
+        expressionPrinter.Visit(Index);
+        expressionPrinter.Append("]");
+    }
+
+    public override bool Equals(object? obj)
+        => ReferenceEquals(this, obj) || (obj is CouchbaseArrayIndexExpression other && Equals(other));
+
+    private bool Equals(CouchbaseArrayIndexExpression other)
+        => base.Equals(other) && Array.Equals(other.Array) && Index.Equals(other.Index);
+
+    public override int GetHashCode()
+        => HashCode.Combine(base.GetHashCode(), Array, Index);
+}

--- a/src/Couchbase.EntityFrameworkCore/Query/Internal/CouchbaseParameterBasedSqlProcessor.cs
+++ b/src/Couchbase.EntityFrameworkCore/Query/Internal/CouchbaseParameterBasedSqlProcessor.cs
@@ -1,0 +1,14 @@
+using System.Linq.Expressions;
+using Microsoft.EntityFrameworkCore.Query;
+
+namespace Couchbase.EntityFrameworkCore.Query.Internal;
+
+public class CouchbaseParameterBasedSqlProcessor(
+    RelationalParameterBasedSqlProcessorDependencies dependencies,
+    RelationalParameterBasedSqlProcessorParameters parameters)
+    : RelationalParameterBasedSqlProcessor(dependencies, parameters)
+{
+    protected override Expression ProcessSqlNullability(
+        Expression queryExpression, ParametersCacheDecorator parametersDecorator)
+        => new CouchbaseSqlNullabilityProcessor(Dependencies, Parameters).Process(queryExpression, parametersDecorator);
+}

--- a/src/Couchbase.EntityFrameworkCore/Query/Internal/CouchbaseParameterBasedSqlProcessorFactory.cs
+++ b/src/Couchbase.EntityFrameworkCore/Query/Internal/CouchbaseParameterBasedSqlProcessorFactory.cs
@@ -1,0 +1,10 @@
+using Microsoft.EntityFrameworkCore.Query;
+
+namespace Couchbase.EntityFrameworkCore.Query.Internal;
+
+public class CouchbaseParameterBasedSqlProcessorFactory(RelationalParameterBasedSqlProcessorDependencies dependencies)
+    : IRelationalParameterBasedSqlProcessorFactory
+{
+    public virtual RelationalParameterBasedSqlProcessor Create(RelationalParameterBasedSqlProcessorParameters parameters)
+        => new CouchbaseParameterBasedSqlProcessor(dependencies, parameters);
+}

--- a/src/Couchbase.EntityFrameworkCore/Query/Internal/CouchbaseQuerySqlGenerator.cs
+++ b/src/Couchbase.EntityFrameworkCore/Query/Internal/CouchbaseQuerySqlGenerator.cs
@@ -535,6 +535,19 @@ public class CouchbaseQuerySqlGenerator : QuerySqlGenerator
                     {
                         Sql.Append("RAW ");
                     }
+                    else if (expression is CouchbaseUnnestValueExpression)
+                    {
+                        // A single CouchbaseUnnestValueExpression projection is always the
+                        // SelectExpression TranslatePrimitiveCollection built for a primitive
+                        // collection -- consumed by the surrounding expression tree as an IN-list
+                        // source (.Contains()/.Any(predicate)) or similar set-of-scalars context.
+                        // N1QL's default `SELECT expr` wraps each row in an object keyed by an
+                        // implicit alias (e.g. `{"p": "Bob"}`), which breaks direct value
+                        // comparison against a bare scalar -- confirmed via a live-cluster spike
+                        // that `'Bob' IN (SELECT p FROM ...)` never matches without this.
+                        // `SELECT RAW expr` projects the bare scalar value instead.
+                        Sql.Append("RAW ");
+                    }
                     GenerateList(selectExpression.Projection, e => Visit(e));
                 }
                 else if (selectExpression.Alias == null)
@@ -640,6 +653,31 @@ public class CouchbaseQuerySqlGenerator : QuerySqlGenerator
         }
 
         return selectExpression;
+    }
+
+    /// <summary>
+    /// Renders a scalar subquery (e.g. <c>.Count()</c>/<c>.Sum()</c>/<c>.Max()</c> used in a
+    /// comparison) with a trailing <c>[0]</c> array-subscript. Confirmed via a live-cluster spike:
+    /// unlike ANSI SQL, N1QL's parenthesized-subquery-as-expression syntax always evaluates to an
+    /// ARRAY of the subquery's result rows, even for a single-row/single-column result -- e.g.
+    /// <c>(SELECT RAW COUNT(*) FROM t.public_likes AS p) = 3</c> silently never matches, comparing
+    /// <c>[3]</c> against <c>3</c>, while the identical query with a trailing <c>[0]</c> correctly
+    /// unwraps the one-element array to the bare scalar. <see cref="ExistsExpression"/> and
+    /// <see cref="InExpression"/>'s <c>Subquery</c> shape are unaffected -- N1QL gives
+    /// <c>EXISTS (...)</c>/<c>... IN (...)</c> their own dedicated boolean semantics that don't
+    /// go through this array-valued-expression path (both already render correctly without it).
+    /// </summary>
+    protected override Expression VisitScalarSubquery(ScalarSubqueryExpression scalarSubqueryExpression)
+    {
+        Sql.AppendLine("(");
+        using (Sql.Indent())
+        {
+            Visit(scalarSubqueryExpression.Subquery);
+        }
+
+        Sql.Append(")[0]");
+
+        return scalarSubqueryExpression;
     }
 
     protected override void GenerateExists(ExistsExpression existsExpression, bool negated)
@@ -879,6 +917,75 @@ public class CouchbaseQuerySqlGenerator : QuerySqlGenerator
         => expression is SqlBinaryExpression { OperatorType: ExpressionType.NotEqual } binary
            && ((binary.Left is ColumnExpression lc && lc.TableAlias == ownedAlias && lc.Name == columnName && binary.Right is SqlConstantExpression { Value: null })
                || (binary.Right is ColumnExpression rc && rc.TableAlias == ownedAlias && rc.Name == columnName && binary.Left is SqlConstantExpression { Value: null }));
+
+    /// <summary>
+    /// Dispatch point for provider-specific extension expression types (<see cref="ExpressionType.Extension"/>).
+    /// <see cref="CouchbaseUnnestExpression"/>, <see cref="CouchbaseUnnestValueExpression"/>, and
+    /// <see cref="CouchbaseArrayIndexExpression"/> are the only ones this provider introduces;
+    /// anything else falls through to the base dispatcher (which itself handles all of EF Core's
+    /// own stock extension node types -- <see cref="TableExpression"/>, <see cref="ColumnExpression"/>,
+    /// etc.).
+    /// </summary>
+    protected override Expression VisitExtension(Expression node)
+        => node switch
+        {
+            CouchbaseUnnestExpression unnestExpression => GenerateUnnest(unnestExpression),
+            CouchbaseUnnestValueExpression valueExpression => GenerateUnnestValue(valueExpression),
+            CouchbaseArrayIndexExpression arrayIndexExpression => GenerateArrayIndex(arrayIndexExpression),
+            _ => base.VisitExtension(node),
+        };
+
+    /// <summary>
+    /// Renders a bare reference to a <see cref="CouchbaseUnnestExpression"/>'s alias -- see that
+    /// expression type's remarks for why this, not a named <c>alias.value</c> column reference, is
+    /// the correct projection for N1QL's <c>FROM arrayExpr AS alias</c> (confirmed via a
+    /// live-cluster spike: the SQLite-style <c>alias.value</c> shape silently evaluates to MISSING
+    /// for every row and returns an empty result set, no error).
+    /// </summary>
+    private Expression GenerateUnnestValue(CouchbaseUnnestValueExpression valueExpression)
+    {
+        Sql.Append(Dependencies.SqlGenerationHelper.DelimitIdentifier(valueExpression.Alias));
+        return valueExpression;
+    }
+
+    /// <summary>
+    /// Renders <c>&lt;arrayExpr&gt; AS &lt;alias&gt;</c> as the sole FROM-clause term of the
+    /// wrapping <see cref="SelectExpression"/> that
+    /// <see cref="CouchbaseQueryableMethodTranslatingExpressionVisitor.TranslatePrimitiveCollection"/>
+    /// built for a scalar primitive-collection property. Deliberately omits the literal <c>UNNEST</c>
+    /// keyword: confirmed via a live-cluster spike that this Couchbase Server version rejects
+    /// <c>UNNEST</c> as the primary/sole FROM-term ("UNNEST (reserved word)") -- it's only valid as a
+    /// secondary/join-like term following a real keyspace-ref. A bare correlated array expression as
+    /// the primary FROM-term (no <c>UNNEST</c> keyword at all) is confirmed to work correctly,
+    /// including inside a correlated subquery, which is the only shape
+    /// <see cref="CouchbaseUnnestExpression"/> is ever used in. No positional/ordinal alias either --
+    /// see that method's remarks for why (this Couchbase Server version also rejects
+    /// <c>UNNEST ... AT alias</c>).
+    /// </summary>
+    private Expression GenerateUnnest(CouchbaseUnnestExpression unnestExpression)
+    {
+        var helper = Dependencies.SqlGenerationHelper;
+
+        Visit(unnestExpression.ArrayExpression);
+        Sql.Append(" AS ").Append(helper.DelimitIdentifier(unnestExpression.Alias!));
+
+        return unnestExpression;
+    }
+
+    /// <summary>
+    /// Renders N1QL's native array-subscript syntax (<c>arrayExpr[indexExpr]</c>), built by
+    /// <see cref="CouchbaseQueryableMethodTranslatingExpressionVisitor.TranslateElementAtOrDefault"/>
+    /// for <c>.ElementAt(i)</c>/indexer access over a scalar primitive-collection property.
+    /// </summary>
+    private Expression GenerateArrayIndex(CouchbaseArrayIndexExpression arrayIndexExpression)
+    {
+        Visit(arrayIndexExpression.Array);
+        Sql.Append("[");
+        Visit(arrayIndexExpression.Index);
+        Sql.Append("]");
+
+        return arrayIndexExpression;
+    }
 
     protected override Expression VisitTable(TableExpression tableExpression)
     {
@@ -1120,14 +1227,23 @@ public class CouchbaseQuerySqlGenerator : QuerySqlGenerator
     protected override void GenerateIn(InExpression inExpression, bool negated)
     {
         Visit(inExpression.Item);
-        Sql.Append(negated ? " NOT IN [" : " IN [");
 
+        // N1QL's array-literal IN syntax (`x IN [1, 2, 3]`) only applies to a flat Values list --
+        // a Subquery-shaped InExpression (e.g. `.Contains()` over a queryable source, including
+        // this provider's own UNNEST-backed primitive collections) is a real correlated/uncorrelated
+        // SELECT and must use standard parenthesized subquery-IN syntax instead. Confirmed
+        // pre-existing: `InExpression.Values`/`.Subquery` are mutually-exclusive alternate shapes of
+        // the same node type, and this method previously always bracketed both the same way --
+        // harmless as long as nothing produced the Subquery shape, until primitive collections did.
         if (inExpression.Values is not null)
         {
+            Sql.Append(negated ? " NOT IN [" : " IN [");
             GenerateList(inExpression.Values, e => Visit(e));
+            Sql.Append("]");
         }
         else
         {
+            Sql.Append(negated ? " NOT IN (" : " IN (");
             Sql.AppendLine();
 
             using (Sql.Indent())
@@ -1136,9 +1252,8 @@ public class CouchbaseQuerySqlGenerator : QuerySqlGenerator
             }
 
             Sql.AppendLine();
+            Sql.Append(")");
         }
-
-        Sql.Append("]");
     }
 
     private void GenerateList<T>(

--- a/src/Couchbase.EntityFrameworkCore/Query/Internal/CouchbaseQueryableMethodTranslatingExpressionVisitor.cs
+++ b/src/Couchbase.EntityFrameworkCore/Query/Internal/CouchbaseQueryableMethodTranslatingExpressionVisitor.cs
@@ -1,25 +1,163 @@
+using System.Linq.Expressions;
+using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Query;
+using Microsoft.EntityFrameworkCore.Query.SqlExpressions;
+using Microsoft.EntityFrameworkCore.Storage;
 
 namespace Couchbase.EntityFrameworkCore.Query.Internal;
 
 public class CouchbaseQueryableMethodTranslatingExpressionVisitor : RelationalQueryableMethodTranslatingExpressionVisitor
 {
+    private readonly IRelationalTypeMappingSource _typeMappingSource;
+    private readonly SqlAliasManager _sqlAliasManager;
+
     public CouchbaseQueryableMethodTranslatingExpressionVisitor(
         QueryableMethodTranslatingExpressionVisitorDependencies dependencies,
         RelationalQueryableMethodTranslatingExpressionVisitorDependencies relationalDependencies,
         RelationalQueryCompilationContext queryCompilationContext)
         : base(dependencies, relationalDependencies, queryCompilationContext)
     {
+        _typeMappingSource = relationalDependencies.TypeMappingSource;
+        _sqlAliasManager = queryCompilationContext.SqlAliasManager;
     }
 
     protected CouchbaseQueryableMethodTranslatingExpressionVisitor(
         CouchbaseQueryableMethodTranslatingExpressionVisitor parentVisitor)
         : base(parentVisitor)
     {
+        _typeMappingSource = parentVisitor._typeMappingSource;
+        _sqlAliasManager = parentVisitor._sqlAliasManager;
     }
 
     protected override QueryableMethodTranslatingExpressionVisitor CreateSubqueryVisitor()
         => new CouchbaseQueryableMethodTranslatingExpressionVisitor(this);
+
+    /// <summary>
+    /// Expands a scalar "primitive collection" property (e.g. <c>List&lt;string&gt; Tags</c>
+    /// mapped directly to a JSON array field, not via <c>OwnsMany</c>) into a queryable rowset,
+    /// modeled on SQLite's <c>TranslatePrimitiveCollection</c> (<c>json_each</c>-based)
+    /// implementation but rendering as a bare correlated <c>FROM arrayExpr AS alias</c> term (no
+    /// literal <c>UNNEST</c> keyword) -- see <see cref="CouchbaseUnnestExpression"/>'s remarks for
+    /// why. Once this returns a well-formed <see cref="ShapedQueryExpression"/>, every
+    /// order-independent LINQ collection operator (.Where/.Count/.Contains/.Any/...) composes on
+    /// top of it for free via EF Core's own generic, provider-agnostic machinery.
+    /// </summary>
+    /// <remarks>
+    /// Unlike SQLite/SqlServer, this carries no positional/ordinal column -- a live-cluster spike
+    /// confirmed this Couchbase Server version rejects <c>UNNEST ... AT alias</c> syntax entirely,
+    /// so there's no way to get a deterministic array position out of the unnest rowset itself.
+    /// Element indexing is instead handled entirely by <see cref="TranslateElementAtOrDefault"/>
+    /// below, rendering N1QL's native array-subscript syntax directly rather than relying on the
+    /// base class's generic Skip+Limit-over-an-ordered-rowset approach (which requires exactly the
+    /// ordinal column this provider cannot produce).
+    /// </remarks>
+    protected override ShapedQueryExpression? TranslatePrimitiveCollection(
+        SqlExpression sqlExpression,
+        IProperty? property,
+        string tableAlias)
+    {
+        // Parameter-rooted primitive collections (no mapped IProperty, e.g. a local List<T>
+        // captured in a closure) are explicitly out of scope for v1 -- see the plan's scope notes.
+        if (property?.GetElementType() is not { } elementType)
+        {
+            return null;
+        }
+
+        var elementClrType = elementType.ClrType;
+        var elementTypeMapping = (RelationalTypeMapping?)sqlExpression.TypeMapping?.ElementTypeMapping
+            ?? _typeMappingSource.FindMapping(elementClrType);
+
+        var unnestExpression = new CouchbaseUnnestExpression(tableAlias, sqlExpression);
+        var valueExpression = new CouchbaseUnnestValueExpression(
+            tableAlias, elementType.IsNullable, elementClrType.UnwrapNullableType(), elementTypeMapping);
+
+#pragma warning disable EF1001 // SelectExpression's (tables, projection, identifier, aliasManager) constructor is an internal API.
+        var selectExpression = new SelectExpression(
+            [unnestExpression],
+            valueExpression,
+            identifier: [],
+            _sqlAliasManager);
+#pragma warning restore EF1001
+
+        Expression shaperExpression = new ProjectionBindingExpression(
+            selectExpression, new ProjectionMember(), elementClrType.MakeNullable());
+
+        if (elementClrType != shaperExpression.Type)
+        {
+            shaperExpression = Expression.Convert(shaperExpression, elementClrType);
+        }
+
+        return new ShapedQueryExpression(selectExpression, shaperExpression);
+    }
+
+    /// <summary>
+    /// Renders N1QL's native <c>arrayExpr[indexExpr]</c> subscript directly, rather than the base
+    /// class's generic OFFSET/LIMIT-over-an-ordered-rowset approach -- see the remarks on
+    /// <see cref="TranslatePrimitiveCollection"/> for why that approach isn't available here.
+    /// Only handles the exact, untouched shape <see cref="TranslatePrimitiveCollection"/> itself
+    /// produces (a bare <see cref="CouchbaseUnnestExpression"/>, no predicate/ordering/offset/limit
+    /// applied yet) -- anything else (e.g. <c>.Where(...).ElementAt(i)</c>,
+    /// <c>.OrderBy(...).ElementAt(i)</c>) returns <see langword="null"/>, which surfaces as EF
+    /// Core's standard "could not be translated" exception rather than silently producing an
+    /// incorrect result for a composition this provider cannot express correctly.
+    /// </summary>
+    protected override ShapedQueryExpression? TranslateElementAtOrDefault(
+        ShapedQueryExpression source, Expression index, bool returnDefault)
+    {
+        if (source.QueryExpression is not SelectExpression
+            {
+                Tables: [CouchbaseUnnestExpression unnestExpression],
+                Predicate: null,
+                Orderings: [],
+                Offset: null,
+                Limit: null,
+                IsDistinct: false,
+            } selectExpression)
+        {
+            return null;
+        }
+
+        // The SelectExpression built by TranslatePrimitiveCollection uses the single-scalar-
+        // projection constructor, which stores the projection via the projection-mapping
+        // dictionary (read back through GetProjection), not the finalized Projection list --
+        // that list only populates once ApplyProjection() runs, later in the pipeline.
+        var sourceShaperExpression = source.ShaperExpression;
+        if (sourceShaperExpression is UnaryExpression { NodeType: ExpressionType.Convert } unary)
+        {
+            sourceShaperExpression = unary.Operand;
+        }
+
+        if (sourceShaperExpression is not ProjectionBindingExpression projectionBindingExpression)
+        {
+            return null;
+        }
+
+        var translatedIndex = TranslateExpression(index);
+        if (translatedIndex == null)
+        {
+            return null;
+        }
+
+        var valueProjection = (SqlExpression)selectExpression.GetProjection(projectionBindingExpression);
+        var arrayIndexExpression = new CouchbaseArrayIndexExpression(
+            unnestExpression.ArrayExpression, translatedIndex, valueProjection.Type, valueProjection.TypeMapping);
+
+#pragma warning disable EF1001 // SelectExpression(projection, aliasManager) constructor is an internal API.
+        var scalarSelectExpression = new SelectExpression(arrayIndexExpression, _sqlAliasManager);
+#pragma warning restore EF1001
+
+        var resultShaperExpression = new ProjectionBindingExpression(
+            scalarSelectExpression, new ProjectionMember(), valueProjection.Type.MakeNullable());
+
+        // Must be non-Enumerable for RelationalSqlTranslatingExpressionVisitor.VisitExtension's
+        // ShapedQueryExpression case to fold this into a scalar subquery -- the 2-arg
+        // ShapedQueryExpression constructor defaults to Enumerable, which that fold explicitly
+        // excludes (it's meant for genuine collection-returning subqueries, not `.ElementAt()`'s
+        // single-value result). The 3-arg (queryExpression, shaperExpression, cardinality)
+        // constructor is private; UpdateResultCardinality is the public way to set it.
+        return new ShapedQueryExpression(scalarSelectExpression, resultShaperExpression)
+            .UpdateResultCardinality(ResultCardinality.SingleOrDefault);
+    }
 }
 
 /* ************************************************************

--- a/src/Couchbase.EntityFrameworkCore/Query/Internal/CouchbaseSqlNullabilityProcessor.cs
+++ b/src/Couchbase.EntityFrameworkCore/Query/Internal/CouchbaseSqlNullabilityProcessor.cs
@@ -1,0 +1,51 @@
+using Microsoft.EntityFrameworkCore.Query;
+using Microsoft.EntityFrameworkCore.Query.SqlExpressions;
+
+namespace Couchbase.EntityFrameworkCore.Query.Internal;
+
+/// <summary>
+/// Extends the base nullability processor to handle <see cref="CouchbaseArrayIndexExpression"/> --
+/// the base <see cref="SqlNullabilityProcessor"/> throws "Unhandled expression" for any custom
+/// <see cref="SqlExpression"/> subtype it doesn't recognize (confirmed: this is the exact wall
+/// SQLite's own <c>GlobExpression</c>/<c>RegexpExpression</c> hit, solved via the same
+/// <c>VisitCustomSqlExpression</c> override this class copies).
+/// </summary>
+public class CouchbaseSqlNullabilityProcessor : SqlNullabilityProcessor
+{
+    public CouchbaseSqlNullabilityProcessor(
+        RelationalParameterBasedSqlProcessorDependencies dependencies,
+        RelationalParameterBasedSqlProcessorParameters parameters)
+        : base(dependencies, parameters)
+    {
+    }
+
+    protected override SqlExpression VisitCustomSqlExpression(
+        SqlExpression sqlExpression, bool allowOptimizedExpansion, out bool nullable)
+        => sqlExpression switch
+        {
+            CouchbaseArrayIndexExpression arrayIndexExpression
+                => VisitArrayIndex(arrayIndexExpression, allowOptimizedExpansion, out nullable),
+            CouchbaseUnnestValueExpression valueExpression
+                => VisitUnnestValue(valueExpression, out nullable),
+            _ => base.VisitCustomSqlExpression(sqlExpression, allowOptimizedExpansion, out nullable)
+        };
+
+    protected virtual SqlExpression VisitUnnestValue(CouchbaseUnnestValueExpression valueExpression, out bool nullable)
+    {
+        nullable = valueExpression.IsNullable;
+        return valueExpression;
+    }
+
+    protected virtual SqlExpression VisitArrayIndex(
+        CouchbaseArrayIndexExpression arrayIndexExpression, bool allowOptimizedExpansion, out bool nullable)
+    {
+        var array = Visit(arrayIndexExpression.Array, out _);
+        var index = Visit(arrayIndexExpression.Index, out _);
+
+        // N1QL returns MISSING (falsy) for an out-of-range/negative subscript rather than
+        // erroring, so this is always potentially null regardless of its operands' nullability.
+        nullable = true;
+
+        return arrayIndexExpression.Update(array, index);
+    }
+}

--- a/src/Couchbase.EntityFrameworkCore/Query/Internal/CouchbaseUnnestExpression.cs
+++ b/src/Couchbase.EntityFrameworkCore/Query/Internal/CouchbaseUnnestExpression.cs
@@ -1,0 +1,108 @@
+using System.Linq.Expressions;
+using System.Reflection;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Query;
+using Microsoft.EntityFrameworkCore.Query.SqlExpressions;
+
+namespace Couchbase.EntityFrameworkCore.Query.Internal;
+
+/// <summary>
+/// An expression that represents N1QL's <c>UNNEST</c> clause in a SQL tree, used to expand a
+/// JSON array (a scalar "primitive collection" property, e.g. <c>List&lt;string&gt;</c>) into a
+/// virtual rowset of one row per array element -- Couchbase's equivalent of SQL Server's
+/// <c>OPENJSON</c>/SQLite's <c>json_each</c>. Modeled directly on
+/// <see href="https://github.com/dotnet/efcore/blob/main/src/EFCore.Sqlite.Core/Query/Internal/SqlExpressions/JsonEachExpression.cs">
+/// JsonEachExpression</see>.
+/// </summary>
+/// <remarks>
+/// Unlike <c>json_each(...)</c>/<c>OPENJSON(...)</c> (self-contained, callable table-valued
+/// functions), N1QL's <c>UNNEST</c> is a clause, not a function -- it has no parentheses.
+/// Extends <see cref="TableExpressionBase"/> directly rather than
+/// <see cref="TableValuedFunctionExpression"/> for that reason.
+/// <para>
+/// Carries no positional/ordinal alias -- confirmed empirically that this Couchbase Server
+/// version rejects <c>UNNEST ... AT alias</c> as a syntax error ("AT (reserved word)") in every
+/// position tried. Element indexing (<c>.ElementAt(i)</c>/<c>arr[i]</c>) is therefore NOT
+/// implemented via Skip+Limit over an ordered unnest rowset (the SqlServer/SQLite pattern) --
+/// instead <see cref="CouchbaseQueryableMethodTranslatingExpressionVisitor"/> overrides
+/// <c>TranslateElementAtOrDefault</c> to render N1QL's native <c>arr[index]</c> subscript
+/// directly via <see cref="CouchbaseArrayIndexExpression"/>. This expression type is used only
+/// for the order-independent operators (<c>.Contains()</c>/<c>.Any(predicate)</c>/<c>.Count()</c>/
+/// <c>.Where()</c>), which don't need positional information at all.
+/// </para>
+/// </remarks>
+public class CouchbaseUnnestExpression : TableExpressionBase
+{
+    /// <summary>The array-valued expression being unnested (typically a <see cref="ColumnExpression"/>).</summary>
+    public virtual SqlExpression ArrayExpression { get; }
+
+    public CouchbaseUnnestExpression(string alias, SqlExpression arrayExpression)
+        : base(alias)
+    {
+        ArrayExpression = arrayExpression;
+    }
+
+    private CouchbaseUnnestExpression(
+        string alias, SqlExpression arrayExpression, IReadOnlyDictionary<string, IAnnotation>? annotations)
+        : base(alias, annotations)
+    {
+        ArrayExpression = arrayExpression;
+    }
+
+    protected override Expression VisitChildren(ExpressionVisitor visitor)
+    {
+        var visitedArrayExpression = (SqlExpression)visitor.Visit(ArrayExpression);
+        return Update(visitedArrayExpression);
+    }
+
+    public virtual CouchbaseUnnestExpression Update(SqlExpression arrayExpression)
+        => arrayExpression == ArrayExpression
+            ? this
+            : new CouchbaseUnnestExpression(Alias!, arrayExpression);
+
+    public override TableExpressionBase Clone(string? alias, ExpressionVisitor cloningExpressionVisitor)
+    {
+        var newArrayExpression = (SqlExpression)cloningExpressionVisitor.Visit(ArrayExpression);
+        var clone = new CouchbaseUnnestExpression(alias!, newArrayExpression);
+
+        foreach (var annotation in GetAnnotations())
+        {
+            clone.AddAnnotation(annotation.Name, annotation.Value);
+        }
+
+        return clone;
+    }
+
+    public override CouchbaseUnnestExpression WithAlias(string newAlias)
+        => new(newAlias, ArrayExpression);
+
+    protected override TableExpressionBase WithAnnotations(IReadOnlyDictionary<string, IAnnotation> annotations)
+        => new CouchbaseUnnestExpression(Alias!, ArrayExpression, annotations);
+
+    private static ConstructorInfo? _quotingConstructor;
+
+    public override Expression Quote()
+        => Expression.New(
+            _quotingConstructor ??= typeof(CouchbaseUnnestExpression).GetConstructor(
+                [typeof(string), typeof(SqlExpression)])!,
+            Expression.Constant(Alias, typeof(string)),
+            ArrayExpression.Quote());
+
+    protected override void Print(ExpressionPrinter expressionPrinter)
+    {
+        // No "UNNEST " prefix -- matches CouchbaseQuerySqlGenerator.GenerateUnnest, which
+        // deliberately omits the keyword (see the remarks above and on that method for why).
+        expressionPrinter.Visit(ArrayExpression);
+        expressionPrinter.Append(" AS ").Append(Alias!);
+        PrintAnnotations(expressionPrinter);
+    }
+
+    public override bool Equals(object? obj)
+        => ReferenceEquals(this, obj) || (obj is CouchbaseUnnestExpression other && Equals(other));
+
+    private bool Equals(CouchbaseUnnestExpression other)
+        => base.Equals(other) && ArrayExpression.Equals(other.ArrayExpression);
+
+    public override int GetHashCode()
+        => HashCode.Combine(base.GetHashCode(), ArrayExpression);
+}

--- a/src/Couchbase.EntityFrameworkCore/Query/Internal/CouchbaseUnnestValueExpression.cs
+++ b/src/Couchbase.EntityFrameworkCore/Query/Internal/CouchbaseUnnestValueExpression.cs
@@ -1,0 +1,64 @@
+using System.Linq.Expressions;
+using System.Reflection;
+using Microsoft.EntityFrameworkCore.Query;
+using Microsoft.EntityFrameworkCore.Query.SqlExpressions;
+using Microsoft.EntityFrameworkCore.Storage;
+
+namespace Couchbase.EntityFrameworkCore.Query.Internal;
+
+/// <summary>
+/// Represents a reference to the element value itself produced by a
+/// <see cref="CouchbaseUnnestExpression"/>'s alias (e.g. the <c>p</c> in
+/// <c>FROM t.public_likes AS p</c>) -- used as the sole projection of the
+/// <see cref="SelectExpression"/> <see cref="CouchbaseQueryableMethodTranslatingExpressionVisitor.TranslatePrimitiveCollection"/>
+/// builds for a scalar primitive-collection property.
+/// </summary>
+/// <remarks>
+/// Unlike SQLite's <c>json_each</c> (a table-valued function whose output rows have real
+/// named columns -- <c>key</c>, <c>value</c>, <c>type</c>, etc. -- so a plain
+/// <see cref="ColumnExpression"/> named <c>"value"</c> is the correct projection there),
+/// N1QL's bare <c>FROM arrayExpr AS alias</c> binds <c>alias</c> directly to each array
+/// ELEMENT, not to a wrapper row-object with a <c>.value</c> field. Confirmed via a live-cluster
+/// spike: projecting/filtering on <c>alias.value</c> silently evaluates to MISSING for every row
+/// (since a scalar element like a string has no such field), producing an empty result set with
+/// no error -- the correct reference is the bare alias itself.
+/// </remarks>
+public class CouchbaseUnnestValueExpression : SqlExpression
+{
+    private static ConstructorInfo? _quotingConstructor;
+
+    public virtual string Alias { get; }
+    public virtual bool IsNullable { get; }
+
+    public CouchbaseUnnestValueExpression(string alias, bool isNullable, Type type, RelationalTypeMapping? typeMapping)
+        : base(type, typeMapping)
+    {
+        Alias = alias;
+        IsNullable = isNullable;
+    }
+
+    protected override Expression VisitChildren(ExpressionVisitor visitor) => this;
+
+#pragma warning disable EF9100 // RelationalExpressionQuotingUtilities is evaluation-purposes-only -- matches the same pattern EF Core's own SqlExpression subclasses (e.g. SqlUnaryExpression) use internally for this exact purpose.
+    public override Expression Quote()
+        => Expression.New(
+            _quotingConstructor ??= typeof(CouchbaseUnnestValueExpression).GetConstructor(
+                [typeof(string), typeof(bool), typeof(Type), typeof(RelationalTypeMapping)])!,
+            Expression.Constant(Alias, typeof(string)),
+            Expression.Constant(IsNullable),
+            Expression.Constant(Type),
+            RelationalExpressionQuotingUtilities.QuoteTypeMapping(TypeMapping));
+#pragma warning restore EF9100
+
+    protected override void Print(ExpressionPrinter expressionPrinter)
+        => expressionPrinter.Append(Alias);
+
+    public override bool Equals(object? obj)
+        => ReferenceEquals(this, obj) || (obj is CouchbaseUnnestValueExpression other && Equals(other));
+
+    private bool Equals(CouchbaseUnnestValueExpression other)
+        => base.Equals(other) && Alias == other.Alias && IsNullable == other.IsNullable;
+
+    public override int GetHashCode()
+        => HashCode.Combine(base.GetHashCode(), Alias, IsNullable);
+}

--- a/src/Couchbase.EntityFrameworkCore/Storage/Internal/CouchbaseDatabaseWrapper.cs
+++ b/src/Couchbase.EntityFrameworkCore/Storage/Internal/CouchbaseDatabaseWrapper.cs
@@ -502,7 +502,22 @@ public class CouchbaseDatabaseWrapper : Database
     /// </summary>
     private static object? ApplyConverter(IProperty property, object? rawValue)
     {
-        var converter = property.GetValueConverter() ?? property.FindTypeMapping()?.Converter;
+        var explicitConverter = property.GetValueConverter();
+        if (explicitConverter is null && property.GetElementType() is not null)
+        {
+            // Scalar "primitive collection" properties (List<T>/T[], not OwnsMany) get an
+            // automatic CollectionToJsonStringConverter from EF Core's type-mapping source
+            // unless a provider declares native array storage support -- correct for a
+            // relational text column, but Couchbase documents are already JSON, so applying it
+            // here would double-encode the array as a quoted JSON string instead of a native
+            // array field. Skip it and let the raw CLR collection flow through to the
+            // document's own JSON serialization, which already writes it as a real array (see
+            // CouchbaseArrayIndexExpression/TranslatePrimitiveCollection, which assume exactly
+            // this on the read side).
+            return rawValue;
+        }
+
+        var converter = explicitConverter ?? property.FindTypeMapping()?.Converter;
         // Always call the converter if one is present, even for null rawValue, because a
         // converter with ConvertsNulls=true may map null to a non-null provider value.
         return converter is not null && (rawValue is not null || converter.ConvertsNulls)

--- a/tests/Couchbase.EntityFrameworkCore.IntegrationTests/Models/TravelSampleDbContext.cs
+++ b/tests/Couchbase.EntityFrameworkCore.IntegrationTests/Models/TravelSampleDbContext.cs
@@ -34,6 +34,14 @@ public class TravelSampleDbContext(DbContextOptions<TravelSampleDbContext> optio
         // overrides those flat-column reads with the nested JSON when present.
         modelBuilder.Entity<TravelSampleFixture.Hotel>().OwnsOne(h => h.Geo);
 
+        // PublicLikes is a scalar primitive collection (List<string>, not OwnsMany) -- its
+        // [JsonPropertyName("public_likes")] attribute is currently NOT honored for primitive-
+        // collection properties (a separate, pre-existing bug: JsonPropertyNameConvention's
+        // HasColumnName gets overwritten by something in the primitive-collection discovery path,
+        // confirmed empirically -- the generated column name comes out "publicLikes", not
+        // "public_likes"). Set the column name explicitly via fluent API until that's fixed.
+        modelBuilder.Entity<TravelSampleFixture.Hotel>().Property(h => h.PublicLikes).HasColumnName("public_likes");
+
         // Configure Couchbase mappings
         modelBuilder.ConfigureToCouchbase(this, true);
         modelBuilder.Entity<TravelSampleFixture.DestinationAirport>().ToCouchbaseCollection(this, "destinationairport");

--- a/tests/Couchbase.EntityFrameworkCore.IntegrationTests/Tests/CrudTests.cs
+++ b/tests/Couchbase.EntityFrameworkCore.IntegrationTests/Tests/CrudTests.cs
@@ -810,4 +810,174 @@ public class CrudTests(
             Assert.Null(deletedHotel);
         }
     }
+
+    // -------------------------------------------------------------------------
+    // PublicLikes -- a scalar "primitive collection" property (List<string>, not OwnsMany) mapped
+    // directly to a JSON array field. TranslatePrimitiveCollection expands it into a rowset via
+    // N1QL's UNNEST ... AS value for .Count/.Contains/.Any, while indexer/.ElementAt() render N1QL's
+    // native arr[i] subscript directly (TranslateElementAtOrDefault) -- this Couchbase Server version
+    // doesn't support UNNEST's AT-alias positional binding, so there's no ordered-rowset indexing
+    // fallback available. These exercise real query EXECUTION against a live cluster, not just
+    // generated-SQL-text assertions -- the actual point, since the whole feature is about a
+    // previously-untranslatable LINQ shape.
+    // -------------------------------------------------------------------------
+
+    [Fact]
+    public async Task Hotel_PublicLikes_Indexer_ReturnsMatchingHotel()
+    {
+        const int id = 999999002;
+        try
+        {
+            await using (var writeCtx = travelSampleFixture.GetDbContext())
+            {
+                writeCtx.Update(new TravelSampleFixture.Hotel
+                {
+                    Id = id,
+                    Type = "hotel",
+                    Title = "Indexer Test Hotel",
+                    Name = "Indexer Test Hotel",
+                    PublicLikes = ["Alice", "Bob", "Carol"],
+                });
+                await writeCtx.SaveChangesAsync();
+            }
+
+            await using var readCtx = travelSampleFixture.GetDbContext();
+            var match = await readCtx.Hotels.Where(h => h.PublicLikes![0] == "Alice").ToListAsync();
+            Assert.Contains(match, h => h.Id == id);
+
+            var noMatch = await readCtx.Hotels.Where(h => h.PublicLikes![0] == "Bob").ToListAsync();
+            Assert.DoesNotContain(noMatch, h => h.Id == id);
+        }
+        finally
+        {
+            await using var cleanupCtx = travelSampleFixture.GetDbContext();
+            var toRemove = await cleanupCtx.Hotels.SingleOrDefaultAsync(h => h.Id == id);
+            if (toRemove != null)
+            {
+                cleanupCtx.Remove(toRemove);
+                await cleanupCtx.SaveChangesAsync();
+            }
+        }
+    }
+
+    [Fact]
+    public async Task Hotel_PublicLikes_Contains_ReturnsMatchingHotel()
+    {
+        const int id = 999999003;
+        try
+        {
+            await using (var writeCtx = travelSampleFixture.GetDbContext())
+            {
+                writeCtx.Update(new TravelSampleFixture.Hotel
+                {
+                    Id = id,
+                    Type = "hotel",
+                    Title = "Contains Test Hotel",
+                    Name = "Contains Test Hotel",
+                    PublicLikes = ["Alice", "Bob", "Carol"],
+                });
+                await writeCtx.SaveChangesAsync();
+            }
+
+            await using var readCtx = travelSampleFixture.GetDbContext();
+            var match = await readCtx.Hotels.Where(h => h.PublicLikes!.Contains("Bob")).ToListAsync();
+            Assert.Contains(match, h => h.Id == id);
+
+            var noMatch = await readCtx.Hotels.Where(h => h.PublicLikes!.Contains("Nobody")).ToListAsync();
+            Assert.DoesNotContain(noMatch, h => h.Id == id);
+        }
+        finally
+        {
+            await using var cleanupCtx = travelSampleFixture.GetDbContext();
+            var toRemove = await cleanupCtx.Hotels.SingleOrDefaultAsync(h => h.Id == id);
+            if (toRemove != null)
+            {
+                cleanupCtx.Remove(toRemove);
+                await cleanupCtx.SaveChangesAsync();
+            }
+        }
+    }
+
+    [Fact]
+    public async Task Hotel_PublicLikes_CountAndAnyPredicate_MatchExpectedHotels()
+    {
+        const int id = 999999004;
+        try
+        {
+            await using (var writeCtx = travelSampleFixture.GetDbContext())
+            {
+                writeCtx.Update(new TravelSampleFixture.Hotel
+                {
+                    Id = id,
+                    Type = "hotel",
+                    Title = "Count Test Hotel",
+                    Name = "Count Test Hotel",
+                    PublicLikes = ["Alice", "Bob", "Carol"],
+                });
+                await writeCtx.SaveChangesAsync();
+            }
+
+            await using var readCtx = travelSampleFixture.GetDbContext();
+
+            var countMatch = await readCtx.Hotels.Where(h => h.PublicLikes!.Count == 3).ToListAsync();
+            Assert.Contains(countMatch, h => h.Id == id);
+
+            var countNoMatch = await readCtx.Hotels.Where(h => h.PublicLikes!.Count > 10).ToListAsync();
+            Assert.DoesNotContain(countNoMatch, h => h.Id == id);
+
+            var anyMatch = await readCtx.Hotels.Where(h => h.PublicLikes!.Any(n => n.StartsWith("Car"))).ToListAsync();
+            Assert.Contains(anyMatch, h => h.Id == id);
+
+            var anyNoMatch = await readCtx.Hotels.Where(h => h.PublicLikes!.Any(n => n == "Nobody")).ToListAsync();
+            Assert.DoesNotContain(anyNoMatch, h => h.Id == id);
+        }
+        finally
+        {
+            await using var cleanupCtx = travelSampleFixture.GetDbContext();
+            var toRemove = await cleanupCtx.Hotels.SingleOrDefaultAsync(h => h.Id == id);
+            if (toRemove != null)
+            {
+                cleanupCtx.Remove(toRemove);
+                await cleanupCtx.SaveChangesAsync();
+            }
+        }
+    }
+
+    [Fact]
+    public async Task Hotel_PublicLikes_AbsentField_ExcludedNotError()
+    {
+        // A hotel written without PublicLikes at all (genuinely MISSING, not an empty array) must
+        // be excluded from queries over the collection, not error -- mirrors N1QL's general
+        // MISSING-is-falsy semantics this provider already leans on elsewhere.
+        const int id = 999999005;
+        try
+        {
+            await using (var writeCtx = travelSampleFixture.GetDbContext())
+            {
+                writeCtx.Update(new TravelSampleFixture.Hotel
+                {
+                    Id = id,
+                    Type = "hotel",
+                    Title = "No Likes Test Hotel",
+                    Name = "No Likes Test Hotel",
+                    PublicLikes = null,
+                });
+                await writeCtx.SaveChangesAsync();
+            }
+
+            await using var readCtx = travelSampleFixture.GetDbContext();
+            var results = await readCtx.Hotels.Where(h => h.PublicLikes!.Contains("Anyone")).ToListAsync();
+            Assert.DoesNotContain(results, h => h.Id == id);
+        }
+        finally
+        {
+            await using var cleanupCtx = travelSampleFixture.GetDbContext();
+            var toRemove = await cleanupCtx.Hotels.SingleOrDefaultAsync(h => h.Id == id);
+            if (toRemove != null)
+            {
+                cleanupCtx.Remove(toRemove);
+                await cleanupCtx.SaveChangesAsync();
+            }
+        }
+    }
 }

--- a/tests/Couchbase.EntityFrameworkCore.UnitTests/Couchbase/EntityFrameworkCore/Query/PrimitiveCollectionTests.cs
+++ b/tests/Couchbase.EntityFrameworkCore.UnitTests/Couchbase/EntityFrameworkCore/Query/PrimitiveCollectionTests.cs
@@ -1,0 +1,124 @@
+using Couchbase.EntityFrameworkCore.Extensions;
+using Microsoft.EntityFrameworkCore;
+using Xunit;
+
+namespace Couchbase.EntityFrameworkCore.UnitTests.Couchbase.EntityFrameworkCore.Query;
+
+/// <summary>
+/// Verifies LINQ query support for a scalar "primitive collection" property (a plain
+/// <c>List&lt;T&gt;</c>/<c>T[]</c> mapped directly to a JSON array field, not via <c>OwnsMany</c>).
+/// This provider implements two hooks: <c>TranslatePrimitiveCollection</c>, expanding the array
+/// into a rowset via a bare correlated <c>&lt;arrayExpr&gt; AS value</c> FROM-term (no literal
+/// <c>UNNEST</c> keyword -- this Couchbase Server version rejects it as a primary/sole FROM-term)
+/// (<see cref="Couchbase.EntityFrameworkCore.Query.Internal.CouchbaseUnnestExpression"/>) for
+/// order-independent operators (.Where/.Count/.Contains/.Any), and
+/// <c>TranslateElementAtOrDefault</c>, rendering N1QL's native <c>arr[i]</c> subscript directly
+/// (<see cref="Couchbase.EntityFrameworkCore.Query.Internal.CouchbaseArrayIndexExpression"/>) for
+/// indexer/<c>.ElementAt()</c> access -- this Couchbase Server version also rejects <c>AT pos</c>
+/// positional-binding syntax entirely, so there's no ordered-rowset fallback available for
+/// indexing, unlike SQLite/SqlServer.
+/// </summary>
+public class PrimitiveCollectionTests
+{
+    private class Post
+    {
+        public int PostId { get; set; }
+        public List<string> Tags { get; set; } = [];
+    }
+
+    private class PostContext(DbContextOptions<PostContext> options) : DbContext(options)
+    {
+        public DbSet<Post> Posts { get; set; } = null!;
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            modelBuilder.Entity<Post>(b =>
+            {
+                b.ToCouchbaseCollection("bucket", "scope", "post");
+                b.HasKey(p => p.PostId);
+            });
+        }
+    }
+
+    private static PostContext CreateContext()
+    {
+        var clusterOptions = new ClusterOptions()
+            .WithConnectionString("couchbase://localhost")
+            .WithPasswordAuthentication("Administrator", "password");
+        var builder = new DbContextOptionsBuilder<PostContext>();
+        builder.UseCouchbaseProvider(clusterOptions);
+        return new PostContext(builder.Options);
+    }
+
+    [Fact]
+    public void Indexer_TranslatesToNativeArraySubscript()
+    {
+        using var ctx = CreateContext();
+        var sql = ctx.Posts.Where(p => p.Tags[0] == "x").ToQueryString();
+
+        Assert.Contains("`b`.`Tags`[0] = 'x'", sql);
+    }
+
+    [Fact]
+    public void ElementAt_WithNonZeroIndex_UsesThatSubscript()
+    {
+        using var ctx = CreateContext();
+        var sql = ctx.Posts.Where(p => p.Tags.ElementAt(3) == "x").ToQueryString();
+
+        Assert.Contains("`b`.`Tags`[3] = 'x'", sql);
+    }
+
+    [Fact]
+    public void Contains_TranslatesToSubqueryIn_NotArrayLiteralBrackets()
+    {
+        using var ctx = CreateContext();
+        var sql = ctx.Posts.Where(p => p.Tags.Contains("x")).ToQueryString();
+
+        Assert.Contains("'x' IN (", sql);
+        Assert.Contains("FROM `b`.`Tags` AS `t`", sql);
+        // The subquery-IN shape must use parens, not this provider's array-literal IN brackets.
+        Assert.DoesNotContain("IN [", sql);
+    }
+
+    [Fact]
+    public void Count_TranslatesToCountSubquery()
+    {
+        using var ctx = CreateContext();
+        var sql = ctx.Posts.Where(p => p.Tags.Count > 1).ToQueryString();
+
+        Assert.Contains("SELECT RAW COUNT(*)", sql);
+        Assert.Contains("FROM `b`.`Tags` AS `t`", sql);
+    }
+
+    [Fact]
+    public void AnyWithPredicate_TranslatesToSubqueryIn()
+    {
+        using var ctx = CreateContext();
+        var sql = ctx.Posts.Where(p => p.Tags.Any(t => t == "x")).ToQueryString();
+
+        Assert.Contains("'x' IN (", sql);
+        Assert.DoesNotContain("IN [", sql);
+    }
+
+    [Fact]
+    public void ProjectedElementAt_TranslatesToNativeArraySubscript()
+    {
+        using var ctx = CreateContext();
+        var sql = ctx.Posts.Select(p => p.Tags[0]).ToQueryString();
+
+        Assert.Contains("SELECT `b`.`Tags`[0]", sql);
+    }
+
+    [Fact]
+    public void ArrayLiteralIn_StillUsesBrackets_NotBrokenByRegression()
+    {
+        // Control case: an ordinary .Contains() over an in-memory list (not a queryable primitive
+        // collection) must still use this provider's array-literal IN syntax -- confirms the
+        // GenerateIn subquery-vs-values fix didn't regress the pre-existing, far more common case.
+        using var ctx = CreateContext();
+        var ids = new[] { 1, 2, 3 };
+        var sql = ctx.Posts.Where(p => ids.Contains(p.PostId)).ToQueryString();
+
+        Assert.Contains("IN [$ids1, $ids2, $ids3]", sql);
+    }
+}


### PR DESCRIPTION
….Any(predicate))

List<T>/T[] properties mapped directly (not via OwnsMany) now translate over into working N1QL: indexer/.ElementAt() renders a native arr[i] subscript, while .Contains()/.Count/.Any(predicate) expand the array via a correlated UNNEST-style subquery.

Getting there required fixing several real bugs surfaced only by live-cluster execution, not just generated-SQL-text checks:
- The write path was silently JSON-string-encoding these properties via EF Core's default primitive-collection converter instead of storing a native array (CouchbaseDatabaseWrapper.ApplyConverter).
- The UNNEST projection assumed a SQLite-json_each-style "value" column; N1QL binds the alias directly to the element, so a new CouchbaseUnnestValueExpression is used instead.
- Subquery projections needed SELECT RAW to avoid N1QL's implicit object-wrapping, and scalar subqueries (e.g. Count() == n) needed a trailing [0] since N1QL evaluates any parenthesized subquery expression as an array, unlike ANSI SQL.
- Added CouchbaseSqlNullabilityProcessor/CouchbaseParameterBasedSqlProcessor since the base SqlNullabilityProcessor doesn't know about this provider's custom SqlExpression types.

Indexer/.ElementAt() always behaves like .ElementAtOrDefault() (N1QL returns MISSING for out-of-range rather than throwing). Not supported: .OrderBy()/.Where() composed with .ElementAt(), and reverse-.Contains() over a local in-memory collection.