### PR TITLE
Add Unix-millis DateTime storage mode ([UnixMillisDateTime])

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,20 @@ and this project aims to follow [Semantic Versioning](https://semver.org/spec/v2
 
 ### Added
 
+- **`[UnixMillisDateTime]`/`HasUnixMillisDateTime` — Unix-millis `DateTime` storage mode.** Stores a
+  `DateTime` property as Unix epoch milliseconds (a JSON `NUMBER`) instead of this provider's
+  default ISO-8601 string, for data that already uses that convention. Attaches a
+  `ValueConverter<DateTime, long>` via EF Core's own standard `HasConversion` mechanism — composed
+  with the existing `typeof(long)` -> `LongTypeMapping("NUMBER")` entry with no new type-mapping
+  class or `FindMapping(IProperty)` override needed (confirmed via `.ToQueryString()` spike:
+  `instance.TypeMapping` on a converted property already resolves correctly through EF Core's own
+  generic converter-composition machinery). `.Year`/`.Month`/etc./`.Date`/`Add*` translate to
+  N1QL's `DATE_PART_MILLIS`/`DATE_TRUNC_MILLIS`/`DATE_ADD_MILLIS` instead of the `_STR` family.
+  Confirmed structural limitation, not fixable via smarter type propagation: comparing a
+  millis-mapped property directly against `DateTime.UtcNow`/`.Now`/`.Today` now throws a clear
+  `NotSupportedException` at query-translation time (previously would have silently compared a
+  `NUMBER` against a string) — capture the value into a local variable before the query instead.
+  See [Unix-millis DateTime storage](docs/configuration.md#unix-millis-datetime-storage).
 - **`.Any(predicate)`/`.All(predicate)`/`.Count(predicate)` over a *nested* `OwnsMany` navigation**
   (reached through another owned navigation, e.g. `c.ContactMethods.Any(m => m.Tags.Any(t =>
   t.Key == "priority"))`, at any depth) — confirmed to need no new production code: the existing

--- a/docs/Queries.md
+++ b/docs/Queries.md
@@ -166,6 +166,14 @@ omitted when milliseconds are exactly zero, e.g. `2026-03-14T00:00:00Z`), but is
 your data uses a different string convention — see
 [DateTime string format](configuration.md#datetime-string-format).
 
+A `DateTime` property marked
+[`[UnixMillisDateTime]`](configuration.md#unix-millis-datetime-storage) is stored as a JSON
+`NUMBER` (Unix epoch milliseconds) instead of an ISO-8601 string, and its `.Year`/`.Month`/etc./
+`.Date`/`Add*` members instead translate to N1QL's `_MILLIS` date-function family
+(`DATE_PART_MILLIS`/`DATE_TRUNC_MILLIS`/`DATE_ADD_MILLIS`) rather than the `_STR` family shown
+above — see [Unix-millis DateTime storage](configuration.md#unix-millis-datetime-storage) for the
+comparison-against-`DateTime.UtcNow` caveat.
+
 Not yet supported: `Math.Min`/`Math.Max` (N1QL's `ARRAY_MAX`/`ARRAY_MIN` take a single array
 argument, not two scalars — no array-literal expression support exists yet to build one), trig
 functions (`Sin`/`Cos`/`Tan`/...), and secondary-index support for EF Core's `HasIndex()` (see

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -137,6 +137,52 @@ that specific property — the static `DateTime.Now`/`.UtcNow`/`.Today` translat
 associated property to read an override from, so they always use the context-wide default even
 in a query that also touches an overridden property.
 
+### Unix-millis DateTime storage
+
+Some Couchbase data stores dates as Unix epoch milliseconds (a JSON `NUMBER`) rather than a
+string. Mark a property with `[UnixMillisDateTime]` (or the `HasUnixMillisDateTime` fluent API) to
+store and query it that way instead of this provider's default ISO-8601 string:
+
+```csharp
+public class Event
+{
+    public int Id { get; set; }
+
+    [UnixMillisDateTime]
+    public DateTime OccurredAt { get; set; }
+}
+```
+
+```csharp
+// Equivalent fluent form:
+modelBuilder.Entity<Event>()
+    .Property(e => e.OccurredAt)
+    .HasUnixMillisDateTime();
+```
+
+Under the hood this attaches a `ValueConverter<DateTime, long>` — EF Core's own standard
+value-conversion mechanism — so normal read/write paths need no special handling. Query-side member
+access (`.Year`, `.Date`, `Add*`) translates to N1QL's `_MILLIS` date-function family
+(`DATE_PART_MILLIS`/`DATE_TRUNC_MILLIS`/`DATE_ADD_MILLIS`) instead of the `_STR` family used for the
+default string representation — see [Supported functions](Queries.md#supported-functions).
+
+**Comparing against `DateTime.UtcNow`/`.Now`/`.Today` directly is not supported.** These static
+members have no associated property, so they always translate to the `_STR`-family functions
+regardless of what they're compared against — each side of a comparison is translated
+independently, with the static member's N1QL function chosen before any binary-expression-level
+context exists to know it's being compared against a millis column. Comparing a
+`[UnixMillisDateTime]` property directly against one of them throws `NotSupportedException` at
+query-translation time rather than silently comparing a `NUMBER` against a `_STR` function's
+string result. Capture the value into a local variable before the query instead:
+
+```csharp
+var now = DateTime.UtcNow;
+var recent = await context.Events.Where(e => e.OccurredAt > now).ToListAsync();
+```
+
+A captured local becomes a query parameter, which correctly infers the millis conversion from the
+property it's compared against — unlike the static members, which never see that context.
+
 ## Multiple buckets and clusters
 
 By default a `DbContext` targets a single configured bucket (and scope), and every entity is

--- a/docs/limitations.md
+++ b/docs/limitations.md
@@ -98,6 +98,15 @@ The Couchbase SDK is asynchronous, so the synchronous EF Core code paths throw `
   navigation above. Use `.Any(predicate)` with an inner indexer instead (e.g.
   `customer.ContactMethods.Any(m => m.Tags[0].Key == "priority")`), which is fully supported. See
   [Modeling — OwnsMany](modeling.md#ownsmany).
+* **A `[UnixMillisDateTime]`-mapped property cannot be compared directly against
+  `DateTime.UtcNow`/`.Now`/`.Today`** — these static members have no associated property, so they
+  always translate to the string-based date-function family regardless of what they're compared
+  against, and the comparison throws `NotSupportedException` at query-translation time rather than
+  silently comparing a `NUMBER` against a string. Capture the value into a local variable before
+  the query instead. This mode also has no bearing on GSI/secondary-index alignment — this
+  provider has no `HasIndex()` support at all (see above), so whether a hand-created secondary
+  index matches a millis-mapped comparison's shape is entirely the user's own responsibility. See
+  [Unix-millis DateTime storage](configuration.md#unix-millis-datetime-storage).
 
 See also [Querying](Queries.md) and [Configuration](configuration.md).
 

--- a/src/Couchbase.EntityFrameworkCore/Extensions/CouchbasePropertyBuilderExtensions.cs
+++ b/src/Couchbase.EntityFrameworkCore/Extensions/CouchbasePropertyBuilderExtensions.cs
@@ -493,6 +493,48 @@ public static class CouchbasePropertyBuilderExtensions
 
     #endregion
 
+    #region Unix Millis DateTime Storage
+
+    /// <summary>
+    /// Stores this <see cref="DateTime"/> property as Unix epoch milliseconds (a JSON
+    /// <c>NUMBER</c>) instead of this provider's default ISO-8601 string. Equivalent to applying
+    /// <see cref="Couchbase.EntityFrameworkCore.Metadata.UnixMillisDateTimeAttribute"/> to the
+    /// property.
+    /// </summary>
+    /// <remarks>
+    /// <see cref="DateTime.UtcNow"/>/<see cref="DateTime.Now"/>/<see cref="DateTime.Today"/> have no
+    /// associated property, so they cannot be made millis-aware — comparing this property directly
+    /// against one of them throws at query-translation time. Capture the value into a local
+    /// variable before the query instead.
+    /// </remarks>
+    /// <param name="propertyBuilder">The property builder.</param>
+    /// <returns>The same property builder for method chaining.</returns>
+    /// <example>
+    /// <code>
+    /// modelBuilder.Entity&lt;Event&gt;()
+    ///     .Property(e => e.OccurredAt)
+    ///     .HasUnixMillisDateTime();
+    /// </code>
+    /// </example>
+    public static PropertyBuilder<TProperty> HasUnixMillisDateTime<TProperty>(
+        this PropertyBuilder<TProperty> propertyBuilder)
+    {
+        var clrType = propertyBuilder.Metadata.ClrType;
+        if (clrType != typeof(DateTime) && clrType != typeof(DateTime?))
+        {
+            throw new InvalidOperationException(
+                $"HasUnixMillisDateTime() can only be used on properties of type DateTime or DateTime?, but property " +
+                $"'{propertyBuilder.Metadata.DeclaringType.ClrType.Name}.{propertyBuilder.Metadata.Name}' " +
+                $"is of type '{clrType.Name}'.");
+        }
+
+        propertyBuilder.HasConversion(typeof(UnixMillisDateTimeConverter));
+
+        return propertyBuilder;
+    }
+
+    #endregion
+
     #region META() Field Override
 
     /// <summary>

--- a/src/Couchbase.EntityFrameworkCore/Metadata/Conventions/CouchbaseConventionSetBuilder.cs
+++ b/src/Couchbase.EntityFrameworkCore/Metadata/Conventions/CouchbaseConventionSetBuilder.cs
@@ -19,6 +19,7 @@ public class CouchbaseConventionSetBuilder : RelationalConventionSetBuilder
         conventionSet.Add(new JsonPropertyNameConvention(Dependencies));
         conventionSet.Add(new JsonPropertyConvention(Dependencies));
         conventionSet.Add(new DateTimeFormatConvention(Dependencies));
+        conventionSet.Add(new UnixMillisDateTimeConvention(Dependencies));
         conventionSet.Add(new CouchbaseMetaConvention(Dependencies));
         return conventionSet;
     }

--- a/src/Couchbase.EntityFrameworkCore/Metadata/Conventions/UnixMillisDateTimeConvention.cs
+++ b/src/Couchbase.EntityFrameworkCore/Metadata/Conventions/UnixMillisDateTimeConvention.cs
@@ -1,0 +1,56 @@
+using System.Reflection;
+using Couchbase.EntityFrameworkCore.Storage.Internal;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using Microsoft.EntityFrameworkCore.Metadata.Conventions;
+using Microsoft.EntityFrameworkCore.Metadata.Conventions.Infrastructure;
+
+namespace Couchbase.EntityFrameworkCore.Metadata.Conventions;
+
+/// <summary>
+/// A convention that processes <see cref="UnixMillisDateTimeAttribute"/> on properties and
+/// configures them to be stored as Unix epoch milliseconds instead of an ISO-8601 string.
+/// </summary>
+public class UnixMillisDateTimeConvention : PropertyAttributeConventionBase<UnixMillisDateTimeAttribute>
+{
+    public UnixMillisDateTimeConvention(ProviderConventionSetBuilderDependencies dependencies)
+        : base(dependencies)
+    {
+    }
+
+    protected override void ProcessPropertyAdded(
+        IConventionPropertyBuilder propertyBuilder,
+        UnixMillisDateTimeAttribute attribute,
+        MemberInfo clrMember,
+        IConventionContext context)
+    {
+        var clrType = propertyBuilder.Metadata.ClrType;
+        if (clrType != typeof(DateTime) && clrType != typeof(DateTime?))
+        {
+            throw new InvalidOperationException(
+                $"[UnixMillisDateTime] can only be applied to properties of type DateTime or DateTime?, but property " +
+                $"'{propertyBuilder.Metadata.DeclaringType.ClrType.Name}.{propertyBuilder.Metadata.Name}' " +
+                $"is of type '{clrType.Name}'.");
+        }
+
+        propertyBuilder.HasConverter(typeof(UnixMillisDateTimeConverter), fromDataAnnotation: true);
+    }
+}
+
+/* ************************************************************
+ *
+ *    @author Couchbase <info@couchbase.com>
+ *    @copyright 2025 Couchbase, Inc.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ *
+ * ************************************************************/

--- a/src/Couchbase.EntityFrameworkCore/Metadata/UnixMillisDateTimeAttribute.cs
+++ b/src/Couchbase.EntityFrameworkCore/Metadata/UnixMillisDateTimeAttribute.cs
@@ -1,0 +1,35 @@
+namespace Couchbase.EntityFrameworkCore.Metadata;
+
+/// <summary>
+/// Stores the annotated <see cref="DateTime"/> property as Unix epoch milliseconds (a JSON
+/// <c>NUMBER</c>) instead of this provider's default ISO-8601 string.
+/// </summary>
+/// <remarks>
+/// Under the hood this configures a <see cref="Storage.Internal.UnixMillisDateTimeConverter"/> via
+/// <c>HasConversion</c> — EF Core's own standard value-conversion mechanism, so normal
+/// materialization/write paths need no Couchbase-specific handling. Query-side member access
+/// (<c>.Year</c>, <c>.Date</c>, <c>Add*</c>) is translated to N1QL's <c>_MILLIS</c> date-function
+/// family instead of the <c>_STR</c> family used for the default string representation.
+/// <para>
+/// <see cref="DateTime.UtcNow"/>/<see cref="DateTime.Now"/>/<see cref="DateTime.Today"/> have no
+/// associated property, so they cannot be made millis-aware — comparing a
+/// <see cref="UnixMillisDateTimeAttribute"/>-annotated property directly against one of these
+/// throws at query-translation time. Capture the value into a local variable before the query
+/// instead (<c>var now = DateTime.UtcNow; ... Where(x =&gt; x.MillisProp &gt; now)</c>) — the
+/// captured value becomes a parameter, which correctly converts through the same mechanism as any
+/// other comparand.
+/// </para>
+/// </remarks>
+/// <example>
+/// <code>
+/// public class Event
+/// {
+///     [UnixMillisDateTime]
+///     public DateTime OccurredAt { get; set; }
+/// }
+/// </code>
+/// </example>
+[AttributeUsage(AttributeTargets.Property)]
+public class UnixMillisDateTimeAttribute : Attribute
+{
+}

--- a/src/Couchbase.EntityFrameworkCore/Query/Internal/CouchbaseQuerySqlGenerator.cs
+++ b/src/Couchbase.EntityFrameworkCore/Query/Internal/CouchbaseQuerySqlGenerator.cs
@@ -9,6 +9,7 @@ using System.Reflection.Metadata;
 using System.Text;
 using Couchbase.EntityFrameworkCore.Infrastructure;
 using Couchbase.EntityFrameworkCore.Metadata;
+using Couchbase.EntityFrameworkCore.Storage.Internal;
 using Couchbase.EntityFrameworkCore.Utils;
 using Couchbase.Extensions.DependencyInjection;
 using Microsoft.EntityFrameworkCore;
@@ -1223,6 +1224,55 @@ public class CouchbaseQuerySqlGenerator : QuerySqlGenerator
             .Append(Dependencies.SqlGenerationHelper.DelimitIdentifier(tableExpression.Alias));
 
         return tableExpression;
+    }
+
+    private static readonly HashSet<string> DateTimeStrFunctionNames =
+        new(StringComparer.Ordinal) { "NOW_UTC", "NOW_LOCAL", "DATE_TRUNC_STR", "DATE_PART_STR", "DATE_ADD_STR" };
+
+    private static readonly HashSet<ExpressionType> ComparisonOperators = new()
+    {
+        ExpressionType.Equal, ExpressionType.NotEqual,
+        ExpressionType.LessThan, ExpressionType.LessThanOrEqual,
+        ExpressionType.GreaterThan, ExpressionType.GreaterThanOrEqual,
+    };
+
+    /// <summary>
+    /// Guards against a confirmed structural limitation: <see cref="DateTime.UtcNow"/>/
+    /// <see cref="DateTime.Now"/>/<see cref="DateTime.Today"/> have no associated property, so
+    /// <see cref="Metadata.UnixMillisDateTimeAttribute"/>-mapped properties (stored as a
+    /// <c>NUMBER</c>) cannot be compared against them directly -- each side of a comparison is
+    /// translated independently, with the static member's <c>_STR</c>-family N1QL function chosen
+    /// before any binary-expression-level context exists to know it's being compared against a
+    /// millis column. Confirmed empirically: EF Core's binary-comparison type inference does not
+    /// (and structurally cannot) retroactively change an already-built function call. Rather than
+    /// silently comparing a <c>NUMBER</c> against a <c>_STR</c> function's string result (which
+    /// would produce a wrong-but-plausible-looking query), detect the shape here and throw --
+    /// mirrors this provider's established "fail loud instead of silently wrong" pattern (e.g. the
+    /// <c>NotSupportedException</c> thrown for an unsupported aggregate over an owned collection).
+    /// </summary>
+    protected override Expression VisitSqlBinary(SqlBinaryExpression sqlBinaryExpression)
+    {
+        if (ComparisonOperators.Contains(sqlBinaryExpression.OperatorType))
+        {
+            CheckForMismatchedDateTimeStorageComparison(sqlBinaryExpression.Left, sqlBinaryExpression.Right);
+            CheckForMismatchedDateTimeStorageComparison(sqlBinaryExpression.Right, sqlBinaryExpression.Left);
+        }
+
+        return base.VisitSqlBinary(sqlBinaryExpression);
+    }
+
+    private static void CheckForMismatchedDateTimeStorageComparison(SqlExpression millisSide, SqlExpression strSide)
+    {
+        if (UnixMillisDateTimeConverter.IsUnixMillis(millisSide.TypeMapping)
+            && strSide is SqlFunctionExpression { IsBuiltIn: true, Name: var name }
+            && DateTimeStrFunctionNames.Contains(name))
+        {
+            throw new NotSupportedException(
+                "Comparing a [UnixMillisDateTime] property directly against DateTime.UtcNow/.Now/.Today "
+                + "is not supported -- these static members have no associated property, so they cannot "
+                + "be translated as milliseconds to match. Capture the value into a local variable before "
+                + "the query instead, e.g. `var now = DateTime.UtcNow; ... .Where(x => x.MillisProp > now)`.");
+        }
     }
 
     protected override Expression VisitColumn(ColumnExpression columnExpression)

--- a/src/Couchbase.EntityFrameworkCore/Query/Internal/Translators/CouchbaseDateTimeMemberTranslator.cs
+++ b/src/Couchbase.EntityFrameworkCore/Query/Internal/Translators/CouchbaseDateTimeMemberTranslator.cs
@@ -42,6 +42,18 @@ namespace Couchbase.EntityFrameworkCore.Query.Internal.Translators;
 /// <c>.Today</c> branches have no associated property/instance and always use the context-wide
 /// default -- there is no per-property signal available for them.
 /// </para>
+/// <para>
+/// If <paramref name="instance"/>'s resolved type mapping carries a
+/// <see cref="Storage.Internal.UnixMillisDateTimeConverter"/> (i.e. the property is
+/// <see cref="Metadata.UnixMillisDateTimeAttribute"/>-annotated), the date-part and <c>.Date</c>
+/// members instead translate to N1QL's <c>_MILLIS</c> date-function family
+/// (<c>DATE_PART_MILLIS</c>/<c>DATE_TRUNC_MILLIS</c>), which operates on/returns milliseconds
+/// directly -- no format string involved, unlike the <c>_STR</c> family. This check is confirmed
+/// necessary empirically: EF Core's own binary-comparison type inference does NOT propagate a
+/// converted property's type mapping onto anything -- each side of a comparison/member access is
+/// translated independently, so without this branch a millis-mapped property's <c>.Year</c>/
+/// <c>.Date</c> would silently emit a <c>_STR</c>-family call against a <c>NUMBER</c> column.
+/// </para>
 /// </summary>
 public class CouchbaseDateTimeMemberTranslator : IMemberTranslator
 {
@@ -82,6 +94,16 @@ public class CouchbaseDateTimeMemberTranslator : IMemberTranslator
     {
         if (instance != null && DatePartMappings.TryGetValue(member, out var part))
         {
+            if (UnixMillisDateTimeConverter.IsUnixMillis(instance.TypeMapping))
+            {
+                return _sqlExpressionFactory.Function(
+                    "DATE_PART_MILLIS",
+                    new[] { instance, _sqlExpressionFactory.Constant(part) },
+                    nullable: true,
+                    argumentsPropagateNullability: new[] { true, false },
+                    returnType);
+            }
+
             return _sqlExpressionFactory.Function(
                 "DATE_PART_STR",
                 new[] { instance, _sqlExpressionFactory.Constant(part) },
@@ -92,6 +114,17 @@ public class CouchbaseDateTimeMemberTranslator : IMemberTranslator
 
         if (instance != null && DateMemberInfo.Equals(member))
         {
+            if (UnixMillisDateTimeConverter.IsUnixMillis(instance.TypeMapping))
+            {
+                return _sqlExpressionFactory.Function(
+                    "DATE_TRUNC_MILLIS",
+                    new[] { instance, _sqlExpressionFactory.Constant("day") },
+                    nullable: true,
+                    argumentsPropagateNullability: new[] { true, false },
+                    returnType,
+                    instance.TypeMapping);
+            }
+
             // Prefer the format baked into the instance's own resolved type mapping -- this is
             // how a per-property [DateTimeFormat]/HasDateTimeFormat override (a distinct
             // CouchbaseDateTimeTypeMapping instance per property) takes effect, with zero DI

--- a/src/Couchbase.EntityFrameworkCore/Query/Internal/Translators/CouchbaseDateTimeMethodTranslator.cs
+++ b/src/Couchbase.EntityFrameworkCore/Query/Internal/Translators/CouchbaseDateTimeMethodTranslator.cs
@@ -1,4 +1,5 @@
 using System.Reflection;
+using Couchbase.EntityFrameworkCore.Storage.Internal;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.Query;
@@ -15,6 +16,13 @@ namespace Couchbase.EntityFrameworkCore.Query.Internal.Translators;
 /// <c>2026-03-15T09:26:53.123Z</c> directly). Couchbase's own documentation describes this
 /// function's return value as milliseconds, which does NOT match observed behavior; trust the
 /// live result over the docs here. No MILLIS_TO_STR/MILLIS_TO_UTC wrapping is needed.
+/// <para>
+/// If <c>instance</c>'s resolved type mapping carries a
+/// <see cref="UnixMillisDateTimeConverter"/> (i.e. the property is
+/// <see cref="Metadata.UnixMillisDateTimeAttribute"/>-annotated), translates to N1QL's
+/// <c>DATE_ADD_MILLIS(date_millis, n, part)</c> instead, which operates on/returns milliseconds
+/// directly.
+/// </para>
 /// </summary>
 public class CouchbaseDateTimeMethodTranslator : IMethodCallTranslator
 {
@@ -43,8 +51,12 @@ public class CouchbaseDateTimeMethodTranslator : IMethodCallTranslator
     {
         if (instance != null && AddMethodMappings.TryGetValue(method, out var part))
         {
+            var functionName = UnixMillisDateTimeConverter.IsUnixMillis(instance.TypeMapping)
+                ? "DATE_ADD_MILLIS"
+                : "DATE_ADD_STR";
+
             return _sqlExpressionFactory.Function(
-                "DATE_ADD_STR",
+                functionName,
                 new[] { instance, arguments[0], _sqlExpressionFactory.Constant(part) },
                 nullable: true,
                 argumentsPropagateNullability: new[] { true, true, false },

--- a/src/Couchbase.EntityFrameworkCore/Storage/Internal/UnixMillisDateTimeConverter.cs
+++ b/src/Couchbase.EntityFrameworkCore/Storage/Internal/UnixMillisDateTimeConverter.cs
@@ -1,0 +1,63 @@
+using Microsoft.EntityFrameworkCore.Storage;
+using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
+
+namespace Couchbase.EntityFrameworkCore.Storage.Internal;
+
+/// <summary>
+/// Converts <see cref="DateTime"/> values to/from Unix epoch milliseconds (a JSON <c>NUMBER</c>),
+/// for properties configured via <see cref="Metadata.UnixMillisDateTimeAttribute"/>/
+/// <c>HasUnixMillisDateTime</c>.
+/// </summary>
+/// <remarks>
+/// Values are treated as UTC on the way in (matching this provider's general UTC-oriented
+/// treatment of <see cref="DateTime"/> elsewhere -- see <see cref="CouchbaseDateTimeTypeMapping"/>)
+/// and materialize back as <see cref="DateTimeKind.Utc"/>.
+/// <para>
+/// No custom <see cref="RelationalTypeMapping"/> is needed for this converter: composed with the
+/// existing <c>typeof(long)</c> -&gt; <see cref="Microsoft.EntityFrameworkCore.Storage.LongTypeMapping"/>("NUMBER")
+/// entry already in <see cref="CouchbaseTypeMappingSource"/>, EF Core's own generic
+/// converter-composition machinery (<c>TypeMappingSource.FindMapping(IProperty)</c>) already
+/// resolves a correctly-converting mapping with zero provider-specific plumbing -- confirmed
+/// empirically via <c>.ToQueryString()</c>: <c>instance.TypeMapping</c> on a converted property is
+/// a stock <see cref="Microsoft.EntityFrameworkCore.Storage.LongTypeMapping"/> with
+/// <see cref="RelationalTypeMapping.Converter"/> set to this type,
+/// <see cref="RelationalTypeMapping.ClrType"/> is <see cref="DateTime"/>, and the provider CLR type
+/// is <see cref="long"/>.
+/// </para>
+/// </remarks>
+public class UnixMillisDateTimeConverter : ValueConverter<DateTime, long>
+{
+    public UnixMillisDateTimeConverter()
+        : base(
+            d => new DateTimeOffset(DateTime.SpecifyKind(d, DateTimeKind.Utc)).ToUnixTimeMilliseconds(),
+            l => DateTimeOffset.FromUnixTimeMilliseconds(l).UtcDateTime)
+    {
+    }
+
+    /// <summary>
+    /// Returns <see langword="true"/> if <paramref name="mapping"/> is a converted mapping backed
+    /// by a <see cref="UnixMillisDateTimeConverter"/> -- i.e. the property/expression it belongs to
+    /// is stored as Unix epoch milliseconds rather than this provider's default ISO-8601 string.
+    /// </summary>
+    public static bool IsUnixMillis(Microsoft.EntityFrameworkCore.Storage.CoreTypeMapping? mapping)
+        => mapping is RelationalTypeMapping { Converter: UnixMillisDateTimeConverter };
+}
+
+/* ************************************************************
+ *
+ *    @author Couchbase <info@couchbase.com>
+ *    @copyright 2025 Couchbase, Inc.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ *
+ * ************************************************************/

--- a/tests/Couchbase.EntityFrameworkCore.IntegrationTests/Tests/UnixMillisDateTimeTests.cs
+++ b/tests/Couchbase.EntityFrameworkCore.IntegrationTests/Tests/UnixMillisDateTimeTests.cs
@@ -1,0 +1,168 @@
+using Couchbase.EntityFrameworkCode.IntegrationTests.Fixtures;
+using Couchbase.EntityFrameworkCore;
+using Couchbase.EntityFrameworkCore.Extensions;
+using Couchbase.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+
+namespace Couchbase.EntityFrameworkCode.IntegrationTests.Tests;
+
+/// <summary>
+/// Proves <see cref="UnixMillisDateTimeAttribute"/>/<c>HasUnixMillisDateTime</c> round-trips
+/// against a real cluster: stored as a raw JSON <c>NUMBER</c> (not a string), and
+/// <c>.Year</c>/<c>.Date</c>/<c>.AddDays</c> query translation actually executes correctly against
+/// real data -- not just that the generated SQL text looks right.
+/// </summary>
+[Collection(CouchbaseTestingCollection.Name)]
+public class UnixMillisDateTimeTests(BloggingFixture fixture) : IAsyncLifetime
+{
+    private static readonly string CollectionName = "unixmillis" + Guid.NewGuid().ToString("N");
+
+    private static readonly DateTime OccurredAt =
+        new(DateTime.UtcNow.Year - 1, 3, 14, 9, 26, 53, 123, DateTimeKind.Utc);
+
+    private static readonly long OccurredAtMillis = new DateTimeOffset(OccurredAt).ToUnixTimeMilliseconds();
+
+    private EventDbContext _context = null!;
+
+    public async Task InitializeAsync()
+    {
+        var optionsBuilder = new DbContextOptionsBuilder<EventDbContext>();
+        optionsBuilder.UseCouchbase(
+            new global::Couchbase.ClusterOptions()
+                .WithConnectionString(fixture.Host)
+                .WithPasswordAuthentication(fixture.Username, fixture.Password),
+            o =>
+            {
+                o.Bucket = fixture.BucketName;
+                o.Scope = fixture.ScopeName;
+                o.AutoCreateIndexes = true;
+                o.ScanConsistency = global::Couchbase.Query.QueryScanConsistency.RequestPlus;
+            });
+        optionsBuilder.ConfigureWarnings(w => w.Ignore(CoreEventId.ManyServiceProvidersCreatedWarning));
+
+        _context = new EventDbContext(optionsBuilder.Options, CollectionName);
+        await _context.Database.EnsureCreatedAsync();
+
+        // Written directly via the KV API as a raw NUMBER, independent of this provider's own
+        // write path, to prove the query side reads real millis data correctly rather than only
+        // round-tripping data this same provider wrote.
+        var clusterOptions = new global::Couchbase.ClusterOptions()
+            .WithConnectionString(fixture.Host)
+            .WithPasswordAuthentication(fixture.Username, fixture.Password)
+            .WithSerializer(global::Couchbase.Core.IO.Serializers.SystemTextJsonSerializer.Create());
+        using var cluster = await global::Couchbase.Cluster.ConnectAsync(clusterOptions);
+        var bucket = await cluster.BucketAsync(fixture.BucketName);
+        var scope = await bucket.ScopeAsync(fixture.ScopeName);
+        var collection = scope.Collection(CollectionName);
+        await collection.InsertAsync("1", new Dictionary<string, object>
+        {
+            ["Id"] = 1L,
+            ["OccurredAt"] = OccurredAtMillis,
+        });
+    }
+
+    [Fact]
+    public async Task StoredValue_IsRawNumber_NotString()
+    {
+        var result = await _context.Database
+            .SqlQueryRaw<long>($"SELECT RAW `OccurredAt` FROM `{fixture.BucketName}`.`{fixture.ScopeName}`.`{CollectionName}` WHERE META().id = '1'")
+            .ToListAsync();
+
+        Assert.Single(result);
+        Assert.Equal(OccurredAtMillis, result[0]);
+    }
+
+    [Fact]
+    public async Task Year_TranslatesAndExecutesCorrectly()
+    {
+        var result = await _context.Events.Where(e => e.OccurredAt.Year == OccurredAt.Year).ToListAsync();
+        Assert.Single(result);
+    }
+
+    [Fact]
+    public async Task Date_TranslatesAndExecutesCorrectly()
+    {
+        var expected = new DateTime(OccurredAt.Year, OccurredAt.Month, OccurredAt.Day, 0, 0, 0, DateTimeKind.Utc);
+        var result = await _context.Events.Where(e => e.OccurredAt.Date == expected).ToListAsync();
+        Assert.Single(result);
+    }
+
+    [Fact]
+    public async Task AddDays_TranslatesAndExecutesCorrectly()
+    {
+        var dayLater = OccurredAt.AddDays(1);
+        var result = await _context.Events.Where(e => e.OccurredAt.AddDays(1) == dayLater).ToListAsync();
+        Assert.Single(result);
+    }
+
+    [Fact]
+    public async Task Equality_AgainstCapturedConstant_TranslatesAndExecutesCorrectly()
+    {
+        var result = await _context.Events.Where(e => e.OccurredAt == OccurredAt).ToListAsync();
+        Assert.Single(result);
+    }
+
+    [Fact]
+    public async Task RoundTrip_ThroughSaveChanges_ReadsBackSameValue()
+    {
+        var newTimestamp = new DateTime(OccurredAt.Year, 7, 4, 12, 0, 0, DateTimeKind.Utc);
+        _context.Events.Add(new Event { Id = 2, OccurredAt = newTimestamp });
+        await _context.SaveChangesAsync();
+
+        var optionsBuilder = new DbContextOptionsBuilder<EventDbContext>();
+        optionsBuilder.UseCouchbase(
+            new global::Couchbase.ClusterOptions()
+                .WithConnectionString(fixture.Host)
+                .WithPasswordAuthentication(fixture.Username, fixture.Password),
+            o =>
+            {
+                o.Bucket = fixture.BucketName;
+                o.Scope = fixture.ScopeName;
+                o.ScanConsistency = global::Couchbase.Query.QueryScanConsistency.RequestPlus;
+            });
+        optionsBuilder.ConfigureWarnings(w => w.Ignore(CoreEventId.ManyServiceProvidersCreatedWarning));
+
+        await using var freshContext = new EventDbContext(optionsBuilder.Options, CollectionName);
+        var result = await freshContext.Events.AsNoTracking().FirstAsync(e => e.Id == 2);
+        Assert.Equal(newTimestamp, result.OccurredAt);
+    }
+
+    public async Task DisposeAsync()
+    {
+        await _context.DisposeAsync();
+
+        try
+        {
+            var clusterOptions = new global::Couchbase.ClusterOptions()
+                .WithConnectionString(fixture.Host)
+                .WithCredentials(fixture.Username, fixture.Password);
+            using var cluster = await global::Couchbase.Cluster.ConnectAsync(clusterOptions);
+            var bucket = await cluster.BucketAsync(fixture.BucketName);
+            await bucket.Collections.DropCollectionAsync(fixture.ScopeName, CollectionName);
+        }
+        catch (global::Couchbase.Management.Collections.CollectionNotFoundException)
+        {
+        }
+    }
+
+    public class Event
+    {
+        public long Id { get; set; }
+
+        [UnixMillisDateTime]
+        public DateTime OccurredAt { get; set; }
+    }
+
+    public class EventDbContext(DbContextOptions<EventDbContext> options, string collectionName)
+        : DbContext(options)
+    {
+        public DbSet<Event> Events { get; set; } = null!;
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            base.OnModelCreating(modelBuilder);
+            modelBuilder.Entity<Event>().ToCouchbaseCollection(this, collectionName);
+        }
+    }
+}

--- a/tests/Couchbase.EntityFrameworkCore.UnitTests/Couchbase/EntityFrameworkCore/Extensions/CouchbasePropertyBuilderExtensionsTests.cs
+++ b/tests/Couchbase.EntityFrameworkCore.UnitTests/Couchbase/EntityFrameworkCore/Extensions/CouchbasePropertyBuilderExtensionsTests.cs
@@ -743,6 +743,47 @@ public class CouchbasePropertyBuilderExtensionsTests
 
     #endregion
 
+    #region HasUnixMillisDateTime Tests
+
+    [Fact]
+    public void HasUnixMillisDateTime_OnDateTimeProperty_SetsUnixMillisConverter()
+    {
+        var modelBuilder = new ModelBuilder();
+        var entityBuilder = modelBuilder.Entity<DateTimeEntity>();
+
+        entityBuilder.Property(e => e.ShipDate).HasUnixMillisDateTime();
+
+        var property = modelBuilder.Model.FindEntityType(typeof(DateTimeEntity))!.FindProperty(nameof(DateTimeEntity.ShipDate));
+        Assert.IsType<UnixMillisDateTimeConverter>(property!.GetValueConverter());
+    }
+
+    [Fact]
+    public void HasUnixMillisDateTime_OnNullableDateTimeProperty_SetsUnixMillisConverter()
+    {
+        var modelBuilder = new ModelBuilder();
+        var entityBuilder = modelBuilder.Entity<DateTimeEntity>();
+
+        entityBuilder.Property(e => e.OptionalShipDate).HasUnixMillisDateTime();
+
+        var property = modelBuilder.Model.FindEntityType(typeof(DateTimeEntity))!.FindProperty(nameof(DateTimeEntity.OptionalShipDate));
+        Assert.IsType<UnixMillisDateTimeConverter>(property!.GetValueConverter());
+    }
+
+    [Fact]
+    public void HasUnixMillisDateTime_OnNonDateTimeProperty_ThrowsInvalidOperationException()
+    {
+        var modelBuilder = new ModelBuilder();
+        var entityBuilder = modelBuilder.Entity<DateTimeEntity>();
+
+        var exception = Assert.Throws<InvalidOperationException>(() =>
+            entityBuilder.Property(e => e.Id).HasUnixMillisDateTime());
+
+        Assert.Contains("HasUnixMillisDateTime()", exception.Message);
+        Assert.Contains("DateTime", exception.Message);
+    }
+
+    #endregion
+
     #region HasCouchbaseMeta Tests
 
     [Fact]

--- a/tests/Couchbase.EntityFrameworkCore.UnitTests/Couchbase/EntityFrameworkCore/Metadata/Conventions/UnixMillisDateTimeConventionTests.cs
+++ b/tests/Couchbase.EntityFrameworkCore.UnitTests/Couchbase/EntityFrameworkCore/Metadata/Conventions/UnixMillisDateTimeConventionTests.cs
@@ -1,0 +1,59 @@
+using Couchbase.EntityFrameworkCore.Extensions;
+using Couchbase.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore;
+using Xunit;
+
+namespace Couchbase.EntityFrameworkCore.UnitTests.Couchbase.EntityFrameworkCore.Metadata.Conventions;
+
+/// <summary>
+/// Verifies <see cref="Couchbase.EntityFrameworkCore.Metadata.Conventions.UnixMillisDateTimeConvention"/>
+/// fails fast when <see cref="UnixMillisDateTimeAttribute"/> is misapplied to a non-<see cref="DateTime"/>
+/// property, rather than silently attaching a converter EF Core's own value-conversion pipeline
+/// would then fail on in a much more confusing way at some later point.
+/// </summary>
+public class UnixMillisDateTimeConventionTests
+{
+    [Fact]
+    public void UnixMillisDateTimeAttribute_OnNonDateTimeProperty_ThrowsAtModelBuildTime()
+    {
+        using var ctx = CreateContext();
+
+        var exception = Assert.Throws<InvalidOperationException>(() => ctx.Model);
+
+        Assert.Contains("[UnixMillisDateTime]", exception.Message);
+        Assert.Contains("DateTime", exception.Message);
+    }
+
+    private static InvalidAttributeContext CreateContext()
+    {
+        var clusterOptions = new ClusterOptions()
+            .WithConnectionString("couchbase://localhost")
+            .WithPasswordAuthentication("Administrator", "password");
+
+        var builder = new DbContextOptionsBuilder<InvalidAttributeContext>();
+        builder.UseCouchbaseProvider(clusterOptions);
+        return new InvalidAttributeContext(builder.Options);
+    }
+
+    private class InvalidAttributeEntity
+    {
+        public int Id { get; set; }
+
+        [UnixMillisDateTime]
+        public int NotADateTime { get; set; }
+    }
+
+    private class InvalidAttributeContext(DbContextOptions<InvalidAttributeContext> options) : DbContext(options)
+    {
+        public DbSet<InvalidAttributeEntity> Entities { get; set; } = null!;
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            modelBuilder.Entity<InvalidAttributeEntity>(b =>
+            {
+                b.ToCouchbaseCollection("bucket", "scope", "invalidUnixMillisPost");
+                b.HasKey(p => p.Id);
+            });
+        }
+    }
+}

--- a/tests/Couchbase.EntityFrameworkCore.UnitTests/Couchbase/EntityFrameworkCore/Query/CouchbaseUnixMillisDateTimeSqlGenerationTests.cs
+++ b/tests/Couchbase.EntityFrameworkCore.UnitTests/Couchbase/EntityFrameworkCore/Query/CouchbaseUnixMillisDateTimeSqlGenerationTests.cs
@@ -1,0 +1,197 @@
+using Couchbase.EntityFrameworkCore.Extensions;
+using Couchbase.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore;
+using Xunit;
+
+namespace Couchbase.EntityFrameworkCore.UnitTests.Couchbase.EntityFrameworkCore.Query;
+
+/// <summary>
+/// Verifies <see cref="UnixMillisDateTimeAttribute"/>/<c>HasUnixMillisDateTime</c>: a property so
+/// configured translates <c>.Year</c>/<c>.Date</c>/<c>Add*</c> to N1QL's <c>_MILLIS</c> date-function
+/// family instead of the default <c>_STR</c> family, and a direct comparison against
+/// <see cref="DateTime.UtcNow"/>/<see cref="DateTime.Now"/>/<see cref="DateTime.Today"/> throws at
+/// translation time rather than silently comparing a <c>NUMBER</c> against a <c>_STR</c> function's
+/// string result (see <see cref="CouchbaseQuerySqlGenerator"/>'s <c>VisitSqlBinary</c> override).
+/// </summary>
+public class CouchbaseUnixMillisDateTimeSqlGenerationTests
+{
+    [Fact]
+    public void Year_WithUnixMillisAttribute_TranslatesToDatePartMillis()
+    {
+        using var ctx = CreateContext();
+        var sql = ctx.Events.Where(e => e.OccurredAt.Year == 2026).ToQueryString();
+
+        Assert.Contains("DATE_PART_MILLIS(", sql, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("'year'", sql);
+        Assert.DoesNotContain("DATE_PART_STR(", sql, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void Date_WithUnixMillisAttribute_TranslatesToDateTruncMillis()
+    {
+        using var ctx = CreateContext();
+        var stamp = new DateTime(2026, 1, 1);
+        var sql = ctx.Events.Where(e => e.OccurredAt.Date == stamp).ToQueryString();
+
+        Assert.Contains("DATE_TRUNC_MILLIS(", sql, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("'day'", sql);
+        Assert.DoesNotContain("DATE_TRUNC_STR(", sql, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void AddDays_WithUnixMillisAttribute_TranslatesToDateAddMillis()
+    {
+        using var ctx = CreateContext();
+        var stamp = new DateTime(2026, 1, 1);
+        var sql = ctx.Events.Where(e => e.OccurredAt.AddDays(1) == stamp).ToQueryString();
+
+        Assert.Contains("DATE_ADD_MILLIS(", sql, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("'day'", sql);
+        Assert.DoesNotContain("DATE_ADD_STR(", sql, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void Year_WithUnixMillisFluent_TranslatesToDatePartMillis()
+    {
+        using var ctx = CreateFluentContext();
+        var sql = ctx.Events.Where(e => e.OccurredAt.Year == 2026).ToQueryString();
+
+        Assert.Contains("DATE_PART_MILLIS(", sql, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void RegularDateTimeProperty_UnaffectedByUnixMillisOnSiblingProperty()
+    {
+        using var ctx = CreateContext();
+        var sql = ctx.Events.Where(e => e.LoggedAt.Year == 2026).ToQueryString();
+
+        Assert.Contains("DATE_PART_STR(", sql, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("DATE_PART_MILLIS(", sql, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void Equality_WithUnixMillisAttribute_ComparesAgainstCapturedConstant_DoesNotThrow()
+    {
+        using var ctx = CreateContext();
+        var stamp = new DateTime(2026, 1, 1);
+
+        var sql = ctx.Events.Where(e => e.OccurredAt == stamp).ToQueryString();
+
+        Assert.Contains("`OccurredAt`", sql);
+    }
+
+    [Fact]
+    public void ComparisonAgainstUtcNow_WithUnixMillisAttribute_Throws()
+    {
+        using var ctx = CreateContext();
+
+        var exception = Assert.Throws<NotSupportedException>(
+            () => ctx.Events.Where(e => e.OccurredAt > DateTime.UtcNow).ToQueryString());
+
+        Assert.Contains("UnixMillisDateTime", exception.Message);
+    }
+
+    [Fact]
+    public void ComparisonAgainstNow_WithUnixMillisAttribute_Throws()
+    {
+        using var ctx = CreateContext();
+
+        Assert.Throws<NotSupportedException>(
+            () => ctx.Events.Where(e => e.OccurredAt > DateTime.Now).ToQueryString());
+    }
+
+    [Fact]
+    public void ComparisonAgainstToday_WithUnixMillisAttribute_Throws()
+    {
+        using var ctx = CreateContext();
+
+        Assert.Throws<NotSupportedException>(
+            () => ctx.Events.Where(e => e.OccurredAt > DateTime.Today).ToQueryString());
+    }
+
+    [Fact]
+    public void ComparisonAgainstUtcNow_ReversedOperandOrder_StillThrows()
+    {
+        using var ctx = CreateContext();
+
+        Assert.Throws<NotSupportedException>(
+            () => ctx.Events.Where(e => DateTime.UtcNow < e.OccurredAt).ToQueryString());
+    }
+
+    [Fact]
+    public void ComparisonAgainstUtcNow_WithRegularProperty_DoesNotThrow()
+    {
+        using var ctx = CreateContext();
+
+        var sql = ctx.Events.Where(e => e.LoggedAt > DateTime.UtcNow).ToQueryString();
+
+        Assert.Contains("NOW_UTC(", sql, StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static EventContext CreateContext()
+    {
+        var clusterOptions = new ClusterOptions()
+            .WithConnectionString("couchbase://localhost")
+            .WithPasswordAuthentication("Administrator", "password");
+
+        var builder = new DbContextOptionsBuilder<EventContext>();
+        builder.UseCouchbaseProvider(clusterOptions);
+        return new EventContext(builder.Options);
+    }
+
+    private static FluentEventContext CreateFluentContext()
+    {
+        var clusterOptions = new ClusterOptions()
+            .WithConnectionString("couchbase://localhost")
+            .WithPasswordAuthentication("Administrator", "password");
+
+        var builder = new DbContextOptionsBuilder<FluentEventContext>();
+        builder.UseCouchbaseProvider(clusterOptions);
+        return new FluentEventContext(builder.Options);
+    }
+
+    private class Event
+    {
+        public int Id { get; set; }
+
+        [UnixMillisDateTime]
+        public DateTime OccurredAt { get; set; }
+
+        public DateTime LoggedAt { get; set; }
+    }
+
+    private class EventContext(DbContextOptions<EventContext> options) : DbContext(options)
+    {
+        public DbSet<Event> Events { get; set; } = null!;
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            modelBuilder.Entity<Event>(b =>
+            {
+                b.ToCouchbaseCollection("bucket", "scope", "event");
+                b.HasKey(e => e.Id);
+            });
+        }
+    }
+
+    private class FluentEvent
+    {
+        public int Id { get; set; }
+        public DateTime OccurredAt { get; set; }
+    }
+
+    private class FluentEventContext(DbContextOptions<FluentEventContext> options) : DbContext(options)
+    {
+        public DbSet<FluentEvent> Events { get; set; } = null!;
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            modelBuilder.Entity<FluentEvent>(b =>
+            {
+                b.ToCouchbaseCollection("bucket", "scope", "fluentEvent");
+                b.HasKey(e => e.Id);
+                b.Property(e => e.OccurredAt).HasUnixMillisDateTime();
+            });
+        }
+    }
+}


### PR DESCRIPTION
Add [UnixMillisDateTime]/HasUnixMillisDateTime to store a DateTime property as Unix epoch milliseconds (a JSON NUMBER) instead of the default ISO-8601 string, via a standard EF Core
ValueConverter<DateTime, long>. Composes with the existing typeof(long) -> LongTypeMapping("NUMBER") entry through EF Core's own converter-composition machinery, needing no new type-mapping class or FindMapping(IProperty) override.

CouchbaseDateTimeMemberTranslator/CouchbaseDateTimeMethodTranslator now translate .Year/.Month/etc., .Date, and Add* on a millis-mapped property to N1QL's DATE_PART_MILLIS/DATE_TRUNC_MILLIS/DATE_ADD_MILLIS instead of the _STR family.

Comparing a millis-mapped property directly against DateTime.UtcNow/.Now/.Today is a confirmed structural limitation: those static members have no associated property and choose their (always _STR-family) N1QL function before any binary-comparison context exists, so the comparison can silently compare a NUMBER against a string. CouchbaseQuerySqlGenerator.VisitSqlBinary now detects this shape and throws NotSupportedException instead, with capturing the value into a local variable as the documented workaround.

Found and fixed a real EF Core API trap along the way: IConventionPropertyBuilder.HasConversion(Type) does not attach a converter when the type is itself a ValueConverter subclass (unlike the public PropertyBuilder<T>.HasConversion(Type), which detects this and routes to HasConverter internally) — conventions attaching a converter by type must call HasConverter(Type) directly.

Add unit tests (attribute/convention/fluent API, SQL generation, mismatch-guard-throws) and live integration tests, including a raw-KV-written round-trip proving read-side correctness independent of this provider's own write path. Update docs/configuration.md, docs/Queries.md, docs/limitations.md, and CHANGELOG.md.