### PR TITLE
Add Math.Min/Max and EF.Functions.Least/Greatest support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@ and this project aims to follow [Semantic Versioning](https://semver.org/spec/v2
 
 ### Added
 
+- **`Math.Min(a, b)`/`Math.Max(a, b)` and `EF.Functions.Least`/`Greatest`.** N1QL has no variadic
+  `GREATEST`/`LEAST` function — the equivalent is `ARRAY_MIN`/`ARRAY_MAX`, which take a single array
+  argument. Added a new `CouchbaseArrayConstantExpression` (an inline N1QL array literal,
+  `[e1, e2, ...]`) and a `CouchbaseSqlTranslatingExpressionVisitor` overriding EF Core's own
+  `GenerateGreatest`/`GenerateLeast` hooks to build `ARRAY_MAX`/`ARRAY_MIN` over it. Found along the
+  way: EF Core's core `RelationalSqlTranslatingExpressionVisitor` intercepts `Math.Max`/`Math.Min`
+  directly and calls these two hooks (returning `null`/unsupported by default) — registering them in
+  an `IMethodCallTranslator` (the originally-planned approach) is dead code that's never reached.
+  This also means `EF.Functions.Least`/`Greatest` (accepting any number of arguments, not just two)
+  and automatic flattening of a `Math.Max(Math.Max(a, b), c)`-style chain into a single N-ary
+  `ARRAY_MAX([a, b, c])` come for free. See [Supported functions](docs/Queries.md#supported-functions).
 - **`[UnixMillisDateTime]`/`HasUnixMillisDateTime` — Unix-millis `DateTime` storage mode.** Stores a
   `DateTime` property as Unix epoch milliseconds (a JSON `NUMBER`) instead of this provider's
   default ISO-8601 string, for data that already uses that convention. Attaches a

--- a/docs/Queries.md
+++ b/docs/Queries.md
@@ -133,6 +133,8 @@ SQL++ so they run server-side instead of throwing or falling back to client eval
 | `Math.Pow(x, y)`                       | `POWER(x, y)`                       |
 | `Math.Log(x)` / `Log10(x)` / `Exp(x)`  | `LN(x)` / `LOG(x)` / `EXP(x)`        |
 | `Math.Log(x, newBase)`                 | `LN(x) / LN(newBase)`                |
+| `Math.Min(a, b)` / `Math.Max(a, b)`    | `ARRAY_MIN([a, b])` / `ARRAY_MAX([a, b])` |
+| `EF.Functions.Least(...)` / `EF.Functions.Greatest(...)` | `ARRAY_MIN([...])` / `ARRAY_MAX([...])` |
 | `DateTime.Year/Month/Day/Hour/Minute/Second/Millisecond/DayOfWeek/DayOfYear` | `DATE_PART_STR(x, part)` |
 | `DateTime.Date`                        | `DATE_TRUNC_STR(x, 'day', fmt)`     |
 | `DateTime.Now`                         | `NOW_LOCAL(fmt)`                    |
@@ -174,10 +176,14 @@ A `DateTime` property marked
 above — see [Unix-millis DateTime storage](configuration.md#unix-millis-datetime-storage) for the
 comparison-against-`DateTime.UtcNow` caveat.
 
-Not yet supported: `Math.Min`/`Math.Max` (N1QL's `ARRAY_MAX`/`ARRAY_MIN` take a single array
-argument, not two scalars — no array-literal expression support exists yet to build one), trig
-functions (`Sin`/`Cos`/`Tan`/...), and secondary-index support for EF Core's `HasIndex()` (see
-[Limitations](limitations.md)).
+`Math.Min`/`Math.Max` and `EF.Functions.Least`/`Greatest` translate to N1QL's `ARRAY_MIN`/`ARRAY_MAX`
+functions, which take a single array argument rather than N scalar arguments — the provider builds
+an inline array literal (`[a, b, ...]`) to bridge the two. `EF.Functions.Least`/`Greatest` accept
+any number of arguments; a chain of `Math.Max(Math.Max(a, b), c)`-style calls is automatically
+flattened by EF Core into a single N-ary `ARRAY_MAX([a, b, c])` rather than nesting.
+
+Not yet supported: trig functions (`Sin`/`Cos`/`Tan`/...), and secondary-index support for EF
+Core's `HasIndex()` (see [Limitations](limitations.md)).
 
 ## Primitive collections
 

--- a/src/Couchbase.EntityFrameworkCore/Extensions/CouchbaseServiceCollectionExtensions.cs
+++ b/src/Couchbase.EntityFrameworkCore/Extensions/CouchbaseServiceCollectionExtensions.cs
@@ -84,6 +84,7 @@ public static class CouchbaseServiceCollectionExtensions
             .TryAdd<ISqlGenerationHelper, CouchbaseSqlGenerationHelper>()
             .TryAdd<IShapedQueryCompilingExpressionVisitorFactory, CouchbaseShapedQueryCompilingExpressionVisitorFactory>()
             .TryAdd<IQueryableMethodTranslatingExpressionVisitorFactory, CouchbaseQueryableMethodTranslatingExpressionVisitorFactory>()
+            .TryAdd<IRelationalSqlTranslatingExpressionVisitorFactory, CouchbaseSqlTranslatingExpressionVisitorFactory>()
             .TryAdd<IRelationalParameterBasedSqlProcessorFactory, CouchbaseParameterBasedSqlProcessorFactory>()
             .TryAdd<IHistoryRepository, CouchbaseHistoryRepository>()//not used but required by ASP.NET
 

--- a/src/Couchbase.EntityFrameworkCore/Query/Internal/CouchbaseArrayConstantExpression.cs
+++ b/src/Couchbase.EntityFrameworkCore/Query/Internal/CouchbaseArrayConstantExpression.cs
@@ -1,0 +1,124 @@
+using System.Linq.Expressions;
+using System.Reflection;
+using Microsoft.EntityFrameworkCore.Query;
+using Microsoft.EntityFrameworkCore.Query.SqlExpressions;
+using Microsoft.EntityFrameworkCore.Storage;
+
+namespace Couchbase.EntityFrameworkCore.Query.Internal;
+
+/// <summary>
+/// An expression representing an inline N1QL array literal (<c>[e1, e2, ...]</c>) in a SQL tree --
+/// used to build the single array argument N1QL's <c>ARRAY_MIN</c>/<c>ARRAY_MAX</c> require (unlike
+/// C#'s <c>Math.Min(a, b)</c>/<c>Math.Max(a, b)</c>, which take two scalar arguments). Mirrors
+/// <see cref="CouchbaseArrayIndexExpression"/>'s shape -- a small, provider-specific
+/// <see cref="SqlExpression"/> subtype rendered directly by <c>CouchbaseQuerySqlGenerator</c>,
+/// rather than trying to force this shape through a stock <see cref="SqlConstantExpression"/> or
+/// <see cref="SqlFunctionExpression"/>.
+/// </summary>
+public class CouchbaseArrayConstantExpression : SqlExpression
+{
+    private static ConstructorInfo? _quotingConstructor;
+
+    public virtual IReadOnlyList<SqlExpression> Elements { get; }
+
+    public CouchbaseArrayConstantExpression(
+        IReadOnlyList<SqlExpression> elements,
+        Type type,
+        RelationalTypeMapping? typeMapping)
+        : base(type, typeMapping)
+    {
+        Elements = elements;
+    }
+
+    protected override Expression VisitChildren(ExpressionVisitor visitor)
+    {
+        SqlExpression[]? newElements = null;
+        for (var i = 0; i < Elements.Count; i++)
+        {
+            var newElement = (SqlExpression)visitor.Visit(Elements[i]);
+            if (newElement != Elements[i] && newElements == null)
+            {
+                newElements = new SqlExpression[Elements.Count];
+                for (var j = 0; j < i; j++)
+                {
+                    newElements[j] = Elements[j];
+                }
+            }
+
+            if (newElements != null)
+            {
+                newElements[i] = newElement;
+            }
+        }
+
+        return newElements == null ? this : Update(newElements);
+    }
+
+    public virtual CouchbaseArrayConstantExpression Update(IReadOnlyList<SqlExpression> elements)
+        => elements.Count == Elements.Count && elements.Zip(Elements, (a, b) => a == b).All(x => x)
+            ? this
+            : new CouchbaseArrayConstantExpression(elements, Type, TypeMapping);
+
+#pragma warning disable EF9100 // RelationalExpressionQuotingUtilities is evaluation-purposes-only -- matches the same pattern CouchbaseArrayIndexExpression uses for this exact purpose.
+    public override Expression Quote()
+        => Expression.New(
+            _quotingConstructor ??= typeof(CouchbaseArrayConstantExpression).GetConstructor(
+                [typeof(IReadOnlyList<SqlExpression>), typeof(Type), typeof(RelationalTypeMapping)])!,
+            Expression.NewArrayInit(typeof(SqlExpression), Elements.Select(e => e.Quote())),
+            Expression.Constant(Type),
+            RelationalExpressionQuotingUtilities.QuoteTypeMapping(TypeMapping));
+#pragma warning restore EF9100
+
+    protected override void Print(ExpressionPrinter expressionPrinter)
+    {
+        expressionPrinter.Append("[");
+        for (var i = 0; i < Elements.Count; i++)
+        {
+            if (i > 0)
+            {
+                expressionPrinter.Append(", ");
+            }
+
+            expressionPrinter.Visit(Elements[i]);
+        }
+
+        expressionPrinter.Append("]");
+    }
+
+    public override bool Equals(object? obj)
+        => ReferenceEquals(this, obj) || (obj is CouchbaseArrayConstantExpression other && Equals(other));
+
+    private bool Equals(CouchbaseArrayConstantExpression other)
+        => base.Equals(other) && Elements.SequenceEqual(other.Elements);
+
+    public override int GetHashCode()
+    {
+        var hash = new HashCode();
+        hash.Add(base.GetHashCode());
+        foreach (var element in Elements)
+        {
+            hash.Add(element);
+        }
+
+        return hash.ToHashCode();
+    }
+}
+
+/* ************************************************************
+ *
+ *    @author Couchbase <info@couchbase.com>
+ *    @copyright 2025 Couchbase, Inc.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ *
+ * ************************************************************/

--- a/src/Couchbase.EntityFrameworkCore/Query/Internal/CouchbaseQuerySqlGenerator.cs
+++ b/src/Couchbase.EntityFrameworkCore/Query/Internal/CouchbaseQuerySqlGenerator.cs
@@ -1132,11 +1132,11 @@ public class CouchbaseQuerySqlGenerator : QuerySqlGenerator
 
     /// <summary>
     /// Dispatch point for provider-specific extension expression types (<see cref="ExpressionType.Extension"/>).
-    /// <see cref="CouchbaseUnnestExpression"/>, <see cref="CouchbaseUnnestValueExpression"/>, and
-    /// <see cref="CouchbaseArrayIndexExpression"/> are the only ones this provider introduces;
-    /// anything else falls through to the base dispatcher (which itself handles all of EF Core's
-    /// own stock extension node types -- <see cref="TableExpression"/>, <see cref="ColumnExpression"/>,
-    /// etc.).
+    /// <see cref="CouchbaseUnnestExpression"/>, <see cref="CouchbaseUnnestValueExpression"/>,
+    /// <see cref="CouchbaseArrayIndexExpression"/>, and <see cref="CouchbaseArrayConstantExpression"/>
+    /// are the only ones this provider introduces; anything else falls through to the base
+    /// dispatcher (which itself handles all of EF Core's own stock extension node types --
+    /// <see cref="TableExpression"/>, <see cref="ColumnExpression"/>, etc.).
     /// </summary>
     protected override Expression VisitExtension(Expression node)
         => node switch
@@ -1144,6 +1144,7 @@ public class CouchbaseQuerySqlGenerator : QuerySqlGenerator
             CouchbaseUnnestExpression unnestExpression => GenerateUnnest(unnestExpression),
             CouchbaseUnnestValueExpression valueExpression => GenerateUnnestValue(valueExpression),
             CouchbaseArrayIndexExpression arrayIndexExpression => GenerateArrayIndex(arrayIndexExpression),
+            CouchbaseArrayConstantExpression arrayConstantExpression => GenerateArrayConstant(arrayConstantExpression),
             _ => base.VisitExtension(node),
         };
 
@@ -1197,6 +1198,29 @@ public class CouchbaseQuerySqlGenerator : QuerySqlGenerator
         Sql.Append("]");
 
         return arrayIndexExpression;
+    }
+
+    /// <summary>
+    /// Renders an inline N1QL array literal (<c>[e1, e2, ...]</c>), built by
+    /// <see cref="CouchbaseSqlTranslatingExpressionVisitor.GenerateGreatest"/>/<c>GenerateLeast</c>
+    /// to supply the single array argument <c>ARRAY_MAX</c>/<c>ARRAY_MIN</c> require.
+    /// </summary>
+    private Expression GenerateArrayConstant(CouchbaseArrayConstantExpression arrayConstantExpression)
+    {
+        Sql.Append("[");
+        for (var i = 0; i < arrayConstantExpression.Elements.Count; i++)
+        {
+            if (i > 0)
+            {
+                Sql.Append(", ");
+            }
+
+            Visit(arrayConstantExpression.Elements[i]);
+        }
+
+        Sql.Append("]");
+
+        return arrayConstantExpression;
     }
 
     protected override Expression VisitTable(TableExpression tableExpression)

--- a/src/Couchbase.EntityFrameworkCore/Query/Internal/CouchbaseSqlNullabilityProcessor.cs
+++ b/src/Couchbase.EntityFrameworkCore/Query/Internal/CouchbaseSqlNullabilityProcessor.cs
@@ -27,6 +27,8 @@ public class CouchbaseSqlNullabilityProcessor : SqlNullabilityProcessor
                 => VisitArrayIndex(arrayIndexExpression, allowOptimizedExpansion, out nullable),
             CouchbaseUnnestValueExpression valueExpression
                 => VisitUnnestValue(valueExpression, out nullable),
+            CouchbaseArrayConstantExpression arrayConstantExpression
+                => VisitArrayConstant(arrayConstantExpression, allowOptimizedExpansion, out nullable),
             _ => base.VisitCustomSqlExpression(sqlExpression, allowOptimizedExpansion, out nullable)
         };
 
@@ -47,5 +49,23 @@ public class CouchbaseSqlNullabilityProcessor : SqlNullabilityProcessor
         nullable = true;
 
         return arrayIndexExpression.Update(array, index);
+    }
+
+    protected virtual SqlExpression VisitArrayConstant(
+        CouchbaseArrayConstantExpression arrayConstantExpression, bool allowOptimizedExpansion, out bool nullable)
+    {
+        var elements = new SqlExpression[arrayConstantExpression.Elements.Count];
+        for (var i = 0; i < elements.Length; i++)
+        {
+            elements[i] = Visit(arrayConstantExpression.Elements[i], out _);
+        }
+
+        // The array literal itself ([e1, e2, ...]) is never null, regardless of whether any
+        // individual element is -- an element being NULL just makes that slot contain NULL, not
+        // the whole array. Distinct from CouchbaseArrayIndexExpression above, where indexing INTO
+        // an array can itself produce MISSING.
+        nullable = false;
+
+        return arrayConstantExpression.Update(elements);
     }
 }

--- a/src/Couchbase.EntityFrameworkCore/Query/Internal/CouchbaseSqlTranslatingExpressionVisitor.cs
+++ b/src/Couchbase.EntityFrameworkCore/Query/Internal/CouchbaseSqlTranslatingExpressionVisitor.cs
@@ -1,0 +1,99 @@
+using Microsoft.EntityFrameworkCore.Query;
+using Microsoft.EntityFrameworkCore.Query.SqlExpressions;
+
+namespace Couchbase.EntityFrameworkCore.Query.Internal;
+
+/// <summary>
+/// Overrides <see cref="GenerateGreatest"/>/<see cref="GenerateLeast"/> to support
+/// <c>Math.Max</c>/<c>Math.Min</c> and <c>EF.Functions.Greatest</c>/<c>EF.Functions.Least</c>.
+/// </summary>
+/// <remarks>
+/// EF Core's own core <c>RelationalSqlTranslatingExpressionVisitor</c> intercepts these methods
+/// directly (confirmed by reading its source -- <c>case { Method.Name: nameof(Math.Max) or
+/// nameof(Math.Min), ... }</c>), calling these two virtual hooks -- which the base class returns
+/// <see langword="null"/> from by default, meaning a provider must override them to support these
+/// methods at all. This was found the hard way: registering <c>Math.Min</c>/<c>Math.Max</c> in
+/// <c>CouchbaseMathMethodTranslator</c> (an <c>IMethodCallTranslator</c>) is dead code for these two
+/// specific methods -- the core visitor never reaches method-call translators for them.
+/// <para>
+/// N1QL has no variadic <c>GREATEST</c>/<c>LEAST</c> function; the equivalent is
+/// <c>ARRAY_MAX</c>/<c>ARRAY_MIN</c>, which take a single array argument. Built via
+/// <see cref="CouchbaseArrayConstantExpression"/> (an inline array literal) wrapped in a
+/// <c>SqlFunctionExpression</c> call to <c>ARRAY_MAX</c>/<c>ARRAY_MIN</c>. This naturally supports
+/// any number of arguments (not just two) -- both <c>EF.Functions.Greatest</c>/<c>Least</c>'s own
+/// N-ary array-parameter shape and the core visitor's own flattening of nested
+/// <c>Math.Max(Math.Max(a, b), c)</c>-style calls into a single N-ary call.
+/// </para>
+/// </remarks>
+public class CouchbaseSqlTranslatingExpressionVisitor : RelationalSqlTranslatingExpressionVisitor
+{
+    public CouchbaseSqlTranslatingExpressionVisitor(
+        RelationalSqlTranslatingExpressionVisitorDependencies dependencies,
+        QueryCompilationContext queryCompilationContext,
+        QueryableMethodTranslatingExpressionVisitor queryableMethodTranslatingExpressionVisitor)
+        : base(dependencies, queryCompilationContext, queryableMethodTranslatingExpressionVisitor)
+    {
+    }
+
+    public override SqlExpression? GenerateGreatest(IReadOnlyList<SqlExpression> expressions, Type resultType)
+        => GenerateArrayAggregate("ARRAY_MAX", expressions, resultType);
+
+    public override SqlExpression? GenerateLeast(IReadOnlyList<SqlExpression> expressions, Type resultType)
+        => GenerateArrayAggregate("ARRAY_MIN", expressions, resultType);
+
+    private SqlExpression? GenerateArrayAggregate(string functionName, IReadOnlyList<SqlExpression> expressions, Type resultType)
+    {
+        // RelationalTypeMappingPostprocessor requires every SqlExpression in the tree -- including
+        // each individual element, not just the array literal wrapper -- to end up with a non-null
+        // TypeMapping. A bare literal argument (e.g. the "1.0" in Math.Max(x, 1.0)) has none yet at
+        // this point in translation, since nothing about our custom array-literal shape lets EF
+        // Core's normal contextual inference (e.g. from the other side of a comparison) reach it.
+        // Align every element to the first one with a resolved mapping (typically a column) --
+        // reasonable since every argument to Math.Max/Min/EF.Functions.Greatest/Least is expected
+        // to share the same comparable type anyway.
+        var sqlExpressionFactory = Dependencies.SqlExpressionFactory;
+        var sharedTypeMapping = expressions.Select(e => e.TypeMapping).FirstOrDefault(m => m != null)
+            ?? Dependencies.TypeMappingSource.FindMapping(resultType);
+        if (sharedTypeMapping == null)
+        {
+            // FindMapping legitimately returns null for CLR types with no registered mapping --
+            // fail translation cleanly here (matching the base class's own null-means-unsupported
+            // convention for these hooks) rather than building a tree with a null TypeMapping that
+            // would surface as a much more confusing failure later in RelationalTypeMappingPostprocessor.
+            return null;
+        }
+
+        var alignedExpressions = expressions
+            .Select(e => sqlExpressionFactory.ApplyTypeMapping(e, sharedTypeMapping))
+            .ToArray();
+
+        var arrayLiteral = new CouchbaseArrayConstantExpression(
+            alignedExpressions, resultType.MakeArrayType(), sharedTypeMapping);
+
+        return Dependencies.SqlExpressionFactory.Function(
+            functionName,
+            new SqlExpression[] { arrayLiteral },
+            nullable: true,
+            argumentsPropagateNullability: new[] { true },
+            resultType);
+    }
+}
+
+/* ************************************************************
+ *
+ *    @author Couchbase <info@couchbase.com>
+ *    @copyright 2025 Couchbase, Inc.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ *
+ * ************************************************************/

--- a/src/Couchbase.EntityFrameworkCore/Query/Internal/CouchbaseSqlTranslatingExpressionVisitorFactory.cs
+++ b/src/Couchbase.EntityFrameworkCore/Query/Internal/CouchbaseSqlTranslatingExpressionVisitorFactory.cs
@@ -1,0 +1,36 @@
+using Microsoft.EntityFrameworkCore.Query;
+
+namespace Couchbase.EntityFrameworkCore.Query.Internal;
+
+public class CouchbaseSqlTranslatingExpressionVisitorFactory : RelationalSqlTranslatingExpressionVisitorFactory
+{
+    public CouchbaseSqlTranslatingExpressionVisitorFactory(RelationalSqlTranslatingExpressionVisitorDependencies dependencies)
+        : base(dependencies)
+    {
+    }
+
+    public override RelationalSqlTranslatingExpressionVisitor Create(
+        QueryCompilationContext queryCompilationContext,
+        QueryableMethodTranslatingExpressionVisitor queryableMethodTranslatingExpressionVisitor)
+        => new CouchbaseSqlTranslatingExpressionVisitor(
+            Dependencies, queryCompilationContext, queryableMethodTranslatingExpressionVisitor);
+}
+
+/* ************************************************************
+ *
+ *    @author Couchbase <info@couchbase.com>
+ *    @copyright 2025 Couchbase, Inc.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ *
+ * ************************************************************/

--- a/tests/Couchbase.EntityFrameworkCore.IntegrationTests/Tests/FunctionTranslationTests.cs
+++ b/tests/Couchbase.EntityFrameworkCore.IntegrationTests/Tests/FunctionTranslationTests.cs
@@ -251,6 +251,49 @@ public class FunctionTranslationTests(BloggingFixture fixture, ITestOutputHelper
     }
 
     [Fact]
+    public async Task Min_ColumnVsConstant_ReturnsSmallerValue()
+    {
+        // Score is -4.7 for the seeded entity -- smaller than 0, so Math.Min(Score, 0) == Score.
+        var result = await _context.Entities.Where(e => Math.Min(e.Score, 0) == e.Score).ToListAsync();
+        Assert.Single(result);
+    }
+
+    [Fact]
+    public async Task Max_ColumnVsConstant_ReturnsLargerValue()
+    {
+        // Score is -4.7 for the seeded entity -- smaller than 0, so Math.Max(Score, 0) == 0, not Score.
+        var result = await _context.Entities.Where(e => Math.Max(e.Score, 0) == 0).ToListAsync();
+        Assert.Single(result);
+    }
+
+    [Fact]
+    public async Task Min_TwoColumns_ReturnsCorrectValue()
+    {
+        var result = await _context.Entities.Where(e => Math.Min(e.Score, e.Score - 1) == e.Score - 1).ToListAsync();
+        Assert.Single(result);
+    }
+
+    [Fact]
+    public async Task EfFunctionsGreatest_ThreeArguments_ReturnsLargestValue()
+    {
+        // Score is -4.7; greatest of Score, 0, and -10 is 0.
+        var result = await _context.Entities
+            .Where(e => EF.Functions.Greatest(e.Score, 0, -10) == 0)
+            .ToListAsync();
+        Assert.Single(result);
+    }
+
+    [Fact]
+    public async Task EfFunctionsLeast_ThreeArguments_ReturnsSmallestValue()
+    {
+        // Score is -4.7; least of Score, 0, and -10 is -10.
+        var result = await _context.Entities
+            .Where(e => EF.Functions.Least(e.Score, 0, -10) == -10)
+            .ToListAsync();
+        Assert.Single(result);
+    }
+
+    [Fact]
     public async Task NewGuid_ProjectsNonEmptyValue()
     {
         // A projection that also references a real column keeps a normal FROM clause -- the

--- a/tests/Couchbase.EntityFrameworkCore.UnitTests/Couchbase/EntityFrameworkCore/Query/CouchbaseMathFunctionSqlGenerationTests.cs
+++ b/tests/Couchbase.EntityFrameworkCore.UnitTests/Couchbase/EntityFrameworkCore/Query/CouchbaseMathFunctionSqlGenerationTests.cs
@@ -133,6 +133,86 @@ public class CouchbaseMathFunctionSqlGenerationTests
         Assert.Contains("/", sql);
     }
 
+    [Fact]
+    public void Min_TranslatesToArrayMinOverArrayLiteral()
+    {
+        using var ctx = CreateContext();
+        var query = ctx.Posts.Where(p => Math.Min(p.Score, 1.0) > 0);
+
+        var sql = query.ToQueryString();
+        Assert.Contains("ARRAY_MIN([", sql, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("`Score`", sql);
+    }
+
+    [Fact]
+    public void Max_TranslatesToArrayMaxOverArrayLiteral()
+    {
+        using var ctx = CreateContext();
+        var query = ctx.Posts.Where(p => Math.Max(p.Score, 1.0) > 0);
+
+        var sql = query.ToQueryString();
+        Assert.Contains("ARRAY_MAX([", sql, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("`Score`", sql);
+    }
+
+    [Fact]
+    public void Min_BothColumns_TranslatesToArrayMinWithBothColumns()
+    {
+        using var ctx = CreateContext();
+        var query = ctx.Posts.Where(p => Math.Min(p.Score, p.OtherScore) > 0);
+
+        var sql = query.ToQueryString();
+        Assert.Contains("ARRAY_MIN([", sql, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("`Score`", sql);
+        Assert.Contains("`OtherScore`", sql);
+    }
+
+    [Fact]
+    public void Max_NestedChain_FlattensIntoSingleArrayMaxWithThreeElements()
+    {
+        // C# only has the 2-arg overload, but EF Core's own core visitor recognizes a chained
+        // Math.Max(Math.Max(a, b), c) of the SAME method and flattens it into a single N-ary
+        // GenerateGreatest([a, b, c]) call -- confirmed by reading RelationalSqlTranslatingExpressionVisitor's
+        // TryFlattenVisit -- rather than nesting ARRAY_MAX(ARRAY_MAX([a,b]), c).
+        using var ctx = CreateContext();
+        var query = ctx.Posts.Where(p => Math.Max(Math.Max(p.Score, p.OtherScore), 1.0) > 0);
+
+        var sql = query.ToQueryString();
+        Assert.Contains("ARRAY_MAX([", sql, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("`Score`", sql);
+        Assert.Contains("`OtherScore`", sql);
+
+        var firstIndex = sql.IndexOf("ARRAY_MAX([", StringComparison.OrdinalIgnoreCase);
+        var secondIndex = sql.IndexOf("ARRAY_MAX([", firstIndex + 1, StringComparison.OrdinalIgnoreCase);
+        Assert.True(secondIndex < 0, "Expected a single flattened ARRAY_MAX([ call, not nested calls.");
+    }
+
+    [Fact]
+    public void EfFunctionsGreatest_TranslatesToArrayMaxOverArrayLiteral()
+    {
+        // Comes for free from the same GenerateGreatest override Math.Max uses -- EF.Functions.Greatest
+        // supports an arbitrary number of arguments (not just two), unlike Math.Max.
+        using var ctx = CreateContext();
+        var query = ctx.Posts.Where(p => EF.Functions.Greatest(p.Score, p.OtherScore, 1.0) > 0);
+
+        var sql = query.ToQueryString();
+        Assert.Contains("ARRAY_MAX([", sql, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("`Score`", sql);
+        Assert.Contains("`OtherScore`", sql);
+    }
+
+    [Fact]
+    public void EfFunctionsLeast_TranslatesToArrayMinOverArrayLiteral()
+    {
+        using var ctx = CreateContext();
+        var query = ctx.Posts.Where(p => EF.Functions.Least(p.Score, p.OtherScore, 1.0) > 0);
+
+        var sql = query.ToQueryString();
+        Assert.Contains("ARRAY_MIN([", sql, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("`Score`", sql);
+        Assert.Contains("`OtherScore`", sql);
+    }
+
     private static PostContext CreateContext()
     {
         var clusterOptions = new ClusterOptions()
@@ -148,6 +228,7 @@ public class CouchbaseMathFunctionSqlGenerationTests
     {
         public int PostId { get; set; }
         public double Score { get; set; }
+        public double OtherScore { get; set; }
     }
 
     private class PostContext(DbContextOptions<PostContext> options) : DbContext(options)


### PR DESCRIPTION
N1QL has no variadic GREATEST/LEAST function -- the equivalent is ARRAY_MIN/ARRAY_MAX, which take a single array argument. Add CouchbaseArrayConstantExpression (an inline N1QL array literal, [e1, e2, ...]) and a CouchbaseSqlTranslatingExpressionVisitor overriding EF Core's GenerateGreatest/GenerateLeast hooks to build ARRAY_MAX/ARRAY_MIN over it.

EF Core's core RelationalSqlTranslatingExpressionVisitor intercepts Math.Max/Math.Min directly and calls these two hooks (returning null/ unsupported by default) -- registering them in an IMethodCallTranslator is dead code that's never reached for these two methods. Overriding the hooks instead also gets EF.Functions.Least/Greatest (any number of arguments, not just two) and automatic flattening of a Math.Max(Math.Max(a, b), c)-style chain into a single N-ary ARRAY_MAX([a, b, c]) for free.

Add unit tests (SQL generation for Min/Max/Greatest/Least, including the flattened-chain shape) and live integration tests proving the generated N1QL actually executes and returns correct results. Update docs/Queries.md and CHANGELOG.md.