### PR TITLE
Add HasIndex() secondary-index auto-creation support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,21 @@ and this project aims to follow [Semantic Versioning](https://semver.org/spec/v2
 
 ### Added
 
+- **`HasIndex()` secondary-index auto-creation.** `EnsureCreatedAsync` (with `AutoCreateIndexes =
+  true`) now creates a N1QL `CREATE INDEX` for every `HasIndex()` declared on the model, in
+  addition to the existing primary-index creation, and waits for each to come online before
+  returning — reusing the same retry-on-transient-failure and online-polling machinery already
+  proven for primary indexes. Composite fields, `.HasFilter(...)` (spliced verbatim into the
+  generated `WHERE` clause), and an explicit `.HasDatabaseName(...)` are all supported; N1QL
+  requires a secondary index to be named (unlike the anonymous `CREATE PRIMARY INDEX`), confirmed
+  via a live spike. `.IsUnique()` is a logged no-op warning (N1QL GSI has no unique-constraint
+  concept), and an index referencing a property declared on an owned type is skipped with a
+  warning (not resolvable to a single JSON field path on the root document in this pass) — both
+  documented gaps rather than silent failures. Found along the way: a secondary index's
+  `system:indexes` row omits the `is_primary` field entirely on this server rather than reporting
+  `false`, so the online-wait query matches by name within the keyspace instead of also filtering
+  on `is_primary = false` (which would otherwise never match, per N1QL's missing-value semantics).
+  See [Secondary indexes (HasIndex())](docs/configuration.md#secondary-indexes-hasindex).
 - **`Math.Sin`/`Cos`/`Tan`/`Asin`/`Acos`/`Atan`/`Atan2`.** Direct 1:1 N1QL equivalents
   (`SIN`/`COS`/`TAN`/`ASIN`/`ACOS`/`ATAN`/`ATAN2`) — no array-literal complexity like `Math.Min`/`Max`
   needed, since these all take/return plain scalars. See

--- a/docs/Queries.md
+++ b/docs/Queries.md
@@ -184,8 +184,8 @@ an inline array literal (`[a, b, ...]`) to bridge the two. `EF.Functions.Least`/
 any number of arguments; a chain of `Math.Max(Math.Max(a, b), c)`-style calls is automatically
 flattened by EF Core into a single N-ary `ARRAY_MAX([a, b, c])` rather than nesting.
 
-Not yet supported: secondary-index support for EF Core's `HasIndex()` (see
-[Limitations](limitations.md)).
+EF Core's `HasIndex()` is supported for auto-creating N1QL secondary indexes via
+`EnsureCreatedAsync` — see [Secondary indexes (HasIndex())](configuration.md#secondary-indexes-hasindex).
 
 ## Primitive collections
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -52,7 +52,7 @@ The [CouchbaseDbContextOptionsBuilder](https://github.com/couchbaselabs/couchbas
 | `Scope` | *(required)* | The scope this context targets by default. |
 | `ScanConsistency` | `NotBounded` | N1QL scan consistency for LINQ/`FromSql`/ADO.NET queries. Set `RequestPlus` for read-after-write consistency at the cost of higher query latency. See [Limitations](limitations.md) for the full explanation. |
 | `AutoCreateScopes` | `false` | Whether `EnsureCreatedAsync` automatically creates non-default scopes referenced by entity mappings. When `false`, collections mapped to a non-default scope are skipped (with a warning) instead of created. |
-| `AutoCreateIndexes` | `false` | Whether `EnsureCreatedAsync` automatically creates a primary index on every collection it creates or already owns, waiting for each index to come online before returning. Does not create secondary indexes — see [Limitations](limitations.md#schema-management-and-migrations). |
+| `AutoCreateIndexes` | `false` | Whether `EnsureCreatedAsync` automatically creates a primary index, and a secondary index for every `HasIndex()` declared on the model, on every collection it creates or already owns — waiting for each index to come online before returning. See [Secondary indexes (HasIndex())](#secondary-indexes-hasindex) below. |
 | `FieldNamingPolicy` | `JsonNamingPolicy.CamelCase` | Controls how CLR navigation names are converted to JSON field names when reading/writing `OwnsMany` embedded collections. Set to `null` to use the CLR name verbatim (PascalCase), or supply a different policy such as `JsonNamingPolicy.SnakeCaseLower`. |
 | `SerializerOptions` | `null` (uses `JsonSerializerDefaults.Web`) | `JsonSerializerOptions` used when deserializing scalar values inside `OwnsMany` collections. Supply a custom instance to match a non-default serializer configured on the Couchbase SDK (custom converters, different enum handling, etc.). |
 | `DateTimeFormat` | `"yyyy-MM-ddTHH:mm:ss.FFFK"` | The .NET custom `DateTime` format string this provider assumes when generating or comparing against `DateTime` string values in SQL++ — used by the LINQ `DateTime` function translators (`.Date`, `.Now`, `.UtcNow`, `.Today`) and for inline `DateTime` literals. See [DateTime string format](#datetime-string-format) below. |
@@ -182,6 +182,42 @@ var recent = await context.Events.Where(e => e.OccurredAt > now).ToListAsync();
 
 A captured local becomes a query parameter, which correctly infers the millis conversion from the
 property it's compared against — unlike the static members, which never see that context.
+
+### Secondary indexes (HasIndex())
+
+When `AutoCreateIndexes` is `true`, `EnsureCreatedAsync` also creates a N1QL secondary (GSI) index
+for every `HasIndex()` declared on the model, in addition to the primary index:
+
+```csharp
+modelBuilder.Entity<Post>(b =>
+{
+    b.ToCouchbaseCollection("bucket", "scope", "post");
+    b.HasIndex(p => p.Score).HasDatabaseName("ix_post_score");
+    b.HasIndex(p => new { p.Category, p.Score }).HasDatabaseName("ix_post_category_score");
+    b.HasIndex(p => p.Score).HasDatabaseName("ix_post_active_score").HasFilter("`Status` = 'active'");
+});
+```
+
+This generates `CREATE INDEX <name> IF NOT EXISTS ON \`bucket\`.\`scope\`.\`collection\`(field[,
+field...]) [WHERE <filter>]` for each index and waits for it to report online, the same way primary
+index creation does. A few things to know:
+
+* **An explicit index name is required.** Unlike `CREATE PRIMARY INDEX` (which is anonymous), N1QL
+  requires every secondary index to have a name — always call `.HasDatabaseName(...)`.
+* **`HasFilter(...)` takes a raw N1QL predicate string**, spliced verbatim into the generated
+  `WHERE` clause (the same convention SqlServer/Sqlite treat it under) — it is not translated from
+  a LINQ expression.
+* **`.IsUnique()` is a no-op, logged as a warning.** N1QL secondary indexes have no concept of a
+  unique constraint the way a relational index does — the index is still created (as a plain,
+  non-unique index), just without the enforcement. Enforce uniqueness in application code if you
+  need it.
+* **Only indexes on the entity's own direct (non-owned) properties are auto-created.** An index
+  referencing a property declared on an owned type (`OwnsOne`/`OwnsMany`) isn't resolvable to a
+  single JSON field path on the root document in this pass — it is skipped with a warning; create
+  it manually instead.
+* Index field names are taken from `GetColumnName()` verbatim — root-level entity properties are
+  unaffected by `FieldNamingPolicy` (that option only applies to `OwnsMany` embedded collection
+  fields).
 
 ## Multiple buckets and clusters
 

--- a/docs/limitations.md
+++ b/docs/limitations.md
@@ -21,27 +21,30 @@ have no Couchbase equivalent.
   procedures have no Couchbase counterpart. Attempting to map an entity DML operation
   to a stored procedure throws `NotSupportedException`.
 
-* **`EnsureCreatedAsync` does not create secondary indexes.** It creates the bucket's scopes and
-  collections (and any configured sequences — see [Sequences](sequences.md)). LINQ,
+* **`EnsureCreatedAsync` does not create any index by default.** It always creates the bucket's
+  scopes and collections (and any configured sequences — see [Sequences](sequences.md)). LINQ,
   `FromSqlRaw`/`FromSql`, and `ExecuteUpdate`/`ExecuteDelete` all run as SQL++ (N1QL) queries
   under the hood, and Couchbase's query service refuses to query a collection that has no primary
   or secondary index at all — set `AutoCreateIndexes = true` on the options builder to have
   `EnsureCreatedAsync` also create a primary index on every collection it creates or already owns,
-  waiting for each one to come online before returning (see
-  [Configuration](configuration.md#ef-core-couchbase-db-provider-options)). This defaults to
+  plus a secondary index for every `HasIndex()` declared on the model, waiting for each one to come
+  online before returning (see
+  [Secondary indexes (HasIndex())](configuration.md#secondary-indexes-hasindex)). This defaults to
   `false`, so by default you must still create at least a primary index yourself:
 
   ```sql
   CREATE PRIMARY INDEX IF NOT EXISTS ON `bucket`.`scope`.`collection`
   ```
 
-  A primary index is enough to get started but scans the whole collection; for real workloads,
-  create secondary indexes on the fields you filter/sort/join by instead
-  (`CREATE INDEX ix_name ON \`bucket\`.\`scope\`.\`collection\`(field)`) — the provider does not
-  automate secondary index creation from your model (there's no equivalent of EF Core's
-  `HasIndex()` support yet). See the [`CreatePrimaryIndexesAsync` helper in the Contoso University
-  sample](https://github.com/couchbaselabs/couchbase-efcore-provider/blob/main/samples/ContosoUniversity/Program.cs)
-  for a worked example of the pattern `AutoCreateIndexes` now automates.
+  A primary index is enough to get started but scans the whole collection; for real workloads, use
+  `HasIndex()` (or create secondary indexes manually) on the fields you filter/sort/join by
+  instead. `HasIndex()` support has some gaps: **N1QL secondary indexes have no unique-constraint
+  concept**, so `.IsUnique()` is a no-op (logged as a warning) rather than enforced, and **an index
+  referencing a property declared on an owned type (`OwnsOne`/`OwnsMany`) is not auto-created** —
+  it's skipped with a warning since it isn't resolvable to a single JSON field path on the root
+  document in this pass; create it manually instead. See
+  [Secondary indexes (HasIndex())](configuration.md#secondary-indexes-hasindex) for the full
+  picture, including the required explicit index name.
 
 See also [Modeling](modeling.md).
 
@@ -103,9 +106,9 @@ The Couchbase SDK is asynchronous, so the synchronous EF Core code paths throw `
   always translate to the string-based date-function family regardless of what they're compared
   against, and the comparison throws `NotSupportedException` at query-translation time rather than
   silently comparing a `NUMBER` against a string. Capture the value into a local variable before
-  the query instead. This mode also has no bearing on GSI/secondary-index alignment — this
-  provider has no `HasIndex()` support at all (see above), so whether a hand-created secondary
-  index matches a millis-mapped comparison's shape is entirely the user's own responsibility. See
+  the query instead. `HasIndex()` on a `[UnixMillisDateTime]` property auto-creates a secondary
+  index normally (it's just a `NUMBER` field like any other), but whether the index's field order
+  matches your queries' access patterns is, as with any index, your own responsibility. See
   [Unix-millis DateTime storage](configuration.md#unix-millis-datetime-storage).
 
 See also [Querying](Queries.md) and [Configuration](configuration.md).

--- a/src/Couchbase.EntityFrameworkCore/Storage/Internal/CouchbaseDatabaseCreator.cs
+++ b/src/Couchbase.EntityFrameworkCore/Storage/Internal/CouchbaseDatabaseCreator.cs
@@ -104,8 +104,6 @@ public class CouchbaseDatabaseCreator :  RelationalDatabaseCreator
     /// </summary>
     private Dictionary<string, List<(string Scope, string Collection, string EntityName)>> GetEntityKeyspacesByBucket()
     {
-        var configuredScope = _couchbaseDbContextOptionsBuilder.Scope;
-
         var byBucket = new Dictionary<string, List<(string Scope, string Collection, string EntityName)>>();
 
         // Always process the configured bucket so its configured scope is ensured even when no
@@ -129,32 +127,34 @@ public class CouchbaseDatabaseCreator :  RelationalDatabaseCreator
                 continue;
             }
 
-            string bucketName;
-            string collectionName;
-            string scopeName;
+            var keyspace = ResolveEntityKeyspace(tableName);
 
-            if (CouchbaseKeyspace.TryParse(tableName, out var keyspace))
+            if (!byBucket.TryGetValue(keyspace.Bucket, out var entries))
             {
-                bucketName = keyspace!.Value.Bucket;
-                collectionName = keyspace.Value.Collection;
-                scopeName = keyspace.Value.Scope;
+                byBucket[keyspace.Bucket] = entries = new List<(string Scope, string Collection, string EntityName)>();
             }
-            else
-            {
-                // Fallback: use table name as collection name in the configured bucket/scope.
-                bucketName = _couchbaseDbContextOptionsBuilder.Bucket;
-                collectionName = tableName;
-                scopeName = configuredScope;
-            }
-
-            if (!byBucket.TryGetValue(bucketName, out var entries))
-            {
-                byBucket[bucketName] = entries = new List<(string Scope, string Collection, string EntityName)>();
-            }
-            entries.Add((scopeName, collectionName, entityType.ClrType.Name));
+            entries.Add((keyspace.Scope, keyspace.Collection, entityType.ClrType.Name));
         }
 
         return byBucket;
+    }
+
+    /// <summary>
+    /// Resolves an entity type's table name into its actual keyspace — parsed as a full
+    /// <c>Bucket.Scope.Collection</c> reference (via <see cref="ToCouchbaseCollection"/>/
+    /// <c>[CouchbaseKeyspace]</c>) when present, falling back to the table name as a collection
+    /// in the configured bucket/scope otherwise. Shared by <see cref="GetEntityKeyspacesByBucket"/>
+    /// and <see cref="CreateSecondaryIndexesAsync"/> so both resolve keyspaces identically.
+    /// </summary>
+    private CouchbaseKeyspace ResolveEntityKeyspace(string tableName)
+    {
+        if (CouchbaseKeyspace.TryParse(tableName, out var keyspace))
+        {
+            return keyspace!.Value;
+        }
+
+        return new CouchbaseKeyspace(
+            _couchbaseDbContextOptionsBuilder.Bucket, _couchbaseDbContextOptionsBuilder.Scope, tableName);
     }
 
     private async Task CreateCollectionsAsync(CancellationToken cancellationToken)
@@ -382,22 +382,204 @@ public class CouchbaseDatabaseCreator :  RelationalDatabaseCreator
 
     private async Task CreatePrimaryIndexAsync(CouchbaseKeyspace keyspace, CancellationToken cancellationToken)
     {
-        var bucket = await GetBucketAsync(keyspace.Bucket, cancellationToken);
-        var scopeObj = await bucket.ScopeAsync(keyspace.Scope);
-
         var bucketIdentifier = _sqlGenerationHelper.DelimitIdentifier(keyspace.Bucket);
         var scopeIdentifier = _sqlGenerationHelper.DelimitIdentifier(keyspace.Scope);
         var collectionIdentifier = _sqlGenerationHelper.DelimitIdentifier(keyspace.Collection);
 
         var sql = $"CREATE PRIMARY INDEX IF NOT EXISTS ON {bucketIdentifier}.{scopeIdentifier}.{collectionIdentifier}";
 
-        _logger.LogDebug("Creating primary index: {Sql}", sql);
+        await ExecuteDdlWithRetryAsync(keyspace, sql, cancellationToken);
+    }
 
-        // A collection just created by CreateCollectionsAsync may not be visible to the query
-        // service yet — the management API's CreateCollectionAsync can return before the query
-        // service's metadata cache picks up the new keyspace, so the very next statement can fail
-        // with "Keyspace not found" even though the collection genuinely exists. Retry rather than
-        // fail EnsureCreatedAsync over what is normally a sub-second propagation delay.
+    /// <summary>
+    /// Creates a secondary index for every <c>HasIndex()</c> declared on the model, when
+    /// <see cref="ICouchbaseDbContextOptionsBuilder.AutoCreateIndexes"/> is enabled, and waits for
+    /// each to report online before returning. Reuses the same "collection was never created"
+    /// skip rule as <see cref="CreateIndexesAsync"/> (primary indexes).
+    /// </summary>
+    /// <remarks>
+    /// Only indexes declared directly on a non-owned entity type's own properties are supported —
+    /// an index referencing a property declared on an owned type is not resolvable to a single
+    /// JSON field path in this pass and is skipped with a warning (see
+    /// <see cref="TryResolveIndexFieldNames"/>). N1QL's GSI has no concept of a unique constraint
+    /// (an index doesn't reject duplicate values the way a relational unique index does), so
+    /// <c>IsUnique</c> is logged as a no-op warning rather than silently ignored or attempted.
+    /// </remarks>
+    private async Task CreateSecondaryIndexesAsync(CancellationToken cancellationToken)
+    {
+        if (!_couchbaseDbContextOptionsBuilder.AutoCreateIndexes)
+        {
+            _logger.LogDebug("Skipping auto-creation of secondary indexes (AutoCreateIndexes = false)");
+            return;
+        }
+
+        var configuredScope = _couchbaseDbContextOptionsBuilder.Scope;
+        // Keyed by (keyspace, index name) rather than a List: a TPH-shared collection (multiple
+        // entity types mapped to the same collection) can otherwise yield the same index more than
+        // once. CREATE INDEX ... IF NOT EXISTS is idempotent server-side regardless, but this also
+        // avoids waiting for the same index to come online twice.
+        var indexesToCreate = new Dictionary<(CouchbaseKeyspace Keyspace, string Name), string>();
+
+        foreach (var entityType in _designTimeModel.Model.GetEntityTypes())
+        {
+            if (entityType.IsOwned())
+            {
+                continue;
+            }
+
+            var tableName = entityType.GetTableName();
+            if (string.IsNullOrEmpty(tableName))
+            {
+                continue;
+            }
+
+            var keyspace = ResolveEntityKeyspace(tableName);
+
+            // A collection that CreateCollectionsAsync skipped (non-default scope with
+            // AutoCreateScopes disabled) was never created, so there is nothing to index.
+            if (keyspace.Scope != configuredScope && !_couchbaseDbContextOptionsBuilder.AutoCreateScopes)
+            {
+                continue;
+            }
+
+            foreach (var index in entityType.GetIndexes())
+            {
+                var indexName = index.GetDatabaseName();
+                if (string.IsNullOrEmpty(indexName))
+                {
+                    // Unlike CREATE PRIMARY INDEX (which is anonymous), N1QL requires every
+                    // secondary index to have a name -- GetDatabaseName() can still return null
+                    // (e.g. the entity's table name itself couldn't be resolved), so this must be
+                    // treated as "cannot create," not assumed non-null.
+                    _logger.LogWarning(
+                        "An index on entity '{EntityName}' has no database name and will not be " +
+                        "auto-created — Couchbase secondary (GSI) indexes require an explicit name " +
+                        "(unlike CREATE PRIMARY INDEX, which is anonymous). Call HasDatabaseName(...) " +
+                        "on the index, or create it manually.",
+                        entityType.ClrType.Name);
+                    continue;
+                }
+
+                if (index.IsUnique)
+                {
+                    _logger.LogWarning(
+                        "Index '{IndexName}' on entity '{EntityName}' is configured as unique, but Couchbase " +
+                        "secondary (GSI) indexes cannot enforce uniqueness — it will be created as a plain, " +
+                        "non-unique index. Enforce uniqueness in application code if required.",
+                        indexName, entityType.ClrType.Name);
+                }
+
+                if (!TryResolveIndexFieldNames(index, entityType, out var fieldNames))
+                {
+                    continue;
+                }
+
+                var ddl = BuildCreateIndexDdl(keyspace, indexName, fieldNames, index.GetFilter());
+
+                // A conflict here (same keyspace + name, different DDL) means two distinct index
+                // definitions in the model collide on name. That's a real model bug, not something
+                // safe to silently pick one of: "CREATE INDEX ... IF NOT EXISTS" is a no-op for
+                // whichever definition loses the race, so the actually-created index could
+                // permanently diverge from one of the two definitions without any error ever
+                // surfacing. Fail loudly instead.
+                if (indexesToCreate.TryGetValue((keyspace, indexName), out var existingDdl))
+                {
+                    if (existingDdl != ddl)
+                    {
+                        throw new InvalidOperationException(
+                            $"Two different index definitions are both named '{indexName}' for " +
+                            $"{keyspace.ToSqlString()}, but describe different DDL. Secondary index " +
+                            "names must be unique and unambiguous within a keyspace, since " +
+                            "\"CREATE INDEX ... IF NOT EXISTS\" silently keeps whichever definition is " +
+                            $"created first. Existing: {existingDdl} New: {ddl}. Rename one of the " +
+                            "conflicting indexes.");
+                    }
+                }
+                else
+                {
+                    indexesToCreate[(keyspace, indexName)] = ddl;
+                }
+            }
+        }
+
+        foreach (var ((keyspace, _), ddl) in indexesToCreate)
+        {
+            await ExecuteDdlWithRetryAsync(keyspace, ddl, cancellationToken);
+        }
+
+        foreach (var (keyspace, indexName) in indexesToCreate.Keys)
+        {
+            await WaitForSecondaryIndexOnlineAsync(keyspace, indexName, cancellationToken);
+        }
+    }
+
+    /// <summary>
+    /// Resolves an index's properties to JSON field names via <see cref="IReadOnlyProperty.GetColumnName()"/>
+    /// (verbatim — root-level entity properties are unaffected by <c>FieldNamingPolicy</c>, which
+    /// only applies to owned-type nested JSON; confirmed against <c>CouchbaseDatabaseWrapper</c>'s
+    /// own write path). Returns <see langword="false"/> (logging a warning) if any property in the
+    /// index is declared on an owned type, since that isn't resolvable to a single JSON field path
+    /// on the root document in this pass.
+    /// </summary>
+    private bool TryResolveIndexFieldNames(IIndex index, IEntityType entityType, out List<string> fieldNames)
+    {
+        fieldNames = new List<string>(index.Properties.Count);
+
+        foreach (var property in index.Properties)
+        {
+            if (property.DeclaringType is IReadOnlyEntityType declaringEntityType && declaringEntityType.IsOwned())
+            {
+                _logger.LogWarning(
+                    "Index '{IndexName}' on entity '{EntityName}' references property '{PropertyName}' " +
+                    "declared on an owned type and will not be auto-created — only indexes on the " +
+                    "entity's own direct properties are supported. Create this index manually.",
+                    index.GetDatabaseName(), entityType.ClrType.Name, property.Name);
+                return false;
+            }
+
+            fieldNames.Add(property.GetColumnName());
+        }
+
+        return true;
+    }
+
+    private string BuildCreateIndexDdl(CouchbaseKeyspace keyspace, string indexName, List<string> fieldNames, string? filter)
+    {
+        var bucketIdentifier = _sqlGenerationHelper.DelimitIdentifier(keyspace.Bucket);
+        var scopeIdentifier = _sqlGenerationHelper.DelimitIdentifier(keyspace.Scope);
+        var collectionIdentifier = _sqlGenerationHelper.DelimitIdentifier(keyspace.Collection);
+        var indexIdentifier = _sqlGenerationHelper.DelimitIdentifier(indexName);
+        var fieldList = string.Join(", ", fieldNames.Select(_sqlGenerationHelper.DelimitIdentifier));
+
+        var sql = $"CREATE INDEX {indexIdentifier} IF NOT EXISTS ON {bucketIdentifier}.{scopeIdentifier}.{collectionIdentifier}({fieldList})";
+
+        // EF Core's HasFilter() takes a raw provider-specific SQL predicate string that the user
+        // writes directly (the same convention SqlServer/Sqlite treat it under) — spliced verbatim
+        // into the WHERE clause rather than translated, matching that established pattern.
+        if (!string.IsNullOrEmpty(filter))
+        {
+            sql += $" WHERE {filter}";
+        }
+
+        return sql;
+    }
+
+    /// <summary>
+    /// Executes a DDL statement (index creation, etc.) against <paramref name="keyspace"/>'s scope,
+    /// retrying on failure. A collection just created by <see cref="CreateCollectionsAsync"/> may
+    /// not be visible to the query service yet — the management API's <c>CreateCollectionAsync</c>
+    /// can return before the query service's metadata cache picks up the new keyspace, so the very
+    /// next statement can fail with "Keyspace not found" even though the collection genuinely
+    /// exists. Retry rather than fail <c>EnsureCreatedAsync</c> over what is normally a sub-second
+    /// propagation delay. Shared by primary- and secondary-index creation.
+    /// </summary>
+    private async Task ExecuteDdlWithRetryAsync(CouchbaseKeyspace keyspace, string sql, CancellationToken cancellationToken)
+    {
+        var bucket = await GetBucketAsync(keyspace.Bucket, cancellationToken);
+        var scopeObj = await bucket.ScopeAsync(keyspace.Scope);
+
+        _logger.LogDebug("Executing DDL for {Keyspace}: {Sql}", keyspace.ToSqlString(), sql);
+
         const int maxAttempts = 10;
         for (var attempt = 1; ; attempt++)
         {
@@ -418,7 +600,7 @@ public class CouchbaseDatabaseCreator :  RelationalDatabaseCreator
             catch (Exception ex) when (ex is not OperationCanceledException && attempt < maxAttempts)
             {
                 _logger.LogDebug(ex,
-                    "Primary index creation for {Keyspace} failed (attempt {Attempt}/{MaxAttempts}); retrying...",
+                    "DDL execution for {Keyspace} failed (attempt {Attempt}/{MaxAttempts}); retrying...",
                     keyspace.ToSqlString(), attempt, maxAttempts);
                 await Task.Delay(TimeSpan.FromSeconds(1), cancellationToken);
             }
@@ -473,6 +655,61 @@ public class CouchbaseDatabaseCreator :  RelationalDatabaseCreator
             {
                 throw new TimeoutException(
                     $"Primary index for {keyspace.ToSqlString()} did not come online within 60 seconds.", lastError);
+            }
+
+            await Task.Delay(TimeSpan.FromSeconds(1), cancellationToken);
+        }
+    }
+
+    private async Task WaitForSecondaryIndexOnlineAsync(CouchbaseKeyspace keyspace, string indexName, CancellationToken cancellationToken)
+    {
+        var onlineDeadline = DateTime.UtcNow + TimeSpan.FromSeconds(60);
+        Exception? lastError = null;
+
+        while (true)
+        {
+            var online = false;
+            try
+            {
+                // Unlike primary indexes (which explicitly report is_primary = true), a secondary
+                // index's system:indexes row was empirically observed (live spike) to OMIT the
+                // is_primary field entirely rather than set it to false. Filtering on
+                // "is_primary = false" therefore never matches -- N1QL treats a comparison against
+                // a missing field as missing, which WHERE treats as falsy -- so that clause is
+                // deliberately left out here; matching by name within this specific keyspace is
+                // already unambiguous.
+                using var result = await _cluster.QueryAsync<int>(
+                    "SELECT RAW COUNT(*) FROM system:indexes WHERE state = 'online' "
+                    + "AND bucket_id = $bucket AND scope_id = $scope AND keyspace_id = $collection AND name = $name",
+                    new QueryOptions()
+                        .Parameter("bucket", keyspace.Bucket)
+                        .Parameter("scope", keyspace.Scope)
+                        .Parameter("collection", keyspace.Collection)
+                        .Parameter("name", indexName)
+                        .CancellationToken(cancellationToken));
+                await foreach (var count in result.Rows)
+                {
+                    online = count > 0;
+                    break;
+                }
+                lastError = null;
+            }
+            catch (Exception ex) when (ex is not OperationCanceledException)
+            {
+                lastError = ex;
+            }
+
+            if (online)
+            {
+                _logger.LogDebug("Secondary index '{IndexName}' online for {Keyspace}", indexName, keyspace.ToSqlString());
+                return;
+            }
+
+            if (DateTime.UtcNow > onlineDeadline)
+            {
+                throw new TimeoutException(
+                    $"Secondary index '{indexName}' for {keyspace.ToSqlString()} did not come online within 60 seconds.",
+                    lastError);
             }
 
             await Task.Delay(TimeSpan.FromSeconds(1), cancellationToken);
@@ -637,9 +874,10 @@ public class CouchbaseDatabaseCreator :  RelationalDatabaseCreator
     /// Asynchronously ensures that the database for the context exists.
     /// If the bucket does not exist, it is created.
     /// Scopes, collections, and sequences are always created if they don't exist,
-    /// regardless of whether the bucket already existed. A primary index is additionally created
-    /// on every collection — and waited for online — when
-    /// <see cref="ICouchbaseDbContextOptionsBuilder.AutoCreateIndexes"/> is enabled.
+    /// regardless of whether the bucket already existed. A primary index, and a secondary index
+    /// for every <c>HasIndex()</c> declared on the model, are additionally created — and waited
+    /// for online — when <see cref="ICouchbaseDbContextOptionsBuilder.AutoCreateIndexes"/> is
+    /// enabled.
     /// </summary>
     /// <param name="cancellationToken">A cancellation token.</param>
     /// <returns>
@@ -658,12 +896,13 @@ public class CouchbaseDatabaseCreator :  RelationalDatabaseCreator
 
         // Always ensure scopes, collections, and sequences exist even if the bucket already
         // existed (they use IF NOT EXISTS / catch-exists patterns). CreateCollectionsAsync
-        // ensures the required scopes per bucket before creating collections. CreateIndexesAsync
-        // runs last since it needs the collections it indexes to already exist, and is a no-op
-        // unless AutoCreateIndexes is enabled.
+        // ensures the required scopes per bucket before creating collections. CreateIndexesAsync/
+        // CreateSecondaryIndexesAsync run last since they need the collections they index to
+        // already exist, and are both no-ops unless AutoCreateIndexes is enabled.
         await CreateCollectionsAsync(cancellationToken);
         await CreateSequencesAsync(cancellationToken);
         await CreateIndexesAsync(cancellationToken);
+        await CreateSecondaryIndexesAsync(cancellationToken);
 
         return created;
     }

--- a/tests/Couchbase.EntityFrameworkCore.IntegrationTests/Tests/IndexCreationTests.cs
+++ b/tests/Couchbase.EntityFrameworkCore.IntegrationTests/Tests/IndexCreationTests.cs
@@ -114,6 +114,190 @@ public class IndexCreationTests(BloggingFixture fixture, ITestOutputHelper outpu
         return count;
     }
 
+    private async Task<int> CountOnlineSecondaryIndexesAsync(
+        string bucketName, string scopeName, string collectionName, string indexName)
+    {
+        var clusterOptions = new global::Couchbase.ClusterOptions()
+            .WithConnectionString(fixture.Host)
+            .WithCredentials(fixture.Username, fixture.Password);
+        using var cluster = await global::Couchbase.Cluster.ConnectAsync(clusterOptions);
+        // No is_primary filter: a secondary index's system:indexes row was empirically observed
+        // to omit that field entirely rather than set it to false, so "is_primary = false" never
+        // matches (see CouchbaseDatabaseCreator.WaitForSecondaryIndexOnlineAsync's own comment).
+        using var result = await cluster.QueryAsync<int>(
+            "SELECT RAW COUNT(*) FROM system:indexes WHERE state = 'online' "
+            + "AND bucket_id = $bucket AND scope_id = $scope AND keyspace_id = $collection AND name = $name",
+            new global::Couchbase.Query.QueryOptions()
+                .Parameter("bucket", bucketName)
+                .Parameter("scope", scopeName)
+                .Parameter("collection", collectionName)
+                .Parameter("name", indexName));
+
+        var count = 0;
+        await foreach (var c in result.Rows)
+        {
+            count = c;
+        }
+
+        return count;
+    }
+
+    [Fact]
+    public async Task EnsureCreatedAsync_WithAutoCreateIndexes_CreatesQueryableSingleFieldSecondaryIndex()
+    {
+        var collectionName = "idxsecfield" + Guid.NewGuid().ToString("N");
+
+        var optionsBuilder = new DbContextOptionsBuilder<SingleFieldIndexDbContext>();
+        optionsBuilder.UseCouchbase(
+            new global::Couchbase.ClusterOptions()
+                .WithConnectionString(fixture.Host)
+                .WithPasswordAuthentication(fixture.Username, fixture.Password),
+            o =>
+            {
+                o.Bucket = fixture.BucketName;
+                o.Scope = fixture.ScopeName;
+                o.AutoCreateIndexes = true;
+            });
+        optionsBuilder.ConfigureWarnings(w => w.Ignore(CoreEventId.ManyServiceProvidersCreatedWarning));
+
+        await using var context = new SingleFieldIndexDbContext(optionsBuilder.Options, collectionName);
+
+        try
+        {
+            await context.Database.EnsureCreatedAsync();
+            outputHelper.WriteLine($"EnsureCreatedAsync completed for {collectionName}");
+
+            var onlineCount = await CountOnlineSecondaryIndexesAsync(
+                fixture.BucketName, fixture.ScopeName, collectionName, "ix_singlefield_score");
+            Assert.Equal(1, onlineCount);
+
+            // Re-running EnsureCreatedAsync must not error (CREATE INDEX ... IF NOT EXISTS is
+            // idempotent server-side, and the collection/primary-index/sequence steps ahead of it
+            // are all already-proven idempotent).
+            await context.Database.EnsureCreatedAsync();
+        }
+        finally
+        {
+            await DropCollectionAsync(collectionName);
+        }
+    }
+
+    [Fact]
+    public async Task EnsureCreatedAsync_WithAutoCreateIndexes_CreatesQueryableCompositeSecondaryIndex()
+    {
+        var collectionName = "idxseccomp" + Guid.NewGuid().ToString("N");
+
+        var optionsBuilder = new DbContextOptionsBuilder<CompositeIndexDbContext>();
+        optionsBuilder.UseCouchbase(
+            new global::Couchbase.ClusterOptions()
+                .WithConnectionString(fixture.Host)
+                .WithPasswordAuthentication(fixture.Username, fixture.Password),
+            o =>
+            {
+                o.Bucket = fixture.BucketName;
+                o.Scope = fixture.ScopeName;
+                o.AutoCreateIndexes = true;
+            });
+        optionsBuilder.ConfigureWarnings(w => w.Ignore(CoreEventId.ManyServiceProvidersCreatedWarning));
+
+        await using var context = new CompositeIndexDbContext(optionsBuilder.Options, collectionName);
+
+        try
+        {
+            await context.Database.EnsureCreatedAsync();
+            outputHelper.WriteLine($"EnsureCreatedAsync completed for {collectionName}");
+
+            var onlineCount = await CountOnlineSecondaryIndexesAsync(
+                fixture.BucketName, fixture.ScopeName, collectionName, "ix_composite_score_category");
+            Assert.Equal(1, onlineCount);
+        }
+        finally
+        {
+            await DropCollectionAsync(collectionName);
+        }
+    }
+
+    [Fact]
+    public async Task EnsureCreatedAsync_WithAutoCreateIndexes_CreatesQueryableFilteredSecondaryIndex()
+    {
+        var collectionName = "idxsecfilt" + Guid.NewGuid().ToString("N");
+
+        var optionsBuilder = new DbContextOptionsBuilder<FilteredIndexDbContext>();
+        optionsBuilder.UseCouchbase(
+            new global::Couchbase.ClusterOptions()
+                .WithConnectionString(fixture.Host)
+                .WithPasswordAuthentication(fixture.Username, fixture.Password),
+            o =>
+            {
+                o.Bucket = fixture.BucketName;
+                o.Scope = fixture.ScopeName;
+                o.AutoCreateIndexes = true;
+            });
+        optionsBuilder.ConfigureWarnings(w => w.Ignore(CoreEventId.ManyServiceProvidersCreatedWarning));
+
+        await using var context = new FilteredIndexDbContext(optionsBuilder.Options, collectionName);
+
+        try
+        {
+            await context.Database.EnsureCreatedAsync();
+            outputHelper.WriteLine($"EnsureCreatedAsync completed for {collectionName}");
+
+            var onlineCount = await CountOnlineSecondaryIndexesAsync(
+                fixture.BucketName, fixture.ScopeName, collectionName, "ix_filtered_score");
+            Assert.Equal(1, onlineCount);
+
+            // Prove the filter clause was actually applied, not just that an index by this name
+            // exists: a query matching the filter's condition should be plannable/executable
+            // (the point of the filter is to keep the index small, not to reject non-matching
+            // queries -- this just confirms the WHERE clause was valid N1QL the query service
+            // accepted at CREATE INDEX time).
+            var results = await context.Entities.Where(e => e.Score > 0).ToListAsync();
+            Assert.Empty(results);
+        }
+        finally
+        {
+            await DropCollectionAsync(collectionName);
+        }
+    }
+
+    [Fact]
+    public async Task EnsureCreatedAsync_WithAutoCreateIndexes_CreatesSecondaryIndexInEntityMappedBucket()
+    {
+        // Mirrors EnsureCreatedAsync_WithAutoCreateIndexes_CreatesIndexInEntityMappedBucket for
+        // primary indexes: the entity is mapped to the "secondary" bucket while the context itself
+        // is configured for "default". The secondary (HasIndex) index must be created in
+        // "secondary" -- the bucket the collection actually lives in -- not the configured one.
+        var collectionName = "idxsecbucket" + Guid.NewGuid().ToString("N");
+
+        var optionsBuilder = new DbContextOptionsBuilder<SecondaryBucketSecondaryIndexContext>();
+        optionsBuilder.UseCouchbase(
+            new global::Couchbase.ClusterOptions()
+                .WithConnectionString(fixture.Host)
+                .WithCredentials(fixture.Username, fixture.Password),
+            o =>
+            {
+                o.Bucket = "default";
+                o.Scope = "isolation";
+                o.AutoCreateIndexes = true;
+            });
+        optionsBuilder.ConfigureWarnings(w => w.Ignore(CoreEventId.ManyServiceProvidersCreatedWarning));
+
+        await using var context = new SecondaryBucketSecondaryIndexContext(optionsBuilder.Options, collectionName);
+
+        try
+        {
+            await context.Database.EnsureCreatedAsync();
+
+            var onlineCount = await CountOnlineSecondaryIndexesAsync(
+                "secondary", "isolation", collectionName, "ix_secondarybucket_score");
+            Assert.Equal(1, onlineCount);
+        }
+        finally
+        {
+            await DropCollectionAsync(collectionName, bucketName: "secondary", scopeName: "isolation");
+        }
+    }
+
     [Fact]
     public async Task EnsureCreatedAsync_WithAutoCreateIndexes_CreatesIndexInEntityMappedBucket()
     {
@@ -230,6 +414,97 @@ public class IndexCreationTests(BloggingFixture fixture, ITestOutputHelper outpu
         {
             // Mapped to the "secondary" bucket while the context is configured for "default".
             modelBuilder.Entity<SecondaryBucketEntity>().ToCouchbaseCollection("secondary", "isolation", collectionName);
+        }
+    }
+
+    public class SingleFieldIndexEntity
+    {
+        public long Id { get; set; }
+        public string Name { get; set; } = string.Empty;
+        public double Score { get; set; }
+    }
+
+    public class SingleFieldIndexDbContext(DbContextOptions<SingleFieldIndexDbContext> options, string collectionName)
+        : DbContext(options)
+    {
+        public DbSet<SingleFieldIndexEntity> Entities { get; set; } = null!;
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            base.OnModelCreating(modelBuilder);
+            modelBuilder.Entity<SingleFieldIndexEntity>(b =>
+            {
+                b.ToCouchbaseCollection(this, collectionName);
+                b.HasIndex(e => e.Score).HasDatabaseName("ix_singlefield_score");
+            });
+        }
+    }
+
+    public class CompositeIndexEntity
+    {
+        public long Id { get; set; }
+        public double Score { get; set; }
+        public string Category { get; set; } = string.Empty;
+    }
+
+    public class CompositeIndexDbContext(DbContextOptions<CompositeIndexDbContext> options, string collectionName)
+        : DbContext(options)
+    {
+        public DbSet<CompositeIndexEntity> Entities { get; set; } = null!;
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            base.OnModelCreating(modelBuilder);
+            modelBuilder.Entity<CompositeIndexEntity>(b =>
+            {
+                b.ToCouchbaseCollection(this, collectionName);
+                b.HasIndex(e => new { e.Score, e.Category }).HasDatabaseName("ix_composite_score_category");
+            });
+        }
+    }
+
+    public class FilteredIndexEntity
+    {
+        public long Id { get; set; }
+        public double Score { get; set; }
+    }
+
+    public class FilteredIndexDbContext(DbContextOptions<FilteredIndexDbContext> options, string collectionName)
+        : DbContext(options)
+    {
+        public DbSet<FilteredIndexEntity> Entities { get; set; } = null!;
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            base.OnModelCreating(modelBuilder);
+            modelBuilder.Entity<FilteredIndexEntity>(b =>
+            {
+                b.ToCouchbaseCollection(this, collectionName);
+                b.HasIndex(e => e.Score).HasDatabaseName("ix_filtered_score").HasFilter("`Score` > 0");
+            });
+        }
+    }
+
+    public class SecondaryBucketSecondaryIndexEntity
+    {
+        public long Id { get; set; }
+        public double Score { get; set; }
+    }
+
+    public class SecondaryBucketSecondaryIndexContext(
+        DbContextOptions<SecondaryBucketSecondaryIndexContext> options, string collectionName)
+        : DbContext(options)
+    {
+        public DbSet<SecondaryBucketSecondaryIndexEntity> Entities { get; set; } = null!;
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            // Mapped to the "secondary" bucket while the context is configured for "default".
+            modelBuilder.Entity<SecondaryBucketSecondaryIndexEntity>(b =>
+            {
+                b.ToCouchbaseCollection("secondary", "isolation", collectionName);
+                b.HasIndex(e => e.Score).HasDatabaseName("ix_secondarybucket_score");
+            });
         }
     }
 }

--- a/tests/Couchbase.EntityFrameworkCore.UnitTests/Couchbase/EntityFrameworkCore/Storage/Internal/CouchbaseDatabaseCreatorTests.cs
+++ b/tests/Couchbase.EntityFrameworkCore.UnitTests/Couchbase/EntityFrameworkCore/Storage/Internal/CouchbaseDatabaseCreatorTests.cs
@@ -96,6 +96,46 @@ public class CouchbaseDatabaseCreatorTests
         return new FakeQueryResult<T> { Rows = rows.ToAsyncEnumerable() };
     }
 
+    private static Mock<IProperty> CreateMockProperty(string columnName, IEntityType declaringEntityType)
+    {
+        var mockProperty = new Mock<IProperty>();
+        var columnNameAnnotation = new Mock<IAnnotation>();
+        columnNameAnnotation.Setup(a => a.Value).Returns(columnName);
+        mockProperty.Setup(p => p.FindAnnotation(RelationalAnnotationNames.ColumnName)).Returns(columnNameAnnotation.Object);
+        mockProperty.Setup(p => p.Name).Returns(columnName);
+        mockProperty.Setup(p => p.DeclaringType).Returns(declaringEntityType);
+        return mockProperty;
+    }
+
+    private static Mock<IIndex> CreateMockIndex(
+        IEntityType declaringEntityType,
+        IReadOnlyList<IProperty> properties,
+        string indexName,
+        bool isUnique = false,
+        string? filter = null)
+    {
+        var mockIndex = new Mock<IIndex>();
+        mockIndex.Setup(i => i.Properties).Returns(properties);
+        mockIndex.Setup(i => i.IsUnique).Returns(isUnique);
+        mockIndex.Setup(i => i.DeclaringEntityType).Returns(declaringEntityType);
+        // IIndex.DeclaringEntityType is a covariant `new` property hiding the base
+        // IReadOnlyIndex.DeclaringEntityType slot -- GetDatabaseName()/GetFilter() etc. are
+        // extension methods on IReadOnlyIndex, so that base slot must be set up separately or it
+        // resolves to Moq's default (null), NullReferenceException-ing downstream.
+        mockIndex.As<IReadOnlyIndex>().Setup(i => i.DeclaringEntityType).Returns(declaringEntityType);
+        mockIndex.Setup(i => i.Name).Returns((string?)null);
+        mockIndex.Setup(i => i[RelationalAnnotationNames.Name]).Returns(indexName);
+
+        if (filter != null)
+        {
+            var filterAnnotation = new Mock<IAnnotation>();
+            filterAnnotation.Setup(a => a.Value).Returns(filter);
+            mockIndex.Setup(i => i.FindAnnotation(RelationalAnnotationNames.Filter)).Returns(filterAnnotation.Object);
+        }
+
+        return mockIndex;
+    }
+
     private RelationalDatabaseCreatorDependencies CreateMockDependencies()
     {
         var mockConnection = new Mock<IRelationalConnection>();
@@ -752,6 +792,381 @@ public class CouchbaseDatabaseCreatorTests
         _mockScope.Verify(
             s => s.QueryAsync<dynamic>(It.IsAny<string>(), It.IsAny<QueryOptions>()),
             Times.Never);
+    }
+
+    #endregion
+
+    #region EnsureCreatedAsync Tests - Secondary Index Creation (HasIndex())
+
+    [Fact]
+    public async Task EnsureCreatedAsync_WithAutoCreateIndexesDisabled_DoesNotCreateSecondaryIndex()
+    {
+        // Arrange - AutoCreateIndexes defaults to false via the constructor setup
+        _mockOptions.Setup(o => o.Bucket).Returns("my-bucket");
+        _mockOptions.Setup(o => o.Scope).Returns("my-scope");
+
+        _mockBucketManager.Setup(m => m.GetBucketAsync("my-bucket", It.IsAny<GetBucketOptions>()))
+            .ReturnsAsync(new BucketSettings { Name = "my-bucket" });
+        _mockCluster.Setup(c => c.BucketAsync("my-bucket")).ReturnsAsync(_mockBucket.Object);
+        _mockCollectionManager.Setup(m => m.GetAllScopesAsync(It.IsAny<GetAllScopesOptions>()))
+            .ReturnsAsync(new List<ScopeSpec> { new ScopeSpec("my-scope") });
+
+        var mockEntityType = new Mock<IEntityType>();
+        var mockTableNameAnnotation = new Mock<IAnnotation>();
+        mockTableNameAnnotation.Setup(a => a.Value).Returns("TestCollection");
+        mockEntityType.Setup(e => e.FindAnnotation("Relational:TableName")).Returns(mockTableNameAnnotation.Object);
+        mockEntityType.Setup(e => e.ClrType).Returns(typeof(TestEntity));
+        mockEntityType.Setup(e => e.GetProperties()).Returns(Array.Empty<IProperty>());
+
+        var mockScoreProperty = CreateMockProperty("Score", mockEntityType.Object);
+        var mockIndex = CreateMockIndex(mockEntityType.Object, new[] { mockScoreProperty.Object }, "ix_score");
+        mockEntityType.Setup(e => e.GetIndexes()).Returns(new[] { mockIndex.Object });
+
+        _mockModel.Setup(m => m.GetEntityTypes()).Returns(new[] { mockEntityType.Object });
+
+        var creator = CreateCreator();
+
+        // Act
+        await creator.EnsureCreatedAsync();
+
+        // Assert - no index DDL issued (neither primary nor secondary) when the option is off
+        _mockScope.Verify(
+            s => s.QueryAsync<dynamic>(It.IsAny<string>(), It.IsAny<QueryOptions>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task EnsureCreatedAsync_WithAutoCreateIndexesEnabled_CreatesSingleFieldSecondaryIndex()
+    {
+        // Arrange
+        _mockOptions.Setup(o => o.Bucket).Returns("my-bucket");
+        _mockOptions.Setup(o => o.Scope).Returns("my-scope");
+        _mockOptions.Setup(o => o.AutoCreateIndexes).Returns(true);
+
+        _mockBucketManager.Setup(m => m.GetBucketAsync("my-bucket", It.IsAny<GetBucketOptions>()))
+            .ReturnsAsync(new BucketSettings { Name = "my-bucket" });
+        _mockCluster.Setup(c => c.BucketAsync("my-bucket")).ReturnsAsync(_mockBucket.Object);
+        _mockCollectionManager.Setup(m => m.GetAllScopesAsync(It.IsAny<GetAllScopesOptions>()))
+            .ReturnsAsync(new List<ScopeSpec> { new ScopeSpec("my-scope") });
+
+        var mockEntityType = new Mock<IEntityType>();
+        var mockTableNameAnnotation = new Mock<IAnnotation>();
+        mockTableNameAnnotation.Setup(a => a.Value).Returns("TestCollection");
+        mockEntityType.Setup(e => e.FindAnnotation("Relational:TableName")).Returns(mockTableNameAnnotation.Object);
+        mockEntityType.Setup(e => e.ClrType).Returns(typeof(TestEntity));
+        mockEntityType.Setup(e => e.GetProperties()).Returns(Array.Empty<IProperty>());
+
+        var mockScoreProperty = CreateMockProperty("Score", mockEntityType.Object);
+        var mockIndex = CreateMockIndex(mockEntityType.Object, new[] { mockScoreProperty.Object }, "ix_score");
+        mockEntityType.Setup(e => e.GetIndexes()).Returns(new[] { mockIndex.Object });
+
+        _mockModel.Setup(m => m.GetEntityTypes()).Returns(new[] { mockEntityType.Object });
+
+        var creator = CreateCreator();
+
+        // Act
+        await creator.EnsureCreatedAsync();
+
+        // Assert - the secondary index DDL is issued with the index's own name, the resolved
+        // collection's keyspace, and the single indexed field, and the creator waits for it to
+        // report online via a name-scoped system:indexes check (no is_primary filter -- a
+        // secondary index's row omits that field entirely on this server rather than setting it
+        // to false, confirmed by a live spike; see WaitForSecondaryIndexOnlineAsync's own comment).
+        _mockScope.Verify(
+            s => s.QueryAsync<dynamic>(
+                It.Is<string>(sql => sql.StartsWith("CREATE INDEX `ix_score` IF NOT EXISTS")
+                                      && sql.Contains("`my-bucket`") && sql.Contains("`my-scope`")
+                                      && sql.Contains("`TestCollection`") && sql.Contains("(`Score`)")),
+                It.IsAny<QueryOptions>()),
+            Times.Once);
+        _mockCluster.Verify(
+            c => c.QueryAsync<int>(
+                It.Is<string>(sql => sql.Contains("system:indexes") && sql.Contains("name = $name")),
+                It.IsAny<QueryOptions>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task EnsureCreatedAsync_WithAutoCreateIndexesEnabled_CreatesCompositeSecondaryIndex()
+    {
+        // Arrange
+        _mockOptions.Setup(o => o.Bucket).Returns("my-bucket");
+        _mockOptions.Setup(o => o.Scope).Returns("my-scope");
+        _mockOptions.Setup(o => o.AutoCreateIndexes).Returns(true);
+
+        _mockBucketManager.Setup(m => m.GetBucketAsync("my-bucket", It.IsAny<GetBucketOptions>()))
+            .ReturnsAsync(new BucketSettings { Name = "my-bucket" });
+        _mockCluster.Setup(c => c.BucketAsync("my-bucket")).ReturnsAsync(_mockBucket.Object);
+        _mockCollectionManager.Setup(m => m.GetAllScopesAsync(It.IsAny<GetAllScopesOptions>()))
+            .ReturnsAsync(new List<ScopeSpec> { new ScopeSpec("my-scope") });
+
+        var mockEntityType = new Mock<IEntityType>();
+        var mockTableNameAnnotation = new Mock<IAnnotation>();
+        mockTableNameAnnotation.Setup(a => a.Value).Returns("TestCollection");
+        mockEntityType.Setup(e => e.FindAnnotation("Relational:TableName")).Returns(mockTableNameAnnotation.Object);
+        mockEntityType.Setup(e => e.ClrType).Returns(typeof(TestEntity));
+        mockEntityType.Setup(e => e.GetProperties()).Returns(Array.Empty<IProperty>());
+
+        var mockScoreProperty = CreateMockProperty("Score", mockEntityType.Object);
+        var mockCategoryProperty = CreateMockProperty("Category", mockEntityType.Object);
+        var mockIndex = CreateMockIndex(
+            mockEntityType.Object, new[] { mockScoreProperty.Object, mockCategoryProperty.Object }, "ix_score_category");
+        mockEntityType.Setup(e => e.GetIndexes()).Returns(new[] { mockIndex.Object });
+
+        _mockModel.Setup(m => m.GetEntityTypes()).Returns(new[] { mockEntityType.Object });
+
+        var creator = CreateCreator();
+
+        // Act
+        await creator.EnsureCreatedAsync();
+
+        // Assert - both fields appear, in declaration order, inside a single parenthesized list
+        _mockScope.Verify(
+            s => s.QueryAsync<dynamic>(
+                It.Is<string>(sql => sql.StartsWith("CREATE INDEX `ix_score_category` IF NOT EXISTS")
+                                      && sql.Contains("(`Score`, `Category`)")),
+                It.IsAny<QueryOptions>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task EnsureCreatedAsync_WithAutoCreateIndexesEnabled_CreatesFilteredSecondaryIndex()
+    {
+        // Arrange
+        _mockOptions.Setup(o => o.Bucket).Returns("my-bucket");
+        _mockOptions.Setup(o => o.Scope).Returns("my-scope");
+        _mockOptions.Setup(o => o.AutoCreateIndexes).Returns(true);
+
+        _mockBucketManager.Setup(m => m.GetBucketAsync("my-bucket", It.IsAny<GetBucketOptions>()))
+            .ReturnsAsync(new BucketSettings { Name = "my-bucket" });
+        _mockCluster.Setup(c => c.BucketAsync("my-bucket")).ReturnsAsync(_mockBucket.Object);
+        _mockCollectionManager.Setup(m => m.GetAllScopesAsync(It.IsAny<GetAllScopesOptions>()))
+            .ReturnsAsync(new List<ScopeSpec> { new ScopeSpec("my-scope") });
+
+        var mockEntityType = new Mock<IEntityType>();
+        var mockTableNameAnnotation = new Mock<IAnnotation>();
+        mockTableNameAnnotation.Setup(a => a.Value).Returns("TestCollection");
+        mockEntityType.Setup(e => e.FindAnnotation("Relational:TableName")).Returns(mockTableNameAnnotation.Object);
+        mockEntityType.Setup(e => e.ClrType).Returns(typeof(TestEntity));
+        mockEntityType.Setup(e => e.GetProperties()).Returns(Array.Empty<IProperty>());
+
+        var mockScoreProperty = CreateMockProperty("Score", mockEntityType.Object);
+        var mockIndex = CreateMockIndex(
+            mockEntityType.Object, new[] { mockScoreProperty.Object }, "ix_score_filtered", filter: "`Score` > 0");
+        mockEntityType.Setup(e => e.GetIndexes()).Returns(new[] { mockIndex.Object });
+
+        _mockModel.Setup(m => m.GetEntityTypes()).Returns(new[] { mockEntityType.Object });
+
+        var creator = CreateCreator();
+
+        // Act
+        await creator.EnsureCreatedAsync();
+
+        // Assert - HasFilter()'s raw predicate string is spliced verbatim into a WHERE clause
+        _mockScope.Verify(
+            s => s.QueryAsync<dynamic>(
+                It.Is<string>(sql => sql.Contains("(`Score`)") && sql.EndsWith(" WHERE `Score` > 0")),
+                It.IsAny<QueryOptions>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task EnsureCreatedAsync_WithAutoCreateIndexesEnabled_UniqueIndex_LogsWarningButStillCreatesIndex()
+    {
+        // Arrange - N1QL GSI secondary indexes cannot enforce uniqueness; IsUnique should be a
+        // logged no-op warning, not a thrown error or a silently-dropped index.
+        _mockOptions.Setup(o => o.Bucket).Returns("my-bucket");
+        _mockOptions.Setup(o => o.Scope).Returns("my-scope");
+        _mockOptions.Setup(o => o.AutoCreateIndexes).Returns(true);
+
+        _mockBucketManager.Setup(m => m.GetBucketAsync("my-bucket", It.IsAny<GetBucketOptions>()))
+            .ReturnsAsync(new BucketSettings { Name = "my-bucket" });
+        _mockCluster.Setup(c => c.BucketAsync("my-bucket")).ReturnsAsync(_mockBucket.Object);
+        _mockCollectionManager.Setup(m => m.GetAllScopesAsync(It.IsAny<GetAllScopesOptions>()))
+            .ReturnsAsync(new List<ScopeSpec> { new ScopeSpec("my-scope") });
+
+        var mockEntityType = new Mock<IEntityType>();
+        var mockTableNameAnnotation = new Mock<IAnnotation>();
+        mockTableNameAnnotation.Setup(a => a.Value).Returns("TestCollection");
+        mockEntityType.Setup(e => e.FindAnnotation("Relational:TableName")).Returns(mockTableNameAnnotation.Object);
+        mockEntityType.Setup(e => e.ClrType).Returns(typeof(TestEntity));
+        mockEntityType.Setup(e => e.GetProperties()).Returns(Array.Empty<IProperty>());
+
+        var mockScoreProperty = CreateMockProperty("Score", mockEntityType.Object);
+        var mockIndex = CreateMockIndex(
+            mockEntityType.Object, new[] { mockScoreProperty.Object }, "ix_score_unique", isUnique: true);
+        mockEntityType.Setup(e => e.GetIndexes()).Returns(new[] { mockIndex.Object });
+
+        _mockModel.Setup(m => m.GetEntityTypes()).Returns(new[] { mockEntityType.Object });
+
+        var creator = CreateCreator();
+
+        // Act
+        await creator.EnsureCreatedAsync();
+
+        // Assert - the index is still created as a plain, non-unique index...
+        _mockScope.Verify(
+            s => s.QueryAsync<dynamic>(
+                It.Is<string>(sql => sql.StartsWith("CREATE INDEX `ix_score_unique` IF NOT EXISTS")),
+                It.IsAny<QueryOptions>()),
+            Times.Once);
+
+        // ...and a warning is logged explaining uniqueness cannot be enforced.
+        _mockLogger.Verify(
+            l => l.Log(
+                LogLevel.Warning,
+                It.IsAny<EventId>(),
+                It.Is<It.IsAnyType>((state, _) => state.ToString()!.Contains("cannot enforce uniqueness")),
+                It.IsAny<Exception>(),
+                It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task EnsureCreatedAsync_WithAutoCreateIndexesEnabled_SkipsIndexOnOwnedTypeProperty()
+    {
+        // Arrange - an index referencing a property declared on an owned type isn't resolvable to
+        // a single JSON field path on the root document in this pass; it should be skipped with a
+        // warning rather than producing broken DDL.
+        _mockOptions.Setup(o => o.Bucket).Returns("my-bucket");
+        _mockOptions.Setup(o => o.Scope).Returns("my-scope");
+        _mockOptions.Setup(o => o.AutoCreateIndexes).Returns(true);
+
+        _mockBucketManager.Setup(m => m.GetBucketAsync("my-bucket", It.IsAny<GetBucketOptions>()))
+            .ReturnsAsync(new BucketSettings { Name = "my-bucket" });
+        _mockCluster.Setup(c => c.BucketAsync("my-bucket")).ReturnsAsync(_mockBucket.Object);
+        _mockCollectionManager.Setup(m => m.GetAllScopesAsync(It.IsAny<GetAllScopesOptions>()))
+            .ReturnsAsync(new List<ScopeSpec> { new ScopeSpec("my-scope") });
+
+        var mockEntityType = new Mock<IEntityType>();
+        var mockTableNameAnnotation = new Mock<IAnnotation>();
+        mockTableNameAnnotation.Setup(a => a.Value).Returns("TestCollection");
+        mockEntityType.Setup(e => e.FindAnnotation("Relational:TableName")).Returns(mockTableNameAnnotation.Object);
+        mockEntityType.Setup(e => e.ClrType).Returns(typeof(TestEntity));
+        mockEntityType.Setup(e => e.GetProperties()).Returns(Array.Empty<IProperty>());
+
+        var mockOwnedEntityType = new Mock<IEntityType>();
+        mockOwnedEntityType.Setup(e => e.IsOwned()).Returns(true);
+
+        var mockOwnedProperty = CreateMockProperty("Street", mockOwnedEntityType.Object);
+        var mockIndex = CreateMockIndex(mockEntityType.Object, new[] { mockOwnedProperty.Object }, "ix_address_street");
+        mockEntityType.Setup(e => e.GetIndexes()).Returns(new[] { mockIndex.Object });
+
+        _mockModel.Setup(m => m.GetEntityTypes()).Returns(new[] { mockEntityType.Object });
+
+        var creator = CreateCreator();
+
+        // Act
+        await creator.EnsureCreatedAsync();
+
+        // Assert - no CREATE INDEX for the owned-type-backed index
+        _mockScope.Verify(
+            s => s.QueryAsync<dynamic>(
+                It.Is<string>(sql => sql.StartsWith("CREATE INDEX")),
+                It.IsAny<QueryOptions>()),
+            Times.Never);
+
+        _mockLogger.Verify(
+            l => l.Log(
+                LogLevel.Warning,
+                It.IsAny<EventId>(),
+                It.Is<It.IsAnyType>((state, _) => state.ToString()!.Contains("declared on an owned type")),
+                It.IsAny<Exception>(),
+                It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task EnsureCreatedAsync_WithAutoCreateIndexesEnabled_ConflictingIndexDefinitionsWithSameName_Throws()
+    {
+        // Arrange - two distinct index definitions sharing the same database name within the same
+        // keyspace is a real model bug: "CREATE INDEX ... IF NOT EXISTS" silently keeps whichever
+        // definition is created first, so the actually-created index could permanently diverge from
+        // one of the two definitions with no error ever surfacing. This must fail loudly instead of
+        // silently overwriting the dictionary entry for the first definition.
+        _mockOptions.Setup(o => o.Bucket).Returns("my-bucket");
+        _mockOptions.Setup(o => o.Scope).Returns("my-scope");
+        _mockOptions.Setup(o => o.AutoCreateIndexes).Returns(true);
+
+        _mockBucketManager.Setup(m => m.GetBucketAsync("my-bucket", It.IsAny<GetBucketOptions>()))
+            .ReturnsAsync(new BucketSettings { Name = "my-bucket" });
+        _mockCluster.Setup(c => c.BucketAsync("my-bucket")).ReturnsAsync(_mockBucket.Object);
+        _mockCollectionManager.Setup(m => m.GetAllScopesAsync(It.IsAny<GetAllScopesOptions>()))
+            .ReturnsAsync(new List<ScopeSpec> { new ScopeSpec("my-scope") });
+
+        var mockEntityType = new Mock<IEntityType>();
+        var mockTableNameAnnotation = new Mock<IAnnotation>();
+        mockTableNameAnnotation.Setup(a => a.Value).Returns("TestCollection");
+        mockEntityType.Setup(e => e.FindAnnotation("Relational:TableName")).Returns(mockTableNameAnnotation.Object);
+        mockEntityType.Setup(e => e.ClrType).Returns(typeof(TestEntity));
+        mockEntityType.Setup(e => e.GetProperties()).Returns(Array.Empty<IProperty>());
+
+        var mockScoreProperty = CreateMockProperty("Score", mockEntityType.Object);
+        var mockNameProperty = CreateMockProperty("Name", mockEntityType.Object);
+        var mockIndexA = CreateMockIndex(mockEntityType.Object, new[] { mockScoreProperty.Object }, "ix_conflict");
+        var mockIndexB = CreateMockIndex(mockEntityType.Object, new[] { mockNameProperty.Object }, "ix_conflict");
+        mockEntityType.Setup(e => e.GetIndexes()).Returns(new[] { mockIndexA.Object, mockIndexB.Object });
+
+        _mockModel.Setup(m => m.GetEntityTypes()).Returns(new[] { mockEntityType.Object });
+
+        var creator = CreateCreator();
+
+        // Act & Assert
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(() => creator.EnsureCreatedAsync());
+        Assert.Contains("ix_conflict", ex.Message);
+    }
+
+    [Fact]
+    public async Task EnsureCreatedAsync_WithAutoCreateIndexesEnabled_IdenticalIndexDefinitionsWithSameName_CreatesOnlyOnce()
+    {
+        // Arrange - a TPH-shared collection where two entity types happen to declare the exact
+        // same index (same name, same field) is a legitimate duplicate, not a conflict -- it must
+        // still dedupe to a single CREATE INDEX / online-wait, not throw.
+        _mockOptions.Setup(o => o.Bucket).Returns("my-bucket");
+        _mockOptions.Setup(o => o.Scope).Returns("my-scope");
+        _mockOptions.Setup(o => o.AutoCreateIndexes).Returns(true);
+
+        _mockBucketManager.Setup(m => m.GetBucketAsync("my-bucket", It.IsAny<GetBucketOptions>()))
+            .ReturnsAsync(new BucketSettings { Name = "my-bucket" });
+        _mockCluster.Setup(c => c.BucketAsync("my-bucket")).ReturnsAsync(_mockBucket.Object);
+        _mockCollectionManager.Setup(m => m.GetAllScopesAsync(It.IsAny<GetAllScopesOptions>()))
+            .ReturnsAsync(new List<ScopeSpec> { new ScopeSpec("my-scope") });
+
+        var mockBaseEntityType = new Mock<IEntityType>();
+        var mockBaseTableNameAnnotation = new Mock<IAnnotation>();
+        mockBaseTableNameAnnotation.Setup(a => a.Value).Returns("SharedCollection");
+        mockBaseEntityType.Setup(e => e.FindAnnotation("Relational:TableName")).Returns(mockBaseTableNameAnnotation.Object);
+        mockBaseEntityType.Setup(e => e.ClrType).Returns(typeof(TestEntity));
+        mockBaseEntityType.Setup(e => e.GetProperties()).Returns(Array.Empty<IProperty>());
+        var mockBaseScoreProperty = CreateMockProperty("Score", mockBaseEntityType.Object);
+        var mockBaseIndex = CreateMockIndex(mockBaseEntityType.Object, new[] { mockBaseScoreProperty.Object }, "ix_shared_score");
+        mockBaseEntityType.Setup(e => e.GetIndexes()).Returns(new[] { mockBaseIndex.Object });
+
+        var mockDerivedEntityType = new Mock<IEntityType>();
+        var mockDerivedTableNameAnnotation = new Mock<IAnnotation>();
+        mockDerivedTableNameAnnotation.Setup(a => a.Value).Returns("SharedCollection");
+        mockDerivedEntityType.Setup(e => e.FindAnnotation("Relational:TableName")).Returns(mockDerivedTableNameAnnotation.Object);
+        mockDerivedEntityType.Setup(e => e.ClrType).Returns(typeof(TestDerivedEntity));
+        mockDerivedEntityType.Setup(e => e.GetProperties()).Returns(Array.Empty<IProperty>());
+        var mockDerivedScoreProperty = CreateMockProperty("Score", mockDerivedEntityType.Object);
+        var mockDerivedIndex = CreateMockIndex(mockDerivedEntityType.Object, new[] { mockDerivedScoreProperty.Object }, "ix_shared_score");
+        mockDerivedEntityType.Setup(e => e.GetIndexes()).Returns(new[] { mockDerivedIndex.Object });
+
+        _mockModel.Setup(m => m.GetEntityTypes())
+            .Returns(new[] { mockBaseEntityType.Object, mockDerivedEntityType.Object });
+
+        var creator = CreateCreator();
+
+        // Act
+        await creator.EnsureCreatedAsync();
+
+        // Assert - one CREATE INDEX and one online-wait for the shared definition, not two, and no
+        // exception thrown
+        _mockScope.Verify(
+            s => s.QueryAsync<dynamic>(
+                It.Is<string>(sql => sql.StartsWith("CREATE INDEX `ix_shared_score` IF NOT EXISTS")),
+                It.IsAny<QueryOptions>()),
+            Times.Once);
     }
 
     #endregion


### PR DESCRIPTION
EnsureCreatedAsync now creates a N1QL secondary index for every HasIndex() declared on the model when AutoCreateIndexes is enabled, alongside the existing primary-index creation. Supports composite fields, HasFilter(), and explicit names; IsUnique() is a logged no-op (N1QL GSI has no unique constraint) and indexes on owned-type properties are skipped with a warning. Also fixes a real bug: a secondary index's system:indexes row omits is_primary entirely rather than reporting false, so the online-wait query's is_primary = false filter never matched.