### PR TITLE
Add trig function support (Sin/Cos/Tan/Asin/Acos/Atan/Atan2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project aims to follow [Semantic Versioning](https://semver.org/spec/v2
 
 ### Added
 
+- **`Math.Sin`/`Cos`/`Tan`/`Asin`/`Acos`/`Atan`/`Atan2`.** Direct 1:1 N1QL equivalents
+  (`SIN`/`COS`/`TAN`/`ASIN`/`ACOS`/`ATAN`/`ATAN2`) — no array-literal complexity like `Math.Min`/`Max`
+  needed, since these all take/return plain scalars. See
+  [Supported functions](docs/Queries.md#supported-functions).
 - **`Math.Min(a, b)`/`Math.Max(a, b)` and `EF.Functions.Least`/`Greatest`.** N1QL has no variadic
   `GREATEST`/`LEAST` function — the equivalent is `ARRAY_MIN`/`ARRAY_MAX`, which take a single array
   argument. Added a new `CouchbaseArrayConstantExpression` (an inline N1QL array literal,

--- a/docs/Queries.md
+++ b/docs/Queries.md
@@ -133,6 +133,8 @@ SQL++ so they run server-side instead of throwing or falling back to client eval
 | `Math.Pow(x, y)`                       | `POWER(x, y)`                       |
 | `Math.Log(x)` / `Log10(x)` / `Exp(x)`  | `LN(x)` / `LOG(x)` / `EXP(x)`        |
 | `Math.Log(x, newBase)`                 | `LN(x) / LN(newBase)`                |
+| `Math.Sin/Cos/Tan/Asin/Acos/Atan(x)`   | `SIN/COS/TAN/ASIN/ACOS/ATAN(x)`      |
+| `Math.Atan2(y, x)`                     | `ATAN2(y, x)`                        |
 | `Math.Min(a, b)` / `Math.Max(a, b)`    | `ARRAY_MIN([a, b])` / `ARRAY_MAX([a, b])` |
 | `EF.Functions.Least(...)` / `EF.Functions.Greatest(...)` | `ARRAY_MIN([...])` / `ARRAY_MAX([...])` |
 | `DateTime.Year/Month/Day/Hour/Minute/Second/Millisecond/DayOfWeek/DayOfYear` | `DATE_PART_STR(x, part)` |
@@ -182,8 +184,8 @@ an inline array literal (`[a, b, ...]`) to bridge the two. `EF.Functions.Least`/
 any number of arguments; a chain of `Math.Max(Math.Max(a, b), c)`-style calls is automatically
 flattened by EF Core into a single N-ary `ARRAY_MAX([a, b, c])` rather than nesting.
 
-Not yet supported: trig functions (`Sin`/`Cos`/`Tan`/...), and secondary-index support for EF
-Core's `HasIndex()` (see [Limitations](limitations.md)).
+Not yet supported: secondary-index support for EF Core's `HasIndex()` (see
+[Limitations](limitations.md)).
 
 ## Primitive collections
 

--- a/src/Couchbase.EntityFrameworkCore/Query/Internal/Translators/CouchbaseMathMethodTranslator.cs
+++ b/src/Couchbase.EntityFrameworkCore/Query/Internal/Translators/CouchbaseMathMethodTranslator.cs
@@ -32,6 +32,12 @@ public class CouchbaseMathMethodTranslator : IMethodCallTranslator
         { GetMathMethod(nameof(Math.Log), typeof(double)), "LN" },
         { GetMathMethod(nameof(Math.Log10), typeof(double)), "LOG" }, // N1QL's LOG is fixed base-10.
         { GetMathMethod(nameof(Math.Exp), typeof(double)), "EXP" },
+        { GetMathMethod(nameof(Math.Sin), typeof(double)), "SIN" },
+        { GetMathMethod(nameof(Math.Cos), typeof(double)), "COS" },
+        { GetMathMethod(nameof(Math.Tan), typeof(double)), "TAN" },
+        { GetMathMethod(nameof(Math.Asin), typeof(double)), "ASIN" },
+        { GetMathMethod(nameof(Math.Acos), typeof(double)), "ACOS" },
+        { GetMathMethod(nameof(Math.Atan), typeof(double)), "ATAN" },
     };
 
     private static readonly IReadOnlyDictionary<MethodInfo, string> RoundWithDigitsFunctionMappings = new Dictionary<MethodInfo, string>
@@ -39,6 +45,8 @@ public class CouchbaseMathMethodTranslator : IMethodCallTranslator
         { GetMathMethod(nameof(Math.Round), typeof(double), typeof(int)), "ROUND" },
         { GetMathMethod(nameof(Math.Round), typeof(decimal), typeof(int)), "ROUND" },
     };
+
+    private static readonly MethodInfo Atan2MethodInfo = GetMathMethod(nameof(Math.Atan2), typeof(double), typeof(double));
 
     private static readonly MethodInfo PowMethodInfo = GetMathMethod(nameof(Math.Pow), typeof(double), typeof(double));
 
@@ -71,6 +79,16 @@ public class CouchbaseMathMethodTranslator : IMethodCallTranslator
         {
             return _sqlExpressionFactory.Function(
                 roundFunctionName,
+                new[] { arguments[0], arguments[1] },
+                nullable: true,
+                argumentsPropagateNullability: new[] { true, true },
+                method.ReturnType);
+        }
+
+        if (Atan2MethodInfo.Equals(method))
+        {
+            return _sqlExpressionFactory.Function(
+                "ATAN2",
                 new[] { arguments[0], arguments[1] },
                 nullable: true,
                 argumentsPropagateNullability: new[] { true, true },

--- a/tests/Couchbase.EntityFrameworkCore.IntegrationTests/Tests/FunctionTranslationTests.cs
+++ b/tests/Couchbase.EntityFrameworkCore.IntegrationTests/Tests/FunctionTranslationTests.cs
@@ -251,6 +251,65 @@ public class FunctionTranslationTests(BloggingFixture fixture, ITestOutputHelper
     }
 
     [Fact]
+    public async Task Sin_ReturnsCorrectValue()
+    {
+        // Projected and compared client-side with a tolerance, rather than filtered with an exact
+        // equality WHERE clause, since a transcendental function's last-bit result can legitimately
+        // differ between .NET's and the query engine's underlying math library. Wrapped in an
+        // anonymous type -- a bare scalar .Select(e => expr) is a separate, pre-existing, unrelated
+        // materialization gap in this provider (see CouchbaseCoalesceTests's remarks), not something
+        // this test exists to cover.
+        var result = await _context.Entities.Select(e => new { Value = Math.Sin(e.Score) }).SingleAsync();
+        Assert.Equal(Math.Sin(-4.7), result.Value, precision: 9);
+    }
+
+    [Fact]
+    public async Task Cos_ReturnsCorrectValue()
+    {
+        var result = await _context.Entities.Select(e => new { Value = Math.Cos(e.Score) }).SingleAsync();
+        Assert.Equal(Math.Cos(-4.7), result.Value, precision: 9);
+    }
+
+    [Fact]
+    public async Task Tan_ReturnsCorrectValue()
+    {
+        var result = await _context.Entities.Select(e => new { Value = Math.Tan(e.Score) }).SingleAsync();
+        Assert.Equal(Math.Tan(-4.7), result.Value, precision: 9);
+    }
+
+    [Fact]
+    public async Task Asin_ReturnsCorrectValue()
+    {
+        // Asin/Acos require a domain of [-1, 1] -- Score (-4.7) is out of range, so this projects
+        // (Score - Score), always exactly 0, to stay in-domain while still depending on the
+        // entity property (so EF Core can't fold it client-side before translation) and exercising
+        // the real translator against live data.
+        var result = await _context.Entities.Select(e => new { Value = Math.Asin(e.Score - e.Score) }).SingleAsync();
+        Assert.Equal(Math.Asin(0), result.Value, precision: 9);
+    }
+
+    [Fact]
+    public async Task Acos_ReturnsCorrectValue()
+    {
+        var result = await _context.Entities.Select(e => new { Value = Math.Acos(e.Score - e.Score) }).SingleAsync();
+        Assert.Equal(Math.Acos(0), result.Value, precision: 9);
+    }
+
+    [Fact]
+    public async Task Atan_ReturnsCorrectValue()
+    {
+        var result = await _context.Entities.Select(e => new { Value = Math.Atan(e.Score) }).SingleAsync();
+        Assert.Equal(Math.Atan(-4.7), result.Value, precision: 9);
+    }
+
+    [Fact]
+    public async Task Atan2_ReturnsCorrectValue()
+    {
+        var result = await _context.Entities.Select(e => new { Value = Math.Atan2(e.Score, 1.0) }).SingleAsync();
+        Assert.Equal(Math.Atan2(-4.7, 1.0), result.Value, precision: 9);
+    }
+
+    [Fact]
     public async Task Min_ColumnVsConstant_ReturnsSmallerValue()
     {
         // Score is -4.7 for the seeded entity -- smaller than 0, so Math.Min(Score, 0) == Score.

--- a/tests/Couchbase.EntityFrameworkCore.UnitTests/Couchbase/EntityFrameworkCore/Query/CouchbaseMathFunctionSqlGenerationTests.cs
+++ b/tests/Couchbase.EntityFrameworkCore.UnitTests/Couchbase/EntityFrameworkCore/Query/CouchbaseMathFunctionSqlGenerationTests.cs
@@ -134,6 +134,73 @@ public class CouchbaseMathFunctionSqlGenerationTests
     }
 
     [Fact]
+    public void Sin_TranslatesToSin()
+    {
+        using var ctx = CreateContext();
+        var query = ctx.Posts.Where(p => Math.Sin(p.Score) > 0);
+
+        Assert.Contains("SIN(", query.ToQueryString(), StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void Cos_TranslatesToCos()
+    {
+        using var ctx = CreateContext();
+        var query = ctx.Posts.Where(p => Math.Cos(p.Score) > 0);
+
+        Assert.Contains("COS(", query.ToQueryString(), StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void Tan_TranslatesToTan()
+    {
+        using var ctx = CreateContext();
+        var query = ctx.Posts.Where(p => Math.Tan(p.Score) > 0);
+
+        Assert.Contains("TAN(", query.ToQueryString(), StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void Asin_TranslatesToAsin()
+    {
+        using var ctx = CreateContext();
+        var query = ctx.Posts.Where(p => Math.Asin(p.Score) > 0);
+
+        Assert.Contains("ASIN(", query.ToQueryString(), StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void Acos_TranslatesToAcos()
+    {
+        using var ctx = CreateContext();
+        var query = ctx.Posts.Where(p => Math.Acos(p.Score) > 0);
+
+        Assert.Contains("ACOS(", query.ToQueryString(), StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void Atan_TranslatesToAtan()
+    {
+        using var ctx = CreateContext();
+        var query = ctx.Posts.Where(p => Math.Atan(p.Score) > 0);
+
+        Assert.Contains("ATAN(", query.ToQueryString(), StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void Atan2_TranslatesToAtan2()
+    {
+        // Math.Atan2(y, x) is order-sensitive -- assert the exact argument order rather than just
+        // that both operands appear somewhere in the SQL, so a translator bug that swaps y/x would
+        // actually fail this test.
+        using var ctx = CreateContext();
+        var query = ctx.Posts.Where(p => Math.Atan2(p.Score, p.OtherScore) > 0);
+
+        var sql = query.ToQueryString();
+        Assert.Contains("ATAN2(`b`.`Score`, `b`.`OtherScore`)", sql, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
     public void Min_TranslatesToArrayMinOverArrayLiteral()
     {
         using var ctx = CreateContext();


### PR DESCRIPTION
Add Math.Sin/Cos/Tan/Asin/Acos/Atan to CouchbaseMathMethodTranslator's existing single-argument function mapping (direct 1:1 N1QL equivalents: SIN/COS/TAN/ASIN/ACOS/ATAN), and Math.Atan2(y, x) as a two-argument mapping to N1QL's ATAN2(y, x). Confirmed these methods reach IMethodCallTranslator normally, unlike Math.Min/Max, which EF Core's core visitor intercepts directly before any method-call translator runs.

Add unit tests (SQL generation) and live integration tests proving each function executes correctly against real data, comparing results client-side with a floating-point tolerance rather than an exact-match WHERE clause, since a transcendental function's last-bit result can legitimately differ between .NET's and the query engine's underlying math library. Update docs/Queries.md and CHANGELOG.md.