### PR TITLE
Support nested (depth>1) OwnsMany .Any()/.All()/.Count(predicate)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,18 @@ and this project aims to follow [Semantic Versioning](https://semver.org/spec/v2
 
 ### Added
 
+- **`.Any(predicate)`/`.All(predicate)`/`.Count(predicate)` over a *nested* `OwnsMany` navigation**
+  (reached through another owned navigation, e.g. `c.ContactMethods.Any(m => m.Tags.Any(t =>
+  t.Key == "priority"))`, at any depth) — confirmed to need no new production code: the existing
+  owned-collection detection is written generically per-owned-type and alias-parameterized (not
+  hardcoded to the top-level navigation), so it naturally recurses for the inner shape. An indexer
+  access can also appear as the innermost predicate (e.g. `c.ContactMethods.Any(m => m.Tags[0].Key
+  == "priority")`). A *direct chained* indexer through two levels with no `.Any()`/`.All()`/
+  `.Count()` wrapping it (e.g. `customer.ContactMethods[0].Tags[0].Key`) is confirmed **not**
+  fixable at this provider's layer — it fails inside EF Core's own core query-translation code
+  before any Couchbase-specific code runs, the same class of limitation as `.Contains()` below;
+  use `.Any(predicate)` with an inner indexer instead. See
+  [Modeling — OwnsMany](docs/modeling.md#ownsmany).
 - **`.All(predicate)` and `.Count(predicate)` over a depth-1 `OwnsMany` navigation.**
   `.All(predicate)` needed no new production code — EF Core translates it as the same
   `NOT EXISTS(... WHERE NOT predicate)` shape `.Any(predicate)` already produces, so it flows

--- a/docs/limitations.md
+++ b/docs/limitations.md
@@ -70,10 +70,11 @@ The Couchbase SDK is asynchronous, so the synchronous EF Core code paths throw `
   `OwnsMany`) or as related entities. Plain CLR objects nested on an entity that are
   not mapped this way are ignored by EF Core.
 * **`.Any(predicate)`/`.All(predicate)`/`.Count(predicate)` over an `OwnsMany` navigation are
-  supported only one level deep** (a collection declared directly on the entity being queried) --
-  the *nested* case (reached through another owned navigation, e.g.
-  `c.ContactMethods.Any(m => m.Tags.Any(...))`) is not yet supported. See
-  [Modeling — OwnsMany](modeling.md#ownsmany).
+  supported at any nesting depth** — both a collection declared directly on the entity being
+  queried and the *nested* case, reached through another owned navigation (e.g.
+  `c.ContactMethods.Any(m => m.Tags.Any(t => t.Key == "priority"))`, or deeper). An indexer access
+  can also appear as the innermost predicate (e.g. `c.ContactMethods.Any(m => m.Tags[0].Key ==
+  "priority")`). See [Modeling — OwnsMany](modeling.md#ownsmany).
 * **`.Contains()` directly on an `OwnsMany` navigation is not supported** — this is a crash inside
   EF Core's own core query-translation code, not a gap in this provider's SQL generation, and
   would reproduce for any relational provider once the owned collection's key is composite (the
@@ -89,8 +90,13 @@ The Couchbase SDK is asynchronous, so the synchronous EF Core code paths throw `
 * **Indexer/`.ElementAt()` over a depth-1 `OwnsMany` navigation** (e.g.
   `customer.ContactMethods[0].Type`) has the same `.ElementAtOrDefault()`-like out-of-range
   behavior and the same `.Where(...).ElementAt(...)`-composition limitation as a primitive
-  collection's indexer. Indexing into a scalar collection *nested inside* an owned item (e.g.
-  `customer.ContactMethods[0].Tags[0]`) is not yet supported. See
+  collection's indexer.
+* **A direct chained indexer through two levels of `OwnsMany` is not supported** (e.g.
+  `customer.ContactMethods[0].Tags[0].Key`) — this is a crash inside EF Core's own core
+  query-translation code (`InvalidOperationException`, "could not be translated"), not a gap in
+  this provider's SQL generation, the same class of limitation as `.Contains()` over an `OwnsMany`
+  navigation above. Use `.Any(predicate)` with an inner indexer instead (e.g.
+  `customer.ContactMethods.Any(m => m.Tags[0].Key == "priority")`), which is fully supported. See
   [Modeling — OwnsMany](modeling.md#ownsmany).
 
 See also [Querying](Queries.md) and [Configuration](configuration.md).

--- a/docs/modeling.md
+++ b/docs/modeling.md
@@ -349,9 +349,19 @@ arbitrary (tracked or untracked) `ContactMethod` instance to build the compariso
 property has no CLR getter to read from. `.Any(predicate)` (comparing individual properties, not
 the whole entity) is the supported alternative.
 
-`.Any(predicate)`/`.All(predicate)`/`.Count(predicate)` over a *nested* owned collection (one
-reached through another owned navigation, e.g. `c.ContactMethods.Any(m => m.Tags.Any(...))`) are
-not yet supported.
+`.Any(predicate)`/`.All(predicate)`/`.Count(predicate)` also work when the target collection is
+reached through *another* owned navigation (nested, depth > 1), e.g.:
+
+```csharp
+var withPriorityTag = await context.Customers
+    .Where(c => c.ContactMethods.Any(m => m.Tags.Any(t => t.Key == "priority")))
+    .ToListAsync();
+```
+
+This needs no special-cased translation: each level's `ANY ... SATISFIES ... END` (or correlated
+`COUNT` subquery) is rendered relative to the enclosing level's own array alias, so the same
+mechanism just recurses naturally to any depth. An indexer access can also appear as the
+innermost predicate, e.g. `c.ContactMethods.Any(m => m.Tags[0].Key == "priority")`.
 
 Indexer/`.ElementAt()` access is also supported for a depth-1 `OwnsMany` navigation, translating
 to N1QL's native `parentAlias.field[index].propertyName` array subscript:
@@ -364,9 +374,12 @@ var customersWithEmailFirst = await context.Customers
 
 As with a scalar [primitive collection](#primitive-collections)'s indexer, this always behaves
 like `.ElementAtOrDefault()` — an out-of-range index is excluded/returns default rather than
-throwing. `.Where(...).ElementAt(...)` composed before the index, and indexing into a scalar
-collection nested *inside* an owned item (e.g. `customer.ContactMethods[0].Tags[0]`), are not yet
-supported.
+throwing. `.Where(...).ElementAt(...)` composed before the index is not supported. **A direct
+chained indexer through two levels of `OwnsMany`** (e.g. `customer.ContactMethods[0].Tags[0].Key`,
+as opposed to an indexer appearing inside a `.Any(predicate)` as shown above) **is not
+supported** — this fails inside EF Core's own core query-translation code before any
+Couchbase-specific code runs, the same class of limitation as `.Contains()` above. Use
+`.Any(predicate)` with an inner indexer instead.
 
 ### Field-backed access
 

--- a/tests/Couchbase.EntityFrameworkCore.IntegrationTests/Tests/OwnedTypeTests.cs
+++ b/tests/Couchbase.EntityFrameworkCore.IntegrationTests/Tests/OwnedTypeTests.cs
@@ -1376,4 +1376,98 @@ public class OwnedTypeTests(
         Assert.Single(customers);
         Assert.Equal(1, customers[0].CustomerId);
     }
+
+    // -------------------------------------------------------------------------
+    // .Any()/.All()/.Count(predicate)/indexer through a collection reached via ANOTHER owned
+    // navigation (depth > 1), e.g. customer.ContactMethods.Any(cm => cm.Tags.Any(...)).
+    //
+    // None of this needed new production code -- CouchbaseQuerySqlGenerator's owned-collection
+    // detection (TryGetOwnedEntityTypes/TryStripCorrelation) is written generically per-owned-type
+    // and alias-parameterized, so Visit(residual) naturally recurses back into the same logic for
+    // the inner shape. Only Carol (3) has any ContactMethod with a Tags entry at all: her "email"
+    // method has Tags [{Key="priority", Val="high", Audits=[...]}, {Key="verified", Val="true"}],
+    // her "phone" method has Tags=[]. Alice (1) and Bob (2) have Tags=[] on every ContactMethod.
+    // -------------------------------------------------------------------------
+
+    [Fact]
+    public async Task OwnsMany_NestedAny_ReturnsOnlyCustomerWithMatchingNestedTag()
+    {
+        await using var ctx = fixture.GetDbContext();
+        var customers = await ctx.Customers
+            .Where(c => c.ContactMethods.Any(cm => cm.Tags.Any(t => t.Key == "priority")))
+            .ToListAsync();
+
+        Assert.Single(customers);
+        Assert.Equal(3, customers[0].CustomerId);
+    }
+
+    [Fact]
+    public async Task OwnsMany_NestedAny_Negated_ExcludesCustomerWithMatchingNestedTag()
+    {
+        await using var ctx = fixture.GetDbContext();
+        var customers = await ctx.Customers
+            .Where(c => !c.ContactMethods.Any(cm => cm.Tags.Any(t => t.Key == "priority")))
+            .ToListAsync();
+
+        Assert.Equal(2, customers.Count);
+        Assert.Contains(customers, c => c.CustomerId == 1);
+        Assert.Contains(customers, c => c.CustomerId == 2);
+        Assert.DoesNotContain(customers, c => c.CustomerId == 3);
+    }
+
+    [Fact]
+    public async Task OwnsMany_NestedCountWithPredicate_ReturnsOnlyMatchingCustomer()
+    {
+        await using var ctx = fixture.GetDbContext();
+        var customers = await ctx.Customers
+            .Where(c => c.ContactMethods.Any(cm => cm.Tags.Count(t => t.Key == "priority") > 0))
+            .ToListAsync();
+
+        Assert.Single(customers);
+        Assert.Equal(3, customers[0].CustomerId);
+    }
+
+    [Fact]
+    public async Task OwnsMany_OuterCountWithNestedAnyPredicate_ReturnsOnlyMatchingCustomer()
+    {
+        // Counts ContactMethods that themselves have a matching nested Tag -- only Carol's
+        // "email" method qualifies, so the count is exactly 1 for Carol and 0 for everyone else.
+        await using var ctx = fixture.GetDbContext();
+        var customers = await ctx.Customers
+            .Where(c => c.ContactMethods.Count(cm => cm.Tags.Any(t => t.Key == "priority")) >= 1)
+            .ToListAsync();
+
+        Assert.Single(customers);
+        Assert.Equal(3, customers[0].CustomerId);
+    }
+
+    [Fact]
+    public async Task OwnsMany_NestedAnyWithInnerIndexer_ReturnsOnlyMatchingCustomer()
+    {
+        // .Any() wrapping an inner indexer access (cm.Tags[0]) rather than a further .Any()/.All().
+        // Empty Tags arrays (Alice/Bob, and Carol's "phone" method) must not throw -- N1QL's
+        // array-subscript on an out-of-range/empty array evaluates to MISSING/NULL, which safely
+        // compares false rather than erroring server-side.
+        await using var ctx = fixture.GetDbContext();
+        var customers = await ctx.Customers
+            .Where(c => c.ContactMethods.Any(cm => cm.Tags[0].Key == "priority"))
+            .ToListAsync();
+
+        Assert.Single(customers);
+        Assert.Equal(3, customers[0].CustomerId);
+    }
+
+    [Fact]
+    public async Task OwnsMany_DoublyNestedAny_Depth3ThroughAudits_ReturnsOnlyMatchingCustomer()
+    {
+        // Three levels of owned-collection nesting: Customer -> ContactMethods -> Tags -> Audits.
+        // Only Carol's "priority" tag has an audit with Note == "confirmed".
+        await using var ctx = fixture.GetDbContext();
+        var customers = await ctx.Customers
+            .Where(c => c.ContactMethods.Any(cm => cm.Tags.Any(t => t.Audits.Any(a => a.Note == "confirmed"))))
+            .ToListAsync();
+
+        Assert.Single(customers);
+        Assert.Equal(3, customers[0].CustomerId);
+    }
 }

--- a/tests/Couchbase.EntityFrameworkCore.UnitTests/Couchbase/EntityFrameworkCore/Query/OwnedCollectionNestedTests.cs
+++ b/tests/Couchbase.EntityFrameworkCore.UnitTests/Couchbase/EntityFrameworkCore/Query/OwnedCollectionNestedTests.cs
@@ -1,0 +1,231 @@
+using Couchbase.EntityFrameworkCore.Extensions;
+using Microsoft.EntityFrameworkCore;
+using Xunit;
+
+namespace Couchbase.EntityFrameworkCore.UnitTests.Couchbase.EntityFrameworkCore.Query;
+
+/// <summary>
+/// Verifies <c>.Any(predicate)</c>/<c>.All(predicate)</c>/<c>.Count(predicate)</c> and an
+/// indexer access, when the target <c>OwnsMany</c> collection is reached through ANOTHER owned
+/// navigation (depth &gt; 1, e.g. <c>customer.ContactMethods.Any(cm =&gt; cm.Tags.Any(...))</c>).
+/// <para>
+/// None of this needed new production code: <c>CouchbaseQuerySqlGenerator.GenerateExists</c>'s
+/// <c>Visit(residual)</c> call and <c>TryRenderOwnedCollectionCount</c>'s equivalent naturally
+/// recurse back into the same owned-collection detection logic for the inner shape, because
+/// <c>TryGetOwnedEntityTypes</c>/<c>TryStripCorrelation</c> are written generically per-owned-type
+/// (not hardcoded to the top-level navigation) and are alias-parameterized rather than
+/// identity-tied to a specific table alias.
+/// </para>
+/// <para>
+/// A genuinely DIFFERENT shape -- a direct chained indexer with no <c>.Any()</c>/<c>.All()</c>/
+/// <c>.Count()</c> wrapping it (e.g. <c>c.ContactMethods[0].Tags[0].Key</c>) -- fails inside EF
+/// Core's own core query-translation layer, before any Couchbase provider code runs. See
+/// <see cref="OwnedCollectionChainedIndexerTests"/> for that (documented, not fixable here) case.
+/// </para>
+/// </summary>
+public class OwnedCollectionNestedTests
+{
+    private class Customer
+    {
+        public int CustomerId { get; set; }
+        public List<ContactMethod> ContactMethods { get; set; } = [];
+    }
+
+    private class ContactMethod
+    {
+        public int Id { get; set; }
+        public string Type { get; set; } = "";
+        public List<ContactTag> Tags { get; set; } = [];
+    }
+
+    private class ContactTag
+    {
+        public int Id { get; set; }
+        public string Key { get; set; } = "";
+    }
+
+    private class CustomerContext(DbContextOptions<CustomerContext> options) : DbContext(options)
+    {
+        public DbSet<Customer> Customers { get; set; } = null!;
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            modelBuilder.Entity<Customer>(b =>
+            {
+                b.ToCouchbaseCollection("bucket", "scope", "customer");
+                b.HasKey(c => c.CustomerId);
+                b.OwnsMany(c => c.ContactMethods, cm =>
+                {
+                    cm.HasKey(m => m.Id);
+                    cm.OwnsMany(m => m.Tags, t => t.HasKey(x => x.Id));
+                });
+            });
+        }
+    }
+
+    private static CustomerContext CreateContext()
+    {
+        var clusterOptions = new global::Couchbase.ClusterOptions()
+            .WithConnectionString("couchbase://localhost")
+            .WithPasswordAuthentication("Administrator", "password");
+        var builder = new DbContextOptionsBuilder<CustomerContext>();
+        builder.UseCouchbaseProvider(clusterOptions);
+        return new CustomerContext(builder.Options);
+    }
+
+    [Fact]
+    public void NestedAny_TranslatesToNestedAnySatisfies()
+    {
+        using var ctx = CreateContext();
+        var sql = ctx.Customers
+            .Where(c => c.ContactMethods.Any(cm => cm.Tags.Any(t => t.Key == "priority")))
+            .ToQueryString();
+
+        Assert.Contains(
+            "WHERE ANY `c` IN `b`.`contactMethods` SATISFIES ANY `c0` IN `c`.`tags` SATISFIES `c0`.`key` = 'priority' END END",
+            sql);
+    }
+
+    [Fact]
+    public void NestedAll_TranslatesToNestedNegatedAnySatisfies()
+    {
+        using var ctx = CreateContext();
+        var sql = ctx.Customers
+            .Where(c => c.ContactMethods.Any(cm => cm.Tags.All(t => t.Key == "priority")))
+            .ToQueryString();
+
+        Assert.Contains(
+            "WHERE ANY `c` IN `b`.`contactMethods` SATISFIES NOT (ANY `c0` IN `c`.`tags` SATISFIES `c0`.`key` <> 'priority' END) END",
+            sql);
+    }
+
+    [Fact]
+    public void NestedCountWithPredicate_TranslatesToNestedCorrelatedCountSubquery()
+    {
+        using var ctx = CreateContext();
+        var sql = ctx.Customers
+            .Where(c => c.ContactMethods.Any(cm => cm.Tags.Count(t => t.Key == "priority") > 0))
+            .ToQueryString();
+
+        Assert.Contains(
+            "WHERE ANY `c` IN `b`.`contactMethods` SATISFIES (SELECT RAW COUNT(*) FROM `c`.`tags` AS `c0` WHERE `c0`.`key` = 'priority')[0] > 0 END",
+            sql);
+    }
+
+    [Fact]
+    public void OuterAll_InnerAny_TranslatesToNestedNegation()
+    {
+        using var ctx = CreateContext();
+        var sql = ctx.Customers
+            .Where(c => c.ContactMethods.All(cm => cm.Tags.Any(t => t.Key == "priority")))
+            .ToQueryString();
+
+        Assert.Contains(
+            "WHERE NOT (ANY `c` IN `b`.`contactMethods` SATISFIES NOT (ANY `c0` IN `c`.`tags` SATISFIES `c0`.`key` = 'priority' END) END)",
+            sql);
+    }
+
+    [Fact]
+    public void OuterAny_InnerIndexer_TranslatesToArraySubscriptInsideSatisfies()
+    {
+        using var ctx = CreateContext();
+        var sql = ctx.Customers
+            .Where(c => c.ContactMethods.Any(cm => cm.Tags[0].Key == "priority"))
+            .ToQueryString();
+
+        Assert.Contains(
+            "WHERE ANY `c` IN `b`.`contactMethods` SATISFIES `c`.`tags`[0].`key` = 'priority' END",
+            sql);
+    }
+
+    [Fact]
+    public void NegatedNestedAny_TranslatesToNotWrappingNestedAnySatisfies()
+    {
+        using var ctx = CreateContext();
+        var sql = ctx.Customers
+            .Where(c => !c.ContactMethods.Any(cm => cm.Tags.Any(t => t.Key == "priority")))
+            .ToQueryString();
+
+        Assert.Contains(
+            "WHERE NOT (ANY `c` IN `b`.`contactMethods` SATISFIES ANY `c0` IN `c`.`tags` SATISFIES `c0`.`key` = 'priority' END END)",
+            sql);
+    }
+}
+
+/// <summary>
+/// A direct chained indexer through two levels of <c>OwnsMany</c> with no
+/// <c>.Any()</c>/<c>.All()</c>/<c>.Count()</c> wrapping it (e.g.
+/// <c>c.ContactMethods[0].Tags[0].Key</c>) is a genuinely different shape from
+/// <see cref="OwnedCollectionNestedTests"/>'s cases: it fails inside EF Core's own core
+/// query-translation layer with <see cref="InvalidOperationException"/>, before any Couchbase
+/// provider code runs -- the same class of EF-Core-level limitation already documented for
+/// <c>.Contains()</c> over an <c>OwnsMany</c> navigation. Not fixable in this provider's SQL
+/// generator. <c>.Any(predicate)</c> wrapping an inner indexer (see
+/// <see cref="OwnedCollectionNestedTests.OuterAny_InnerIndexer_TranslatesToArraySubscriptInsideSatisfies"/>)
+/// is the supported alternative.
+/// </summary>
+public class OwnedCollectionChainedIndexerTests
+{
+    private class Customer
+    {
+        public int CustomerId { get; set; }
+        public List<ContactMethod> ContactMethods { get; set; } = [];
+    }
+
+    private class ContactMethod
+    {
+        public int Id { get; set; }
+        public List<ContactTag> Tags { get; set; } = [];
+    }
+
+    private class ContactTag
+    {
+        public int Id { get; set; }
+        public string Key { get; set; } = "";
+    }
+
+    private class CustomerContext(DbContextOptions<CustomerContext> options) : DbContext(options)
+    {
+        public DbSet<Customer> Customers { get; set; } = null!;
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            modelBuilder.Entity<Customer>(b =>
+            {
+                b.ToCouchbaseCollection("bucket", "scope", "customer");
+                b.HasKey(c => c.CustomerId);
+                b.OwnsMany(c => c.ContactMethods, cm =>
+                {
+                    cm.HasKey(m => m.Id);
+                    cm.OwnsMany(m => m.Tags, t => t.HasKey(x => x.Id));
+                });
+            });
+        }
+    }
+
+    private static CustomerContext CreateContext()
+    {
+        var clusterOptions = new global::Couchbase.ClusterOptions()
+            .WithConnectionString("couchbase://localhost")
+            .WithPasswordAuthentication("Administrator", "password");
+        var builder = new DbContextOptionsBuilder<CustomerContext>();
+        builder.UseCouchbaseProvider(clusterOptions);
+        return new CustomerContext(builder.Options);
+    }
+
+    [Fact]
+    public void ChainedIndexerInWhere_FailsEfCoreTranslation_NotSilentlyWrongSql()
+    {
+        using var ctx = CreateContext();
+        Assert.Throws<InvalidOperationException>(
+            () => ctx.Customers.Where(c => c.ContactMethods[0].Tags[0].Key == "priority").ToQueryString());
+    }
+
+    [Fact]
+    public void ChainedIndexerInSelect_FailsEfCoreTranslation_NotSilentlyWrongSql()
+    {
+        using var ctx = CreateContext();
+        Assert.Throws<InvalidOperationException>(
+            () => ctx.Customers.Select(c => c.ContactMethods[0].Tags[0].Key).ToQueryString());
+    }
+}


### PR DESCRIPTION
.Any(predicate)/.All(predicate)/.Count(predicate) over an OwnsMany navigation reached through another owned navigation (e.g. c.ContactMethods.Any(cm => cm.Tags.Any(t => t.Key == "priority"))) now work at any nesting depth. This needed no new production code — the existing owned-collection detection in CouchbaseQuerySqlGenerator is written generically per-owned-type and alias-parameterized, so it naturally recurses for the inner shape. An indexer can also appear as the innermost predicate (cm.Tags[0].Key == "...").

A direct chained double-indexer with no .Any()/.All()/.Count() wrapping it (c.ContactMethods[0].Tags[0].Key) fails inside EF Core's own core query-translation layer before any provider code runs — the same class of limitation as .Contains() over an OwnsMany navigation. Documented as unsupported; .Any(predicate) with an inner indexer is the recommended alternative.

Add unit SQL-generation tests and live integration tests (using the existing depth-3 Carol/ContactMethods/Tags/Audits fixture data, including a 3-level-deep .Any() through Audits) covering both the newly-confirmed nested support and the chained-indexer limitation. Update docs/limitations.md, docs/modeling.md, and CHANGELOG.md