### PR TITLE
Add indexer/.ElementAt() support over depth-1 OwnsMany navigations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@ and this project aims to follow [Semantic Versioning](https://semver.org/spec/v2
 
 ### Added
 
+- **Indexer/`.ElementAt()` over a depth-1 `OwnsMany` navigation** (e.g.
+  `customer.ContactMethods[0].Type`). Previously fell back to EF Core's generic correlated-subquery
+  + OFFSET/LIMIT translation, which — like `.Any(predicate)` before its own fix — hit the same
+  empty-FROM-clause bug (the owned collection's `TableExpression` renders as nothing) and, when
+  used as a projection, additionally returned `null` because EF Core never assigns this shape a
+  projection alias and the fallback alias-inference didn't recognize it either. Now translates to
+  N1QL's native `parentAlias.field[index].propertyName` array subscript, mirroring
+  `.Any(predicate)`'s own detect/strip/render approach. Behaves like `.ElementAtOrDefault()`
+  (out-of-range returns the default rather than throwing). `.Where(...).ElementAt(...)`
+  compositions and indexing into a scalar collection nested inside an owned item are not yet
+  supported. See [Modeling — OwnsMany](docs/modeling.md#ownsmany).
 - **Scalar primitive collections (`List<T>`/`T[]`, not `OwnsMany`).** A `List<T>`/`T[]` property
   of a scalar element type mapped directly on an entity is now stored as a native JSON array
   (previously silently double-encoded as a JSON string via EF Core's default primitive-collection

--- a/docs/Queries.md
+++ b/docs/Queries.md
@@ -194,6 +194,10 @@ N1QL's own `MISSING`-for-out-of-range semantics.
 over a local in-memory collection are not supported for a primitive collection source — see
 [Limitations](limitations.md).
 
+Indexer/`.ElementAt()` is also supported over a depth-1 `OwnsMany` navigation (e.g.
+`customer.ContactMethods[0].Type`), translating to the same native array-subscript approach — see
+[Modeling — OwnsMany](modeling.md#ownsmany).
+
 ## SQL queries
 
 > [!NOTE]

--- a/docs/limitations.md
+++ b/docs/limitations.md
@@ -80,9 +80,13 @@ The Couchbase SDK is asynchronous, so the synchronous EF Core code paths throw `
   throwing) — this Couchbase Server version has no N1QL syntax for a deterministic positional
   binding over an unnested array. `.OrderBy(...).ElementAt(...)`/`.Where(...).ElementAt(...)`
   compositions and reverse-`.Contains()` over a local in-memory collection are not supported for a
-  primitive collection source. Indexing into a scalar collection *inside* an `OwnsMany` navigation
-  (e.g. `customer.ContactMethods[0].Type`) is not yet supported at all. See
-  [Modeling — Primitive collections](modeling.md#primitive-collections).
+  primitive collection source. See [Modeling — Primitive collections](modeling.md#primitive-collections).
+* **Indexer/`.ElementAt()` over a depth-1 `OwnsMany` navigation** (e.g.
+  `customer.ContactMethods[0].Type`) has the same `.ElementAtOrDefault()`-like out-of-range
+  behavior and the same `.Where(...).ElementAt(...)`-composition limitation as a primitive
+  collection's indexer. Indexing into a scalar collection *nested inside* an owned item (e.g.
+  `customer.ContactMethods[0].Tags[0]`) is not yet supported. See
+  [Modeling — OwnsMany](modeling.md#ownsmany).
 
 See also [Querying](Queries.md) and [Configuration](configuration.md).
 

--- a/docs/modeling.md
+++ b/docs/modeling.md
@@ -326,6 +326,21 @@ var withPhone = await context.Customers
 e.g. `c.ContactMethods.Any(m => m.Tags.Any(...))`), `.All(predicate)`, `.Count(predicate)`, and
 `.Contains()` over an owned collection are not yet supported.
 
+Indexer/`.ElementAt()` access is also supported for a depth-1 `OwnsMany` navigation, translating
+to N1QL's native `parentAlias.field[index].propertyName` array subscript:
+
+```csharp
+var customersWithEmailFirst = await context.Customers
+    .Where(c => c.ContactMethods[0].Type == "email")
+    .ToListAsync();
+```
+
+As with a scalar [primitive collection](#primitive-collections)'s indexer, this always behaves
+like `.ElementAtOrDefault()` — an out-of-range index is excluded/returns default rather than
+throwing. `.Where(...).ElementAt(...)` composed before the index, and indexing into a scalar
+collection nested *inside* an owned item (e.g. `customer.ContactMethods[0].Tags[0]`), are not yet
+supported.
+
 ### Field-backed access
 
 If an owned type's properties are get-only (backed by a private field, with no public setter),

--- a/src/Couchbase.EntityFrameworkCore/Query/Internal/CouchbaseProjectionAliases.cs
+++ b/src/Couchbase.EntityFrameworkCore/Query/Internal/CouchbaseProjectionAliases.cs
@@ -76,13 +76,35 @@ internal static class CouchbaseProjectionAliases
     /// *desired* key (what the reader expects), which for a <c>META(alias).field</c> projection is
     /// still the property's own name (e.g. <c>"DocId"</c>) -- see <see cref="NeedsExplicitAlias"/>
     /// for why such a projection can never rely on N1QL's own implicit naming to produce that key.
+    /// <para>
+    /// A projection folded from indexer/<c>.ElementAt()</c> access over a depth-1 <c>OwnsMany</c>
+    /// navigation (<see cref="CouchbaseQuerySqlGenerator.TryResolveOwnedElementAt"/>) gets no
+    /// alias from EF Core at all (unlike a plain member access) -- resolved here as the accessed
+    /// property's own (policy-converted) name, matching exactly what
+    /// <see cref="CouchbaseQuerySqlGenerator"/> renders as the trailing <c>.propertyName</c>
+    /// segment of the native array subscript it emits for this shape.
+    /// </para>
     /// </summary>
-    public static string EffectiveAlias(ProjectionExpression projection)
-        => projection.Alias != string.Empty
-            ? projection.Alias
-            : projection.Expression is ColumnExpression c
-                ? c.Name
-                : string.Empty;
+    public static string EffectiveAlias(ProjectionExpression projection, JsonNamingPolicy? fieldNamingPolicy = null)
+    {
+        if (projection.Alias != string.Empty)
+        {
+            return projection.Alias;
+        }
+
+        if (projection.Expression is ColumnExpression c)
+        {
+            return c.Name;
+        }
+
+        if (projection.Expression is ScalarSubqueryExpression { Subquery: var subquery }
+            && CouchbaseQuerySqlGenerator.TryResolveOwnedElementAt(subquery, out _, out _, out _, out var elementAtColumn))
+        {
+            return fieldNamingPolicy?.ConvertName(elementAtColumn.Name) ?? elementAtColumn.Name;
+        }
+
+        return string.Empty;
+    }
 
     /// <summary>
     /// Whether a projection must get an explicit <c>AS &lt;alias&gt;</c> regardless of what the
@@ -91,21 +113,26 @@ internal static class CouchbaseProjectionAliases
     /// function-call-based expression doesn't reliably (or ever, empirically) produce the
     /// property's own name (e.g. <c>META(d).id</c> does not implicitly come back keyed
     /// <c>"DocId"</c>, or even reliably <c>"id"</c>) the way a bare <c>alias.field</c> reference's
-    /// implicit name always matches its own column name.
+    /// implicit name always matches its own column name. Also true for the owned-collection
+    /// indexer/<c>.ElementAt()</c> shape described on <see cref="EffectiveAlias"/> -- EF Core never
+    /// assigns that projection an alias of its own, so nothing here can rely on it matching N1QL's
+    /// implicit naming by coincidence; an explicit <c>AS</c> is emitted unconditionally instead.
     /// </summary>
     public static bool NeedsExplicitAlias(ProjectionExpression projection)
-        => projection.Expression is ColumnExpression c && GetMetaField(c) != null;
+        => (projection.Expression is ColumnExpression c && GetMetaField(c) != null)
+            || (projection.Expression is ScalarSubqueryExpression { Subquery: var subquery }
+                && CouchbaseQuerySqlGenerator.TryResolveOwnedElementAt(subquery, out _, out _, out _, out _));
 
     /// <summary>
     /// Computes a collision-free alias for every projection, in projection order.  The first
     /// occurrence of an effective alias is kept verbatim; subsequent duplicates get an
     /// incrementing numeric suffix (e.g. <c>rating</c>, <c>rating0</c>, <c>rating1</c>).
     /// </summary>
-    public static string[] ComputeUnique(IReadOnlyList<ProjectionExpression> projections)
+    public static string[] ComputeUnique(IReadOnlyList<ProjectionExpression> projections, JsonNamingPolicy? fieldNamingPolicy = null)
     {
         var names = new string[projections.Count];
         for (var i = 0; i < projections.Count; i++)
-            names[i] = EffectiveAlias(projections[i]);
+            names[i] = EffectiveAlias(projections[i], fieldNamingPolicy);
         return MakeUnique(names);
     }
 

--- a/src/Couchbase.EntityFrameworkCore/Query/Internal/CouchbaseQuerySqlGenerator.cs
+++ b/src/Couchbase.EntityFrameworkCore/Query/Internal/CouchbaseQuerySqlGenerator.cs
@@ -1,5 +1,6 @@
 using System.Collections.Concurrent;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq.Expressions;
 using System.Net.WebSockets;
 using System.Reflection;
@@ -521,8 +522,11 @@ public class CouchbaseQuerySqlGenerator : QuerySqlGenerator
                     && pe.Expression is ColumnExpression col
                     && skippedAliases.Contains(col.TableAlias);
 
-                if (selectExpression.Projection.Count == 1)
+                if (selectExpression.Projection.Count == 1 && selectExpression.Alias != null)
                 {
+                    // Subquery context (used as a WHERE-clause/comparison building block, never
+                    // read back by JSON key directly) -- no alias-correctness concerns, just emit
+                    // the RAW-prefix logic these shapes need and the bare expression.
                     var expression = selectExpression.Projection.First().Expression;
                     if (expression is SqlFunctionExpression sqlFunctionExpression)
                     {
@@ -552,12 +556,13 @@ public class CouchbaseQuerySqlGenerator : QuerySqlGenerator
                 }
                 else if (selectExpression.Alias == null)
                 {
-                    // Top-level SELECT: each row becomes a JSON object keyed by alias, so two
-                    // projections sharing an effective alias (e.g. a collection Include where the
-                    // principal and dependent both expose `rating` / `blogId`) would collide on a
-                    // single key. Emit a unique alias for every colliding projection, aligned with
-                    // the alias array built in CouchbaseShapedQueryCompilingExpressionVisitor.
-                    var uniqueAliases = CouchbaseProjectionAliases.ComputeUnique(selectExpression.Projection);
+                    // Top-level SELECT (including the single-projection case, e.g. a bare
+                    // `.Select(x => x.Scalar)`): each row becomes a JSON object keyed by alias, so
+                    // two projections sharing an effective alias (e.g. a collection Include where
+                    // the principal and dependent both expose `rating` / `blogId`) would collide on
+                    // a single key. Emit a unique alias for every colliding projection, aligned
+                    // with the alias array built in CouchbaseShapedQueryCompilingExpressionVisitor.
+                    var uniqueAliases = CouchbaseProjectionAliases.ComputeUnique(selectExpression.Projection, _fieldNamingPolicy);
                     var emitted = new List<(ProjectionExpression Projection, string Alias)>();
                     for (var i = 0; i < selectExpression.Projection.Count; i++)
                     {
@@ -566,14 +571,21 @@ public class CouchbaseQuerySqlGenerator : QuerySqlGenerator
                             emitted.Add((projection, uniqueAliases[i]));
                     }
 
+                    if (selectExpression.Projection.Count == 1
+                        && selectExpression.Projection[0].Expression is SqlFunctionExpression { Name: "COUNT" } or ExistsExpression or CouchbaseUnnestValueExpression)
+                    {
+                        Sql.Append("RAW ");
+                    }
+
                     GenerateList(emitted, e =>
                     {
                         // Append AS when the unique alias differs from what the projection would
                         // emit on its own (keeps non-colliding queries byte-identical), OR when the
-                        // projection is a META(alias).field column -- N1QL's own implicit naming
-                        // for that shape doesn't reliably produce the desired key (see
+                        // projection needs one unconditionally (a META(alias).field column, or the
+                        // owned-collection indexer/.ElementAt() shape, neither of which N1QL's own
+                        // implicit naming can be relied on to key correctly -- see
                         // CouchbaseProjectionAliases.NeedsExplicitAlias).
-                        if (e.Alias != CouchbaseProjectionAliases.EffectiveAlias(e.Projection)
+                        if (e.Alias != CouchbaseProjectionAliases.EffectiveAlias(e.Projection, _fieldNamingPolicy)
                             || CouchbaseProjectionAliases.NeedsExplicitAlias(e.Projection))
                         {
                             Visit(e.Projection.Expression);
@@ -669,6 +681,27 @@ public class CouchbaseQuerySqlGenerator : QuerySqlGenerator
     /// </summary>
     protected override Expression VisitScalarSubquery(ScalarSubqueryExpression scalarSubqueryExpression)
     {
+        if (TryRenderOwnedElementAt(scalarSubqueryExpression.Subquery))
+        {
+            return scalarSubqueryExpression;
+        }
+
+        // TryRenderOwnedElementAt returned false either because this isn't an owned-collection
+        // ElementAt shape at all (falls through to the generic rendering below, which is correct
+        // for e.g. Count()/Sum()/Max() subqueries), or because it IS one but with an unsupported
+        // composition on top (.Where(...)/.OrderBy(...) before .ElementAt(i) -- out of scope, see
+        // TryResolveOwnedElementAt's remarks). The latter must not fall through: VisitTable
+        // renders an owned TableExpression as nothing (it's embedded JSON, not a real keyspace),
+        // so the generic rendering below would silently produce an empty-FROM-clause N1QL parse
+        // error instead of a clear translation-time failure.
+        if (scalarSubqueryExpression.Subquery.Tables is [TableExpression ownedTableCandidate]
+            && TryGetOwnedEntityTypes(ownedTableCandidate, out _))
+        {
+            throw new NotSupportedException(
+                "Composing .Where(...)/.OrderBy(...) before an indexer/.ElementAt() access over an "
+                + "OwnsMany navigation is not supported.");
+        }
+
         Sql.AppendLine("(");
         using (Sql.Indent())
         {
@@ -678,6 +711,102 @@ public class CouchbaseQuerySqlGenerator : QuerySqlGenerator
         Sql.Append(")[0]");
 
         return scalarSubqueryExpression;
+    }
+
+    /// <summary>
+    /// Renders N1QL's native <c>parentAlias.field[offset].propertyName</c> subscript in place of
+    /// the base class's generic correlated-subquery + OFFSET/LIMIT translation of
+    /// <c>.ElementAt(i)</c>/indexer access over a depth-1 <c>OwnsMany</c> navigation -- mirrors
+    /// <see cref="TryRenderOwnedCollectionAny"/>'s detect/strip/render pattern exactly. Confirmed
+    /// via a Phase-0 spike that <see cref="CouchbaseQueryableMethodTranslatingExpressionVisitor.TranslateElementAtOrDefault"/>
+    /// falling back to the base implementation for this shape hits the exact same
+    /// empty-FROM-clause bug class <c>.Any()</c> had (its sole table is an owned
+    /// <see cref="TableExpression"/>, which <see cref="VisitTable"/> renders as nothing).
+    /// Returns <see langword="false"/> (writing nothing) if the shape doesn't match cleanly --
+    /// including a genuine user <c>.Where(...)</c> composed before <c>.ElementAt(i)</c>, which is
+    /// out of scope for v1 -- so the caller falls through to the default (and, for this shape,
+    /// broken) rendering rather than silently producing an incorrect result.
+    /// </summary>
+    private bool TryRenderOwnedElementAt(SelectExpression subquery)
+    {
+        if (!TryResolveOwnedElementAt(subquery, out var ownership, out var parentAlias, out var offset, out var column))
+        {
+            return false;
+        }
+
+        var fieldName = CouchbaseProjectionAliases.GetOwnedCollectionFieldName(ownership.PrincipalToDependent!, _fieldNamingPolicy);
+        var propertyName = _fieldNamingPolicy?.ConvertName(column.Name) ?? column.Name;
+        var helper = Dependencies.SqlGenerationHelper;
+
+        Sql.Append(helper.DelimitIdentifier(parentAlias))
+            .Append(".")
+            .Append(helper.DelimitIdentifier(fieldName))
+            .Append("[");
+        Visit(offset);
+        Sql.Append("].")
+            .Append(helper.DelimitIdentifier(propertyName));
+
+        return true;
+    }
+
+    /// <summary>
+    /// Detects the exact shape <see cref="TryRenderOwnedElementAt"/> renders -- a correlated
+    /// subquery over a depth-1 <c>OwnsMany</c> navigation's owned table, filtered down to one row
+    /// via <c>OFFSET</c>/<c>LIMIT 1</c> with no other composition -- without writing any SQL.
+    /// Shared with <see cref="CouchbaseProjectionAliases"/> so the SQL generator's rendering and
+    /// the shaped-query compiler's expected-alias computation can never drift (the same concern
+    /// <see cref="CouchbaseProjectionAliases.GetOwnedCollectionFieldName"/> already solves for the
+    /// array field name itself).
+    /// </summary>
+    internal static bool TryResolveOwnedElementAt(
+        SelectExpression subquery,
+        [NotNullWhen(true)] out IForeignKey? ownership,
+        [NotNullWhen(true)] out string? parentAlias,
+        [NotNullWhen(true)] out SqlExpression? offset,
+        [NotNullWhen(true)] out ColumnExpression? column)
+    {
+        ownership = null;
+        parentAlias = null;
+        offset = null;
+        column = null;
+
+        if (subquery is not
+            {
+                Tables: [TableExpression ownedTable],
+                Projection: [{ Expression: ColumnExpression projectedColumn }],
+                Offset: { } off,
+                Limit: SqlConstantExpression { Value: 1 },
+                Orderings: [],
+                IsDistinct: false,
+            }
+            || projectedColumn.TableAlias != ownedTable.Alias
+            || !TryGetOwnedEntityTypes(ownedTable, out var ownedEntityTypes))
+        {
+            return false;
+        }
+
+        foreach (var candidate in ownedEntityTypes)
+        {
+            var candidateOwnership = candidate.FindOwnership();
+            if (candidateOwnership?.PrincipalToDependent == null)
+            {
+                continue;
+            }
+
+            if (!TryStripCorrelation(subquery.Predicate, ownedTable.Alias!, candidateOwnership, out var residual, out var foundParentAlias)
+                || residual != null)
+            {
+                continue;
+            }
+
+            ownership = candidateOwnership;
+            parentAlias = foundParentAlias;
+            offset = off;
+            column = projectedColumn;
+            return true;
+        }
+
+        return false;
     }
 
     protected override void GenerateExists(ExistsExpression existsExpression, bool negated)
@@ -800,7 +929,7 @@ public class CouchbaseQuerySqlGenerator : QuerySqlGenerator
         string ownedAlias,
         IForeignKey ownership,
         out SqlExpression? residual,
-        out string? parentAlias)
+        [NotNullWhen(true)] out string? parentAlias)
     {
         residual = null;
         parentAlias = null;

--- a/src/Couchbase.EntityFrameworkCore/Query/Internal/CouchbaseQueryableMethodTranslatingExpressionVisitor.cs
+++ b/src/Couchbase.EntityFrameworkCore/Query/Internal/CouchbaseQueryableMethodTranslatingExpressionVisitor.cs
@@ -96,15 +96,30 @@ public class CouchbaseQueryableMethodTranslatingExpressionVisitor : RelationalQu
     /// <see cref="TranslatePrimitiveCollection"/> for why that approach isn't available here.
     /// Only handles the exact, untouched shape <see cref="TranslatePrimitiveCollection"/> itself
     /// produces (a bare <see cref="CouchbaseUnnestExpression"/>, no predicate/ordering/offset/limit
-    /// applied yet) -- anything else (e.g. <c>.Where(...).ElementAt(i)</c>,
-    /// <c>.OrderBy(...).ElementAt(i)</c>) returns <see langword="null"/>, which surfaces as EF
-    /// Core's standard "could not be translated" exception rather than silently producing an
-    /// incorrect result for a composition this provider cannot express correctly.
+    /// applied yet). Any OTHER composition over a <see cref="CouchbaseUnnestExpression"/> source --
+    /// <c>.Where(...).ElementAt(i)</c>, <c>.OrderBy(...).ElementAt(i)</c> -- returns
+    /// <see langword="null"/> outright rather than falling back to the base implementation, which
+    /// would still render as syntactically valid but semantically nondeterministic N1QL for that
+    /// source (no <c>AT alias</c> positional binding exists for this provider's unnest rendering,
+    /// so there's no real row order to skip over) -- silently returning a wrong element instead of
+    /// failing loudly. A non-unnest source (e.g. an <c>OwnsMany</c> navigation's FK-joined
+    /// <see cref="TableExpression"/>) still falls back to the base implementation, which
+    /// <see cref="CouchbaseQuerySqlGenerator"/> has its own chance to render correctly (or reject)
+    /// at the SQL-generation layer.
     /// </summary>
     protected override ShapedQueryExpression? TranslateElementAtOrDefault(
         ShapedQueryExpression source, Expression index, bool returnDefault)
     {
-        if (source.QueryExpression is not SelectExpression
+        if (source.QueryExpression is not SelectExpression { Tables: [CouchbaseUnnestExpression] } unnestSourceSelect)
+        {
+            // Not a primitive-collection source at all (e.g. an OwnsMany navigation's FK-joined
+            // TableExpression) -- fall back to the base implementation, which
+            // CouchbaseQuerySqlGenerator has its own chance to render correctly (or reject) at the
+            // SQL-generation layer.
+            return base.TranslateElementAtOrDefault(source, index, returnDefault);
+        }
+
+        if (unnestSourceSelect is not
             {
                 Tables: [CouchbaseUnnestExpression unnestExpression],
                 Predicate: null,
@@ -114,6 +129,13 @@ public class CouchbaseQueryableMethodTranslatingExpressionVisitor : RelationalQu
                 IsDistinct: false,
             } selectExpression)
         {
+            // A primitive-collection source with extra composition already applied --
+            // .Where(...).ElementAt(i), .OrderBy(...).ElementAt(i). Must return null outright
+            // rather than fall back: the base OFFSET/LIMIT implementation would still render as
+            // syntactically valid N1QL over this source (CouchbaseQuerySqlGenerator.GenerateUnnest
+            // handles it), but semantically nondeterministic -- no AT alias positional binding
+            // exists for this provider's unnest rendering, so there's no real row order to skip
+            // over, and it would silently return a wrong element instead of failing loudly.
             return null;
         }
 

--- a/src/Couchbase.EntityFrameworkCore/Query/Internal/CouchbaseShapedQueryCompilingExpressionVisitor.cs
+++ b/src/Couchbase.EntityFrameworkCore/Query/Internal/CouchbaseShapedQueryCompilingExpressionVisitor.cs
@@ -243,7 +243,7 @@ public class CouchbaseShapedQueryCompilingExpressionVisitor : RelationalShapedQu
             // the N1QL result and return DBNull via CouchbaseDbDataReader, which is the expected
             // signal for "no collection rows" — PopulateCollectionNavigations then fills the
             // actual collection from the embedded JSON array.
-            var uniqueAliases = CouchbaseProjectionAliases.ComputeUnique(selectExpression.Projection);
+            var uniqueAliases = CouchbaseProjectionAliases.ComputeUnique(selectExpression.Projection, _couchbaseDbContextOptionsBuilder.FieldNamingPolicy);
             var projectionAliasesExpression = CreateStringArrayLiftableConstant(uniqueAliases, "projectionAliases");
 
             // Resolve each owned navigation's FINAL (post-uniquification) alias, so

--- a/tests/Couchbase.EntityFrameworkCore.IntegrationTests/Tests/OwnedTypeTests.cs
+++ b/tests/Couchbase.EntityFrameworkCore.IntegrationTests/Tests/OwnedTypeTests.cs
@@ -1233,4 +1233,68 @@ public class OwnedTypeTests(
         Assert.Single(customers);
         Assert.Equal(1, customers[0].CustomerId);
     }
+
+    // -------------------------------------------------------------------------
+    // Indexer / .ElementAt() over a depth-1 OwnsMany navigation
+    //
+    // Falls back to EF Core's own generic correlated-subquery + OFFSET/LIMIT translation (the
+    // same shape .Any() has), which hits the identical empty-FROM-clause bug class --
+    // CouchbaseQuerySqlGenerator.VisitScalarSubquery now recognizes this shape and renders N1QL's
+    // native parentAlias.field[index].propertyName subscript instead. Alice (1): [email, phone];
+    // Bob (2): [email] only (no index 1); Carol (3): [email, phone] -- used to prove real
+    // value/inclusion-exclusion behavior, not just that the generated SQL text looks right.
+    // -------------------------------------------------------------------------
+
+    [Fact]
+    public async Task OwnsMany_IndexerProjected_ReturnsCorrectValue()
+    {
+        await using var ctx = fixture.GetDbContext();
+        var type = await ctx.Customers
+            .Where(c => c.CustomerId == 1)
+            .Select(c => c.ContactMethods[0].Type)
+            .SingleAsync();
+
+        Assert.Equal("email", type);
+    }
+
+    [Fact]
+    public async Task OwnsMany_ElementAt_NonZeroIndex_ReturnsCorrectValue()
+    {
+        await using var ctx = fixture.GetDbContext();
+        var value = await ctx.Customers
+            .Where(c => c.CustomerId == 1)
+            .Select(c => c.ContactMethods.ElementAt(1).Value)
+            .SingleAsync();
+
+        Assert.Equal("555-0100", value);
+    }
+
+    [Fact]
+    public async Task OwnsMany_IndexerInPredicate_ReturnsOnlyMatchingCustomers()
+    {
+        // Only Alice (1) and Carol (3) have a "phone" contact method at index 1 -- Bob (2) has no
+        // index 1 at all (a single email-only contact method).
+        await using var ctx = fixture.GetDbContext();
+        var customers = await ctx.Customers
+            .Where(c => c.ContactMethods[1].Type == "phone")
+            .ToListAsync();
+
+        Assert.Equal(2, customers.Count);
+        Assert.Contains(customers, c => c.CustomerId == 1);
+        Assert.Contains(customers, c => c.CustomerId == 3);
+        Assert.DoesNotContain(customers, c => c.CustomerId == 2);
+    }
+
+    [Fact]
+    public async Task OwnsMany_Indexer_OutOfRangeIndex_ExcludedNotError()
+    {
+        // Bob (2) has only one contact method -- ContactMethods[1] is genuinely out of range, and
+        // must be excluded (N1QL's array subscript returns MISSING for it) rather than error.
+        await using var ctx = fixture.GetDbContext();
+        var customers = await ctx.Customers
+            .Where(c => c.ContactMethods[1].Type == "email")
+            .ToListAsync();
+
+        Assert.DoesNotContain(customers, c => c.CustomerId == 2);
+    }
 }

--- a/tests/Couchbase.EntityFrameworkCore.UnitTests/Couchbase/EntityFrameworkCore/Query/OwnedCollectionElementAtTests.cs
+++ b/tests/Couchbase.EntityFrameworkCore.UnitTests/Couchbase/EntityFrameworkCore/Query/OwnedCollectionElementAtTests.cs
@@ -1,0 +1,186 @@
+using System.Text.Json;
+using Couchbase.EntityFrameworkCore.Extensions;
+using Microsoft.EntityFrameworkCore;
+using Xunit;
+
+namespace Couchbase.EntityFrameworkCore.UnitTests.Couchbase.EntityFrameworkCore.Query;
+
+/// <summary>
+/// Verifies indexer/<c>.ElementAt()</c> access over a depth-1 <c>OwnsMany</c> navigation
+/// (e.g. <c>customer.ContactMethods[0].Type</c>) translates to N1QL's native
+/// <c>parentAlias.field[index].propertyName</c> subscript, not the correlated
+/// OFFSET/LIMIT subquery EF Core builds by default -- which this provider's owned-table JOIN
+/// suppression (<c>VisitTable</c>/<c>IsOwnedTable</c>) would otherwise turn into an
+/// empty-FROM-clause N1QL error, the same bug class <c>.Any()</c> had.
+/// </summary>
+public class OwnedCollectionElementAtTests
+{
+    private class Customer
+    {
+        public int CustomerId { get; set; }
+        public string Name { get; set; } = "";
+        public List<ContactMethod> ContactMethods { get; set; } = [];
+    }
+
+    private class ContactMethod
+    {
+        public int Id { get; set; }
+        public string Type { get; set; } = "";
+    }
+
+    private class CustomerContext(DbContextOptions<CustomerContext> options) : DbContext(options)
+    {
+        public DbSet<Customer> Customers { get; set; } = null!;
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            modelBuilder.Entity<Customer>(b =>
+            {
+                b.ToCouchbaseCollection("bucket", "scope", "customer");
+                b.HasKey(c => c.CustomerId);
+                b.OwnsMany(c => c.ContactMethods, cm => cm.HasKey(m => m.Id));
+            });
+        }
+    }
+
+    private static CustomerContext CreateContext(JsonNamingPolicy? fieldNamingPolicy = null)
+    {
+        var clusterOptions = new global::Couchbase.ClusterOptions()
+            .WithConnectionString("couchbase://localhost")
+            .WithPasswordAuthentication("Administrator", "password");
+        var builder = new DbContextOptionsBuilder<CustomerContext>();
+        builder.UseCouchbaseProvider(clusterOptions, o =>
+        {
+            if (fieldNamingPolicy != null)
+            {
+                o.FieldNamingPolicy = fieldNamingPolicy;
+            }
+        });
+        return new CustomerContext(builder.Options);
+    }
+
+    [Fact]
+    public void Indexer_InPredicate_TranslatesToNativeSubscript()
+    {
+        using var ctx = CreateContext();
+        var sql = ctx.Customers.Where(c => c.ContactMethods[0].Type == "email").ToQueryString();
+
+        Assert.Contains("`b`.`contactMethods`[0].`type` = 'email'", sql);
+        Assert.DoesNotContain("LIMIT", sql, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void Indexer_Projected_TranslatesToNativeSubscript()
+    {
+        using var ctx = CreateContext();
+        var sql = ctx.Customers.Select(c => c.ContactMethods[0].Type).ToQueryString();
+
+        Assert.Contains("SELECT `b`.`contactMethods`[0].`type`", sql);
+    }
+
+    [Fact]
+    public void ElementAt_WithNonZeroIndex_UsesThatSubscript()
+    {
+        using var ctx = CreateContext();
+        var sql = ctx.Customers.Where(c => c.ContactMethods[3].Type == "email").ToQueryString();
+
+        Assert.Contains("`b`.`contactMethods`[3].`type` = 'email'", sql);
+    }
+
+    [Fact]
+    public void ElementAtOrDefault_TranslatesToSameNativeSubscript()
+    {
+        // N1QL's array subscript already returns MISSING (falsy) for an out-of-range index, so
+        // ElementAtOrDefault needs no different rendering than the throwing ElementAt/indexer form.
+        using var ctx = CreateContext();
+        var sql = ctx.Customers.Select(c => c.ContactMethods.ElementAtOrDefault(0)!.Type).ToQueryString();
+
+        Assert.Contains("SELECT `b`.`contactMethods`[0].`type`", sql);
+    }
+
+    [Fact]
+    public void NonDefaultFieldNamingPolicy_AppliesToArrayFieldAndPropertyName()
+    {
+        using var ctx = CreateContext(JsonNamingPolicy.SnakeCaseLower);
+        var sql = ctx.Customers.Where(c => c.ContactMethods[0].Type == "email").ToQueryString();
+
+        Assert.Contains("`b`.`contact_methods`[0].`type` = 'email'", sql);
+    }
+
+    [Fact]
+    public void WhereComposedBeforeElementAt_FailsTranslation_NotSilentlyInvalidSql()
+    {
+        // .Where(predicate).ElementAt(i) before the index is out of scope for v1 (see the plan's
+        // scope notes). The correlation-stripping check rejects this shape (a non-null residual
+        // predicate survives stripping) -- and, since the owned collection's TableExpression
+        // renders as nothing (VisitTable), silently falling through to the generic subquery
+        // rendering would produce an empty-FROM-clause N1QL parse error rather than a clear
+        // translation-time failure. Must throw instead.
+        using var ctx = CreateContext();
+        Assert.Throws<NotSupportedException>(
+            () => ctx.Customers
+                .Select(c => c.ContactMethods.Where(m => m.Type == "x").ElementAt(0).Type)
+                .ToQueryString());
+    }
+
+    // -------------------------------------------------------------------------
+    // Regression: OwnsMany item type that itself table-splits a nested OwnsOne -- same concern
+    // OwnedCollectionAnyTests guards for .Any(), applied here to indexer/.ElementAt().
+    // -------------------------------------------------------------------------
+
+    private class RichCustomer
+    {
+        public int CustomerId { get; set; }
+        public List<RichContactMethod> ContactMethods { get; set; } = [];
+    }
+
+    private class RichContactMethod
+    {
+        public int Id { get; set; }
+        public string Type { get; set; } = "";
+        public ContactLabel? Label { get; set; }
+    }
+
+    private class ContactLabel
+    {
+        public string? DisplayName { get; set; }
+    }
+
+    private class RichCustomerContext(DbContextOptions<RichCustomerContext> options) : DbContext(options)
+    {
+        public DbSet<RichCustomer> Customers { get; set; } = null!;
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            modelBuilder.Entity<RichCustomer>(b =>
+            {
+                b.ToCouchbaseCollection("bucket", "scope", "customer");
+                b.HasKey(c => c.CustomerId);
+                b.OwnsMany(c => c.ContactMethods, cm =>
+                {
+                    cm.HasKey(m => m.Id);
+                    cm.OwnsOne(m => m.Label);
+                });
+            });
+        }
+    }
+
+    private static RichCustomerContext CreateRichContext()
+    {
+        var clusterOptions = new global::Couchbase.ClusterOptions()
+            .WithConnectionString("couchbase://localhost")
+            .WithPasswordAuthentication("Administrator", "password");
+        var builder = new DbContextOptionsBuilder<RichCustomerContext>();
+        builder.UseCouchbaseProvider(clusterOptions);
+        return new RichCustomerContext(builder.Options);
+    }
+
+    [Fact]
+    public void ItemTypeWithNestedOwnsOne_StillTranslatesToNativeSubscript()
+    {
+        using var ctx = CreateRichContext();
+        var sql = ctx.Customers.Where(c => c.ContactMethods[0].Type == "phone").ToQueryString();
+
+        Assert.Contains("`b`.`contactMethods`[0].`type` = 'phone'", sql);
+    }
+}

--- a/tests/Couchbase.EntityFrameworkCore.UnitTests/Couchbase/EntityFrameworkCore/Query/PrimitiveCollectionTests.cs
+++ b/tests/Couchbase.EntityFrameworkCore.UnitTests/Couchbase/EntityFrameworkCore/Query/PrimitiveCollectionTests.cs
@@ -110,6 +110,28 @@ public class PrimitiveCollectionTests
     }
 
     [Fact]
+    public void WhereComposedBeforeElementAt_FailsTranslation_NotSilentlyWrong()
+    {
+        // .Where(...).ElementAt(i) over a primitive collection must fail translation outright,
+        // not fall back to EF Core's generic OFFSET/LIMIT implementation: that would render as
+        // syntactically valid N1QL over this provider's UNNEST-less rendering (GenerateUnnest
+        // handles the FROM-clause fine), but there is no AT-alias positional binding to make
+        // OFFSET/LIMIT deterministic, so it would silently return a wrong element instead of
+        // failing loudly.
+        using var ctx = CreateContext();
+        Assert.Throws<InvalidOperationException>(
+            () => ctx.Posts.Select(p => p.Tags.Where(t => t != "x").ElementAt(0)).ToQueryString());
+    }
+
+    [Fact]
+    public void OrderByComposedBeforeElementAt_FailsTranslation_NotSilentlyWrong()
+    {
+        using var ctx = CreateContext();
+        Assert.Throws<InvalidOperationException>(
+            () => ctx.Posts.Select(p => p.Tags.OrderBy(t => t).ElementAt(0)).ToQueryString());
+    }
+
+    [Fact]
     public void ArrayLiteralIn_StillUsesBrackets_NotBrokenByRegression()
     {
         // Control case: an ordinary .Contains() over an in-memory list (not a queryable primitive


### PR DESCRIPTION
customer.ContactMethods[0].Type now translates to N1QL's native parentAlias.field[index].propertyName array subscript, both in predicates and projections, instead of EF Core's generic correlated-subquery + OFFSET/LIMIT translation.

That generic translation hit the same empty-FROM-clause bug .Any() had (the owned collection's TableExpression renders as nothing, since it's a JSON array embedded in the parent document, not a real keyspace). Fixed by detecting the shape in a new CouchbaseQuerySqlGenerator.VisitScalarSubquery override and reusing .Any()'s existing TryGetOwnedEntityTypes/ TryStripCorrelation machinery.

A second, separate bug only showed up once a projection (not just a predicate) was tested live: EF Core never assigns this scalar-subquery shape a projection alias, so top-level `.Select(c => c.ContactMethods[0].Type)` silently returned null (the reader's expected key and N1QL's own implicit naming disagreed). Fixed by extracting a shared TryResolveOwnedElementAt shape-detector and teaching CouchbaseProjectionAliases to force an explicit AS for it.

Behaves like .ElementAtOrDefault() (out-of-range returns default rather than throwing). .Where(...).ElementAt(...) compositions and indexing into a scalar collection nested inside an owned item are not yet supported.