### PR TITLE
Add .All(predicate) and .Count(predicate) support over OwnsMany navig…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,19 @@ and this project aims to follow [Semantic Versioning](https://semver.org/spec/v2
 
 ### Added
 
+- **`.All(predicate)` and `.Count(predicate)` over a depth-1 `OwnsMany` navigation.**
+  `.All(predicate)` needed no new production code — EF Core translates it as the same
+  `NOT EXISTS(... WHERE NOT predicate)` shape `.Any(predicate)` already produces, so it flows
+  through the existing owned-collection detection for free. `.Count(predicate)`/predicate-less
+  `.Count()` translate to a correlated
+  `(SELECT RAW COUNT(*) FROM parentAlias.field AS alias [WHERE predicate])[0]` subquery, mirroring
+  `.Any(predicate)`'s detect/strip/render approach. Any other aggregate composed over an owned
+  collection (e.g. `.Sum()`, `.Max()`) now throws a clear `NotSupportedException` instead of
+  silently producing an empty-FROM-clause N1QL parse error. `.Contains()` directly on an
+  `OwnsMany` navigation is confirmed **not** fixable at this provider's layer — it crashes inside
+  EF Core's own core query-translation code (`RelationalSqlTranslatingExpressionVisitor.ParameterValueExtractor`)
+  for any relational provider once the owned collection's key is composite, EF Core's default for
+  an owned type; use `.Any(predicate)` instead. See [Modeling — OwnsMany](docs/modeling.md#ownsmany).
 - **Indexer/`.ElementAt()` over a depth-1 `OwnsMany` navigation** (e.g.
   `customer.ContactMethods[0].Type`). Previously fell back to EF Core's generic correlated-subquery
   + OFFSET/LIMIT translation, which — like `.Any(predicate)` before its own fix — hit the same

--- a/docs/Queries.md
+++ b/docs/Queries.md
@@ -195,8 +195,10 @@ over a local in-memory collection are not supported for a primitive collection s
 [Limitations](limitations.md).
 
 Indexer/`.ElementAt()` is also supported over a depth-1 `OwnsMany` navigation (e.g.
-`customer.ContactMethods[0].Type`), translating to the same native array-subscript approach — see
-[Modeling — OwnsMany](modeling.md#ownsmany).
+`customer.ContactMethods[0].Type`), translating to the same native array-subscript approach, as
+are `.Any(predicate)`, `.All(predicate)`, and `.Count(predicate)` — see
+[Modeling — OwnsMany](modeling.md#ownsmany) (including why `.Contains()` directly on an `OwnsMany`
+navigation is not supported).
 
 ## SQL queries
 

--- a/docs/limitations.md
+++ b/docs/limitations.md
@@ -69,10 +69,15 @@ The Couchbase SDK is asynchronous, so the synchronous EF Core code paths throw `
   persisted and queried only when configured as EF Core owned types (`OwnsOne` /
   `OwnsMany`) or as related entities. Plain CLR objects nested on an entity that are
   not mapped this way are ignored by EF Core.
-* **`.Any(predicate)` over an `OwnsMany` navigation is supported only one level deep**
-  (a collection declared directly on the entity being queried). `.Any(predicate)` over a
-  *nested* owned collection reached through another owned navigation, `.All(predicate)`,
-  `.Count(predicate)`, and `.Contains()` over an owned collection are not yet supported. See
+* **`.Any(predicate)`/`.All(predicate)`/`.Count(predicate)` over an `OwnsMany` navigation are
+  supported only one level deep** (a collection declared directly on the entity being queried) --
+  the *nested* case (reached through another owned navigation, e.g.
+  `c.ContactMethods.Any(m => m.Tags.Any(...))`) is not yet supported. See
+  [Modeling — OwnsMany](modeling.md#ownsmany).
+* **`.Contains()` directly on an `OwnsMany` navigation is not supported** — this is a crash inside
+  EF Core's own core query-translation code, not a gap in this provider's SQL generation, and
+  would reproduce for any relational provider once the owned collection's key is composite (the
+  default for an owned type). Use `.Any(predicate)` comparing individual properties instead. See
   [Modeling — OwnsMany](modeling.md#ownsmany).
 * **Indexer/`.ElementAt()` over a scalar primitive collection (`List<T>`/`T[]`, not `OwnsMany`)
   has no ordering guarantee beyond direct array position**, and always behaves like

--- a/docs/modeling.md
+++ b/docs/modeling.md
@@ -322,9 +322,36 @@ var withPhone = await context.Customers
     .ToListAsync();
 ```
 
-`.Any(predicate)` over a *nested* owned collection (one reached through another owned navigation,
-e.g. `c.ContactMethods.Any(m => m.Tags.Any(...))`), `.All(predicate)`, `.Count(predicate)`, and
-`.Contains()` over an owned collection are not yet supported.
+`.All(predicate)` and `.Count(predicate)` (with or without a predicate) are also supported for a
+depth-1 `OwnsMany` navigation:
+
+```csharp
+var allEmail = await context.Customers
+    .Where(c => c.ContactMethods.All(m => m.Type == "email"))
+    .ToListAsync();
+
+var twoOrMorePhones = await context.Customers
+    .Where(c => c.ContactMethods.Count(m => m.Type == "phone") >= 2)
+    .ToListAsync();
+```
+
+`.All(predicate)` translates via the same `ANY ... SATISFIES ... END` mechanism as `.Any()` (EF
+Core itself expresses `.All(predicate)` as a negated `.Any(x => !predicate(x))`, so it needs no
+separate translation). `.Count(predicate)`/`.Count()` translate to a correlated
+`(SELECT RAW COUNT(*) FROM parentAlias.field AS alias [WHERE predicate])[0]` subquery.
+
+**`.Contains()` directly on an `OwnsMany` navigation is not supported** — not a limitation of this
+provider's SQL generation, but a crash inside EF Core's own core query-translation code
+(`RelationalSqlTranslatingExpressionVisitor.ParameterValueExtractor`) that reproduces for any
+relational provider once the owned collection's key is composite (owner key + declared key, EF
+Core's default for an owned type): it can't read the shadow foreign-key property's value off an
+arbitrary (tracked or untracked) `ContactMethod` instance to build the comparison, since a shadow
+property has no CLR getter to read from. `.Any(predicate)` (comparing individual properties, not
+the whole entity) is the supported alternative.
+
+`.Any(predicate)`/`.All(predicate)`/`.Count(predicate)` over a *nested* owned collection (one
+reached through another owned navigation, e.g. `c.ContactMethods.Any(m => m.Tags.Any(...))`) are
+not yet supported.
 
 Indexer/`.ElementAt()` access is also supported for a depth-1 `OwnsMany` navigation, translating
 to N1QL's native `parentAlias.field[index].propertyName` array subscript:

--- a/src/Couchbase.EntityFrameworkCore/Query/Internal/CouchbaseQuerySqlGenerator.cs
+++ b/src/Couchbase.EntityFrameworkCore/Query/Internal/CouchbaseQuerySqlGenerator.cs
@@ -686,11 +686,17 @@ public class CouchbaseQuerySqlGenerator : QuerySqlGenerator
             return scalarSubqueryExpression;
         }
 
-        // TryRenderOwnedElementAt returned false either because this isn't an owned-collection
-        // ElementAt shape at all (falls through to the generic rendering below, which is correct
-        // for e.g. Count()/Sum()/Max() subqueries), or because it IS one but with an unsupported
-        // composition on top (.Where(...)/.OrderBy(...) before .ElementAt(i) -- out of scope, see
-        // TryResolveOwnedElementAt's remarks). The latter must not fall through: VisitTable
+        if (TryRenderOwnedCollectionCount(scalarSubqueryExpression.Subquery))
+        {
+            return scalarSubqueryExpression;
+        }
+
+        // Neither of the above matched, either because this isn't an owned-collection subquery at
+        // all (falls through to the generic rendering below, which is correct for e.g.
+        // Sum()/Max() subqueries), or because it IS one but with an unsupported shape --
+        // .Where(...)/.OrderBy(...) before .ElementAt(i), or anything other than a plain
+        // .Count(predicate)-shaped COUNT(*) (out of scope, see TryResolveOwnedElementAt's and
+        // TryRenderOwnedCollectionCount's remarks). The latter must not fall through: VisitTable
         // renders an owned TableExpression as nothing (it's embedded JSON, not a real keyspace),
         // so the generic rendering below would silently produce an empty-FROM-clause N1QL parse
         // error instead of a clear translation-time failure.
@@ -698,8 +704,9 @@ public class CouchbaseQuerySqlGenerator : QuerySqlGenerator
             && TryGetOwnedEntityTypes(ownedTableCandidate, out _))
         {
             throw new NotSupportedException(
-                "Composing .Where(...)/.OrderBy(...) before an indexer/.ElementAt() access over an "
-                + "OwnsMany navigation is not supported.");
+                "This composition over an OwnsMany navigation is not supported (e.g. composing "
+                + ".Where(...)/.OrderBy(...) before an indexer/.ElementAt() access, or a "
+                + "non-Count() aggregate other than .Any()/.All(predicate)/.Count(predicate)).");
         }
 
         Sql.AppendLine("(");
@@ -711,6 +718,81 @@ public class CouchbaseQuerySqlGenerator : QuerySqlGenerator
         Sql.Append(")[0]");
 
         return scalarSubqueryExpression;
+    }
+
+    /// <summary>
+    /// Renders <c>(SELECT RAW COUNT(*) FROM parentAlias.field AS ownedAlias [WHERE
+    /// predicate])[0]</c> in place of the base class's generic correlated-subquery translation of
+    /// <c>.Count(predicate)</c> over a depth-1 <c>OwnsMany</c> navigation -- mirrors
+    /// <see cref="TryRenderOwnedCollectionAny"/>'s detect/strip/render pattern, using the same
+    /// bare-correlated-array-as-FROM-term shape already proven live for a scalar primitive
+    /// collection's <c>.Count</c> (<see cref="CouchbaseQueryableMethodTranslatingExpressionVisitor.TranslatePrimitiveCollection"/>),
+    /// just substituting the owned array field for the primitive one. The trailing <c>[0]</c>
+    /// unwrap matches every other scalar subquery this generator renders (see
+    /// <see cref="VisitScalarSubquery"/>'s remarks on N1QL's array-valued subquery-expression
+    /// semantics).
+    /// </summary>
+    private bool TryRenderOwnedCollectionCount(SelectExpression subquery)
+    {
+        if (subquery is not
+            {
+                Tables: [TableExpression ownedTable],
+                Projection: [{ Expression: SqlFunctionExpression { IsBuiltIn: true, Name: "COUNT" } }],
+                Orderings: [],
+                Offset: null,
+                Limit: null,
+                IsDistinct: false,
+            }
+            || !TryGetOwnedEntityTypes(ownedTable, out var ownedEntityTypes))
+        {
+            return false;
+        }
+
+        foreach (var candidate in ownedEntityTypes)
+        {
+            var ownership = candidate.FindOwnership();
+            if (ownership?.PrincipalToDependent == null)
+            {
+                continue;
+            }
+
+            if (!TryStripCorrelation(subquery.Predicate, ownedTable.Alias!, ownership, out var residual, out var parentAlias))
+            {
+                continue;
+            }
+
+            var fieldName = CouchbaseProjectionAliases.GetOwnedCollectionFieldName(ownership.PrincipalToDependent, _fieldNamingPolicy);
+            var helper = Dependencies.SqlGenerationHelper;
+
+            Sql.Append("(SELECT RAW COUNT(*) FROM ")
+                .Append(helper.DelimitIdentifier(parentAlias!))
+                .Append(".")
+                .Append(helper.DelimitIdentifier(fieldName))
+                .Append(" AS ")
+                .Append(helper.DelimitIdentifier(ownedTable.Alias!));
+
+            if (residual != null)
+            {
+                Sql.Append(" WHERE ");
+
+                var previous = _ownedAnyAlias;
+                _ownedAnyAlias = ownedTable.Alias;
+                try
+                {
+                    Visit(residual);
+                }
+                finally
+                {
+                    _ownedAnyAlias = previous;
+                }
+            }
+
+            Sql.Append(")[0]");
+
+            return true;
+        }
+
+        return false;
     }
 
     /// <summary>

--- a/tests/Couchbase.EntityFrameworkCore.IntegrationTests/Tests/OwnedTypeTests.cs
+++ b/tests/Couchbase.EntityFrameworkCore.IntegrationTests/Tests/OwnedTypeTests.cs
@@ -1297,4 +1297,83 @@ public class OwnedTypeTests(
 
         Assert.DoesNotContain(customers, c => c.CustomerId == 2);
     }
+
+    // -------------------------------------------------------------------------
+    // .All(predicate) / .Count(predicate) over a depth-1 OwnsMany navigation
+    //
+    // .All(predicate) needs no new production code -- EF Core translates it as the same
+    // NOT EXISTS(... WHERE NOT predicate) shape .Any(predicate) already produces, so it flows
+    // through the existing owned-collection detection for free. .Count(predicate) needed a new
+    // CouchbaseQuerySqlGenerator.TryRenderOwnedCollectionCount hook. Alice (1): [email, phone];
+    // Bob (2): [email] only; Carol (3): [email, phone] -- used to prove real inclusion/exclusion,
+    // not just that the generated SQL text looks right.
+    // -------------------------------------------------------------------------
+
+    [Fact]
+    public async Task OwnsMany_All_ReturnsOnlyCustomersWhereEveryContactMatches()
+    {
+        // Only Bob (2) has EVERY contact method matching "email" -- Alice and Carol each also
+        // have a "phone" contact method.
+        await using var ctx = fixture.GetDbContext();
+        var customers = await ctx.Customers
+            .Where(c => c.ContactMethods.All(cm => cm.Type == "email"))
+            .ToListAsync();
+
+        Assert.Single(customers);
+        Assert.Equal(2, customers[0].CustomerId);
+    }
+
+    [Fact]
+    public async Task OwnsMany_All_Negated_ReturnsOnlyCustomersWhereNotEveryContactMatches()
+    {
+        await using var ctx = fixture.GetDbContext();
+        var customers = await ctx.Customers
+            .Where(c => !c.ContactMethods.All(cm => cm.Type == "email"))
+            .ToListAsync();
+
+        Assert.Equal(2, customers.Count);
+        Assert.Contains(customers, c => c.CustomerId == 1);
+        Assert.Contains(customers, c => c.CustomerId == 3);
+    }
+
+    [Fact]
+    public async Task OwnsMany_CountWithPredicate_ReturnsOnlyMatchingCustomers()
+    {
+        await using var ctx = fixture.GetDbContext();
+        var customers = await ctx.Customers
+            .Where(c => c.ContactMethods.Count(cm => cm.Type == "phone") >= 1)
+            .ToListAsync();
+
+        Assert.Equal(2, customers.Count);
+        Assert.Contains(customers, c => c.CustomerId == 1);
+        Assert.Contains(customers, c => c.CustomerId == 3);
+        Assert.DoesNotContain(customers, c => c.CustomerId == 2);
+    }
+
+    [Fact]
+    public async Task OwnsMany_CountWithoutPredicate_ReturnsOnlyMatchingCustomers()
+    {
+        // Alice and Carol have 2 contact methods; Bob has only 1.
+        await using var ctx = fixture.GetDbContext();
+        var customers = await ctx.Customers
+            .Where(c => c.ContactMethods.Count() > 1)
+            .ToListAsync();
+
+        Assert.Equal(2, customers.Count);
+        Assert.Contains(customers, c => c.CustomerId == 1);
+        Assert.Contains(customers, c => c.CustomerId == 3);
+        Assert.DoesNotContain(customers, c => c.CustomerId == 2);
+    }
+
+    [Fact]
+    public async Task OwnsMany_CountWithPredicate_CombinesWithOtherWhereConditions()
+    {
+        await using var ctx = fixture.GetDbContext();
+        var customers = await ctx.Customers
+            .Where(c => c.Name == "Alice" && c.ContactMethods.Count(cm => cm.Type == "phone") >= 1)
+            .ToListAsync();
+
+        Assert.Single(customers);
+        Assert.Equal(1, customers[0].CustomerId);
+    }
 }

--- a/tests/Couchbase.EntityFrameworkCore.UnitTests/Couchbase/EntityFrameworkCore/Query/OwnedCollectionAllCountTests.cs
+++ b/tests/Couchbase.EntityFrameworkCore.UnitTests/Couchbase/EntityFrameworkCore/Query/OwnedCollectionAllCountTests.cs
@@ -1,0 +1,213 @@
+using System.Text.Json;
+using Couchbase.EntityFrameworkCore.Extensions;
+using Microsoft.EntityFrameworkCore;
+using Xunit;
+
+namespace Couchbase.EntityFrameworkCore.UnitTests.Couchbase.EntityFrameworkCore.Query;
+
+/// <summary>
+/// Verifies <c>.All(predicate)</c> and <c>.Count(predicate)</c> over a depth-1 <c>OwnsMany</c>
+/// navigation.
+/// <para>
+/// <c>.All(predicate)</c> needs no new production code: EF Core's own
+/// <c>RelationalQueryableMethodTranslatingExpressionVisitor.TranslateAll</c> translates it as
+/// <c>NOT EXISTS(... WHERE NOT predicate)</c> -- the exact same <see cref="Microsoft.EntityFrameworkCore.Query.SqlExpressions.ExistsExpression"/>
+/// shape <c>.Any(predicate)</c> already produces, so it flows through the existing
+/// <c>CouchbaseQuerySqlGenerator.GenerateExists</c> owned-collection detection for free.
+/// </para>
+/// <para>
+/// <c>.Count(predicate)</c> needed a new <c>CouchbaseQuerySqlGenerator.TryRenderOwnedCollectionCount</c>
+/// hook in <c>VisitScalarSubquery</c>, rendering
+/// <c>(SELECT RAW COUNT(*) FROM parentAlias.field AS ownedAlias [WHERE predicate])[0]</c> --
+/// mirroring the same bare-correlated-array-as-FROM-term shape already proven live for a scalar
+/// primitive collection's <c>.Count</c>.
+/// </para>
+/// </summary>
+public class OwnedCollectionAllCountTests
+{
+    private class Customer
+    {
+        public int CustomerId { get; set; }
+        public string Name { get; set; } = "";
+        public List<ContactMethod> ContactMethods { get; set; } = [];
+    }
+
+    private class ContactMethod
+    {
+        public int Id { get; set; }
+        public string Type { get; set; } = "";
+    }
+
+    private class CustomerContext(DbContextOptions<CustomerContext> options) : DbContext(options)
+    {
+        public DbSet<Customer> Customers { get; set; } = null!;
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            modelBuilder.Entity<Customer>(b =>
+            {
+                b.ToCouchbaseCollection("bucket", "scope", "customer");
+                b.HasKey(c => c.CustomerId);
+                b.OwnsMany(c => c.ContactMethods, cm => cm.HasKey(m => m.Id));
+            });
+        }
+    }
+
+    private static CustomerContext CreateContext(JsonNamingPolicy? fieldNamingPolicy = null)
+    {
+        var clusterOptions = new global::Couchbase.ClusterOptions()
+            .WithConnectionString("couchbase://localhost")
+            .WithPasswordAuthentication("Administrator", "password");
+        var builder = new DbContextOptionsBuilder<CustomerContext>();
+        builder.UseCouchbaseProvider(clusterOptions, o =>
+        {
+            if (fieldNamingPolicy != null)
+            {
+                o.FieldNamingPolicy = fieldNamingPolicy;
+            }
+        });
+        return new CustomerContext(builder.Options);
+    }
+
+    // -------------------------------------------------------------------------
+    // .All(predicate)
+    // -------------------------------------------------------------------------
+
+    [Fact]
+    public void All_TranslatesToNegatedAnySatisfies_NotExists()
+    {
+        using var ctx = CreateContext();
+        var sql = ctx.Customers.Where(c => c.ContactMethods.All(m => m.Type == "email")).ToQueryString();
+
+        Assert.Contains("NOT (ANY `c` IN `b`.`contactMethods` SATISFIES `c`.`type` <> 'email' END)", sql);
+        Assert.DoesNotContain("EXISTS", sql, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void All_NonDefaultFieldNamingPolicy_AppliesToArrayFieldAndPropertyName()
+    {
+        using var ctx = CreateContext(JsonNamingPolicy.SnakeCaseLower);
+        var sql = ctx.Customers.Where(c => c.ContactMethods.All(m => m.Type == "email")).ToQueryString();
+
+        Assert.Contains("`b`.`contact_methods`", sql);
+        Assert.Contains("`c`.`type`", sql);
+    }
+
+    // -------------------------------------------------------------------------
+    // .Count(predicate)
+    // -------------------------------------------------------------------------
+
+    [Fact]
+    public void CountWithPredicate_TranslatesToCorrelatedCountSubquery()
+    {
+        using var ctx = CreateContext();
+        var sql = ctx.Customers.Where(c => c.ContactMethods.Count(m => m.Type == "email") > 1).ToQueryString();
+
+        Assert.Contains(
+            "(SELECT RAW COUNT(*) FROM `b`.`contactMethods` AS `c` WHERE `c`.`type` = 'email')[0] > 1", sql);
+    }
+
+    [Fact]
+    public void CountWithoutPredicate_OmitsWhereClause()
+    {
+        using var ctx = CreateContext();
+        var sql = ctx.Customers.Where(c => c.ContactMethods.Count() > 1).ToQueryString();
+
+        Assert.Contains("(SELECT RAW COUNT(*) FROM `b`.`contactMethods` AS `c`)[0] > 1", sql);
+        Assert.DoesNotContain("WHERE `c`", sql);
+    }
+
+    [Fact]
+    public void Count_NonDefaultFieldNamingPolicy_AppliesToArrayFieldAndPropertyName()
+    {
+        using var ctx = CreateContext(JsonNamingPolicy.SnakeCaseLower);
+        var sql = ctx.Customers.Where(c => c.ContactMethods.Count(m => m.Type == "email") > 1).ToQueryString();
+
+        Assert.Contains("`b`.`contact_methods`", sql);
+        Assert.Contains("`c`.`type` = 'email'", sql);
+    }
+
+    [Fact]
+    public void OtherAggregateOverOwnedCollection_FailsTranslation_NotSilentlyInvalidSql()
+    {
+        // .Sum()/.Max()/.Min()/.Average() over an OwnsMany navigation are out of scope -- only
+        // .Any()/.All(predicate)/.Count(predicate)/indexer/.ElementAt() are supported. Must throw
+        // a clear NotSupportedException rather than silently falling through to the generic
+        // scalar-subquery rendering, which would produce an empty-FROM-clause N1QL parse error
+        // (VisitTable renders the owned TableExpression as nothing).
+        using var ctx = CreateContext();
+        Assert.Throws<NotSupportedException>(
+            () => ctx.Customers.Where(c => c.ContactMethods.Sum(m => m.Id) > 1).ToQueryString());
+    }
+
+    // -------------------------------------------------------------------------
+    // Regression: OwnsMany item type that itself table-splits a nested OwnsOne -- same concern
+    // OwnedCollectionAnyTests/OwnedCollectionElementAtTests guard for their own operators.
+    // -------------------------------------------------------------------------
+
+    private class RichCustomer
+    {
+        public int CustomerId { get; set; }
+        public List<RichContactMethod> ContactMethods { get; set; } = [];
+    }
+
+    private class RichContactMethod
+    {
+        public int Id { get; set; }
+        public string Type { get; set; } = "";
+        public ContactLabel? Label { get; set; }
+    }
+
+    private class ContactLabel
+    {
+        public string? DisplayName { get; set; }
+    }
+
+    private class RichCustomerContext(DbContextOptions<RichCustomerContext> options) : DbContext(options)
+    {
+        public DbSet<RichCustomer> Customers { get; set; } = null!;
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            modelBuilder.Entity<RichCustomer>(b =>
+            {
+                b.ToCouchbaseCollection("bucket", "scope", "customer");
+                b.HasKey(c => c.CustomerId);
+                b.OwnsMany(c => c.ContactMethods, cm =>
+                {
+                    cm.HasKey(m => m.Id);
+                    cm.OwnsOne(m => m.Label);
+                });
+            });
+        }
+    }
+
+    private static RichCustomerContext CreateRichContext()
+    {
+        var clusterOptions = new global::Couchbase.ClusterOptions()
+            .WithConnectionString("couchbase://localhost")
+            .WithPasswordAuthentication("Administrator", "password");
+        var builder = new DbContextOptionsBuilder<RichCustomerContext>();
+        builder.UseCouchbaseProvider(clusterOptions);
+        return new RichCustomerContext(builder.Options);
+    }
+
+    [Fact]
+    public void ItemTypeWithNestedOwnsOne_All_StillTranslatesToNegatedAnySatisfies()
+    {
+        using var ctx = CreateRichContext();
+        var sql = ctx.Customers.Where(c => c.ContactMethods.All(m => m.Type == "phone")).ToQueryString();
+
+        Assert.Contains("NOT (ANY `r` IN `b`.`contactMethods` SATISFIES `r`.`type` <> 'phone' END)", sql);
+    }
+
+    [Fact]
+    public void ItemTypeWithNestedOwnsOne_CountWithPredicate_StillTranslatesToCorrelatedCountSubquery()
+    {
+        using var ctx = CreateRichContext();
+        var sql = ctx.Customers.Where(c => c.ContactMethods.Count(m => m.Type == "phone") > 0).ToQueryString();
+
+        Assert.Contains(
+            "(SELECT RAW COUNT(*) FROM `b`.`contactMethods` AS `r` WHERE `r`.`type` = 'phone')[0] > 0", sql);
+    }
+}


### PR DESCRIPTION
…ations

.All(predicate) needed no new production code: EF Core translates it as the same NOT EXISTS(... WHERE NOT predicate) shape .Any(predicate) already handles, so it flows through the existing owned-collection detection for free.

.Count(predicate)/.Count() needed a new TryRenderOwnedCollectionCount hook in CouchbaseQuerySqlGenerator.VisitScalarSubquery, rendering (SELECT RAW COUNT(*) FROM parentAlias.field AS alias [WHERE predicate])[0]
- mirroring .Any(predicate)'s detect/strip/render pattern. Any other aggregate composed over an owned collection (.Sum(), .Max(), etc.) now throws NotSupportedException instead of silently producing an empty-FROM-clause N1QL parse error.

.Contains() directly on an OwnsMany navigation remains unsupported: a SQL-text-only check first suggested it already worked, but actually executing the query surfaces a crash entirely inside EF Core's own core query-translation code (RelationalSqlTranslatingExpressionVisitor.ParameterValueExtractor can't read a shadow FK property off an owned-type instance) - not something this provider's SQL generator can fix. Documented as a known

EF Core-level limitation, with .Any(predicate) as the alternative. Verified: 1001/1001 unit tests, full live integration suite green across two runs (324/324 both times, no flakiness).