### PR TITLE
Fix cross-bucket sequences targeting the configured bucket instead of…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -148,6 +148,23 @@ and this project aims to follow [Semantic Versioning](https://semver.org/spec/v2
 
 ### Fixed
 
+- **Sequences always targeted the context's configured bucket, not the actual bucket of the
+  entity using them.** `CreateSequencesAsync`/`DropSequencesAsync` and
+  `CouchbaseValueGeneratorSelector`'s runtime `NEXT VALUE FOR` generator now resolve each
+  sequence-owning property's entity's actual bucket (via a new shared `CouchbaseKeyspace.Resolve`
+  helper, mirroring how collections/indexes already resolve per-entity), so an entity mapped to a
+  different bucket via `ToCouchbaseCollection`/`[CouchbaseKeyspace]` gets its sequence created in
+  and read from that same bucket instead of the configured one. The bug was self-consistent
+  (creation and runtime generation agreed on the same wrong bucket, so it never crashed) — it just
+  silently placed the sequence somewhere other than where the entity's data actually lives, which
+  could surface as a permissions issue on the configured bucket, or simply mean the sequence
+  couldn't be found where a user went looking for it. Sequences are now keyed by
+  `(bucket, scope, name)` rather than just `(scope, name)`, so the same sequence name/scope in two
+  different buckets is correctly treated as two distinct sequences, not a naming conflict. The
+  sequence's *scope* is unaffected by this fix — it still defaults to the context's configured
+  scope unless overridden via `UseSequence(scope, name)`/the attribute's `Scope` property. See
+  [Sequences and generated values](docs/sequences.md#usesequence-fluent-api).
+
 - **C#'s `??` (null-coalescing) generated N1QL's nonexistent `COALESCE` function**, reaching the
   server as invalid SQL++ and failing only at query-execution time, never at translation time. Now
   translates to `IFMISSINGORNULL`, which is also the semantically correct choice: a Couchbase

--- a/docs/sequences.md
+++ b/docs/sequences.md
@@ -7,7 +7,12 @@ integer/long primary keys, configured either via the fluent `UseSequence` API or
 ## UseSequence (fluent API)
 
 The simplest form looks up a sequence of the given name in the bucket/scope the `DbContext` is
-already configured for:
+already configured for — unless the property's entity is itself mapped to a different bucket
+(via `ToCouchbaseCollection(bucket, scope, collection)` or `[CouchbaseKeyspace]`), in which case
+the sequence's **bucket** automatically follows that entity's actual bucket, both when it's
+auto-created and when a value is generated at runtime. The sequence's **scope** does not follow
+the entity the same way — it always defaults to the context's configured scope unless you pass
+one explicitly (below).
 
 ```
 modelBuilder.Entity<Order>()
@@ -80,6 +85,12 @@ Sequences targeting a **non-default scope** (via `UseSequence(scope, ...)` or th
 `Scope` property) are **not** auto-created, since that scope might not exist yet — a warning is
 logged instead. Create the scope and sequence yourself in that case, or set `AutoCreate = false`
 if you're managing the sequence's lifecycle entirely outside of `EnsureCreatedAsync`.
+
+If the property's entity is mapped to a different bucket than the context's configured one, the
+sequence is created (and, at runtime, queried via `NEXT VALUE FOR`) in that entity's actual
+bucket, matching how collections and indexes already resolve per-entity — not the context's
+configured bucket. Two sequences with the same name and scope in different buckets are distinct,
+not a naming conflict, since a sequence's true identity is `bucket.scope.name`.
 
 ## Generated GUIDs
 

--- a/src/Couchbase.EntityFrameworkCore/Metadata/CouchbaseKeyspace.cs
+++ b/src/Couchbase.EntityFrameworkCore/Metadata/CouchbaseKeyspace.cs
@@ -147,4 +147,45 @@ public readonly record struct CouchbaseKeyspace
         result = new CouchbaseKeyspace(bucket, scope, collection);
         return true;
     }
+
+    /// <summary>
+    /// Resolves an entity's table name into its actual keyspace: parsed as a full
+    /// <c>Bucket.Scope.Collection</c> reference (via <c>ToCouchbaseCollection</c>/
+    /// <c>[CouchbaseKeyspace]</c>) when <paramref name="tableName"/> is in that form, falling back
+    /// to a bare collection named <paramref name="tableName"/> in
+    /// <paramref name="configuredBucket"/>/<paramref name="configuredScope"/> otherwise.
+    /// </summary>
+    /// <remarks>
+    /// Shared so bucket resolution stays consistent between schema-management code (collection/
+    /// index creation, in <c>CouchbaseDatabaseCreator</c>) and runtime value generation (Couchbase
+    /// sequences, in <c>CouchbaseValueGeneratorSelector</c>) — both need to agree on which bucket a
+    /// given entity's data (and anything derived from it, like a sequence) actually lives in.
+    /// <paramref name="tableName"/> must be non-null and non-empty: a <see cref="CouchbaseKeyspace"/>
+    /// always represents a genuine bucket/scope/collection triple, so there is no valid keyspace to
+    /// return for an entity with no table of its own (e.g. an owned type). Callers that only need
+    /// the bucket, and may have no table name at all, should use <see cref="ResolveBucket"/> instead.
+    /// </remarks>
+    public static CouchbaseKeyspace Resolve(string tableName, string configuredBucket, string configuredScope)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(tableName);
+
+        if (TryParse(tableName, out var keyspace))
+        {
+            return keyspace!.Value;
+        }
+
+        return new CouchbaseKeyspace(configuredBucket, configuredScope, tableName);
+    }
+
+    /// <summary>
+    /// Resolves an entity's table name into just its actual bucket, falling back to
+    /// <paramref name="configuredBucket"/> when <paramref name="tableName"/> isn't a full
+    /// <c>Bucket.Scope.Collection</c> reference — including when it's <see langword="null"/> or
+    /// empty (an entity with no table of its own, e.g. an owned type, or a non-entity
+    /// <c>DeclaringType</c> in value generation). Unlike <see cref="Resolve"/>, this never
+    /// constructs a <see cref="CouchbaseKeyspace"/>, so it has no non-empty-collection
+    /// requirement to satisfy.
+    /// </summary>
+    public static string ResolveBucket(string? tableName, string configuredBucket)
+        => TryParse(tableName, out var keyspace) ? keyspace!.Value.Bucket : configuredBucket;
 }

--- a/src/Couchbase.EntityFrameworkCore/Storage/Internal/CouchbaseDatabaseCreator.cs
+++ b/src/Couchbase.EntityFrameworkCore/Storage/Internal/CouchbaseDatabaseCreator.cs
@@ -140,22 +140,13 @@ public class CouchbaseDatabaseCreator :  RelationalDatabaseCreator
     }
 
     /// <summary>
-    /// Resolves an entity type's table name into its actual keyspace — parsed as a full
-    /// <c>Bucket.Scope.Collection</c> reference (via <see cref="ToCouchbaseCollection"/>/
-    /// <c>[CouchbaseKeyspace]</c>) when present, falling back to the table name as a collection
-    /// in the configured bucket/scope otherwise. Shared by <see cref="GetEntityKeyspacesByBucket"/>
-    /// and <see cref="CreateSecondaryIndexesAsync"/> so both resolve keyspaces identically.
+    /// Resolves an entity type's table name into its actual keyspace. Thin wrapper over
+    /// <see cref="CouchbaseKeyspace.Resolve"/> using this creator's configured bucket/scope as the
+    /// fallback. Shared by <see cref="GetEntityKeyspacesByBucket"/> and
+    /// <see cref="CreateSecondaryIndexesAsync"/> so both resolve keyspaces identically.
     /// </summary>
     private CouchbaseKeyspace ResolveEntityKeyspace(string tableName)
-    {
-        if (CouchbaseKeyspace.TryParse(tableName, out var keyspace))
-        {
-            return keyspace!.Value;
-        }
-
-        return new CouchbaseKeyspace(
-            _couchbaseDbContextOptionsBuilder.Bucket, _couchbaseDbContextOptionsBuilder.Scope, tableName);
-    }
+        => CouchbaseKeyspace.Resolve(tableName, _couchbaseDbContextOptionsBuilder.Bucket, _couchbaseDbContextOptionsBuilder.Scope);
 
     private async Task CreateCollectionsAsync(CancellationToken cancellationToken)
     {
@@ -230,12 +221,20 @@ public class CouchbaseDatabaseCreator :  RelationalDatabaseCreator
 
     private async Task CreateSequencesAsync(CancellationToken cancellationToken)
     {
-        // Collect all unique sequences from the model that should be auto-created
-        // Use tuple key (scope, name) to avoid delimiter parsing issues
-        var sequences = new Dictionary<(string Scope, string Name), CouchbaseSequenceOptions>();
+        // Collect all unique sequences from the model that should be auto-created.
+        // Keyed by (bucket, scope, name) rather than just (scope, name): a sequence lives at
+        // bucket.scope.name, so the same (scope, name) in two DIFFERENT buckets is a genuinely
+        // distinct sequence, not a conflict -- see CouchbaseKeyspace.Resolve for how each
+        // sequence-owning property's entity's actual bucket is determined (mirrors how
+        // GetEntityKeyspacesByBucket() resolves collections/indexes, rather than always assuming
+        // the configured bucket).
+        var sequences = new Dictionary<(string Bucket, string Scope, string Name), CouchbaseSequenceOptions>();
 
         foreach (var entityType in _designTimeModel.Model.GetEntityTypes())
         {
+            var sequenceBucket = CouchbaseKeyspace.ResolveBucket(
+                entityType.GetTableName(), _couchbaseDbContextOptionsBuilder.Bucket);
+
             foreach (var property in entityType.GetProperties())
             {
                 var sequenceName = property.FindAnnotation(CouchbaseValueGeneratorSelector.SequenceNameAnnotation)?.Value as string;
@@ -274,7 +273,7 @@ public class CouchbaseDatabaseCreator :  RelationalDatabaseCreator
                 var options = property.FindAnnotation(CouchbaseValueGeneratorSelector.SequenceOptionsAnnotation)?.Value as CouchbaseSequenceOptions
                     ?? CouchbaseSequenceOptions.Default;
 
-                var key = (sequenceScope, sequenceName);
+                var key = (sequenceBucket, sequenceScope, sequenceName);
                 if (sequences.TryGetValue(key, out var existingOptions))
                 {
                     // Check for conflicting options
@@ -282,10 +281,11 @@ public class CouchbaseDatabaseCreator :  RelationalDatabaseCreator
                     {
                         var propertyPath = $"{property.DeclaringType.ClrType.Name}.{property.Name}";
                         throw new InvalidOperationException(
-                            $"Conflicting sequence options detected for sequence '{sequenceName}' in scope '{sequenceScope}'. " +
-                            $"Property '{propertyPath}' specifies different options than a previously configured property. " +
-                            $"Existing: {existingOptions.ToSqlOptionsClause()}, Conflicting: {options.ToSqlOptionsClause()}. " +
-                            $"Ensure all properties using the same sequence have identical options.");
+                            $"Conflicting sequence options detected for sequence '{sequenceName}' in scope '{sequenceScope}' " +
+                            $"(bucket '{sequenceBucket}'). Property '{propertyPath}' specifies different options than a " +
+                            $"previously configured property. Existing: {existingOptions.ToSqlOptionsClause()}, " +
+                            $"Conflicting: {options.ToSqlOptionsClause()}. Ensure all properties using the same sequence " +
+                            "have identical options.");
                     }
                 }
                 else
@@ -296,19 +296,20 @@ public class CouchbaseDatabaseCreator :  RelationalDatabaseCreator
         }
 
         // Create each sequence
-        foreach (var ((scope, name), options) in sequences)
+        foreach (var ((bucket, scope, name), options) in sequences)
         {
-            await CreateSequenceAsync(scope, name, options, cancellationToken);
+            await CreateSequenceAsync(bucket, scope, name, options, cancellationToken);
         }
     }
 
-    private async Task CreateSequenceAsync(string scope, string sequenceName, CouchbaseSequenceOptions options, CancellationToken cancellationToken)
+    private async Task CreateSequenceAsync(
+        string bucketName, string scope, string sequenceName, CouchbaseSequenceOptions options, CancellationToken cancellationToken)
     {
-        var bucket = await GetBucketAsync(cancellationToken);
+        var bucket = await GetBucketAsync(bucketName, cancellationToken);
         var scopeObj = await bucket.ScopeAsync(scope);
 
         // Build CREATE SEQUENCE statement using proper identifier escaping
-        var bucketIdentifier = _sqlGenerationHelper.DelimitIdentifier(_couchbaseDbContextOptionsBuilder.Bucket);
+        var bucketIdentifier = _sqlGenerationHelper.DelimitIdentifier(bucketName);
         var scopeIdentifier = _sqlGenerationHelper.DelimitIdentifier(scope);
         var sequenceIdentifier = _sqlGenerationHelper.DelimitIdentifier(sequenceName);
 
@@ -742,13 +743,15 @@ public class CouchbaseDatabaseCreator :  RelationalDatabaseCreator
 
     private async Task DropSequencesAsync(CancellationToken cancellationToken)
     {
-        var bucket = await GetBucketAsync(cancellationToken);
-
-        // Collect all unique sequences from the model
-        var sequences = new HashSet<(string Scope, string Name)>();
+        // Collect all unique sequences from the model, keyed by (bucket, scope, name) -- see
+        // CreateSequencesAsync's comment on why bucket must be part of the key.
+        var sequences = new HashSet<(string Bucket, string Scope, string Name)>();
 
         foreach (var entityType in _designTimeModel.Model.GetEntityTypes())
         {
+            var sequenceBucket = CouchbaseKeyspace.ResolveBucket(
+                entityType.GetTableName(), _couchbaseDbContextOptionsBuilder.Bucket);
+
             foreach (var property in entityType.GetProperties())
             {
                 var sequenceName = property.FindAnnotation(CouchbaseValueGeneratorSelector.SequenceNameAnnotation)?.Value as string;
@@ -760,19 +763,20 @@ public class CouchbaseDatabaseCreator :  RelationalDatabaseCreator
                 var sequenceScope = property.FindAnnotation(CouchbaseValueGeneratorSelector.SequenceScopeAnnotation)?.Value as string
                     ?? _couchbaseDbContextOptionsBuilder.Scope;
 
-                sequences.Add((sequenceScope, sequenceName));
+                sequences.Add((sequenceBucket, sequenceScope, sequenceName));
             }
         }
 
         // Drop each sequence
-        foreach (var (scope, sequenceName) in sequences)
+        foreach (var (bucketName, scope, sequenceName) in sequences)
         {
             try
             {
+                var bucket = await GetBucketAsync(bucketName, cancellationToken);
                 var scopeObj = await bucket.ScopeAsync(scope);
 
                 // Use proper identifier escaping
-                var bucketIdentifier = _sqlGenerationHelper.DelimitIdentifier(_couchbaseDbContextOptionsBuilder.Bucket);
+                var bucketIdentifier = _sqlGenerationHelper.DelimitIdentifier(bucketName);
                 var scopeIdentifier = _sqlGenerationHelper.DelimitIdentifier(scope);
                 var sequenceIdentifier = _sqlGenerationHelper.DelimitIdentifier(sequenceName);
 
@@ -793,7 +797,8 @@ public class CouchbaseDatabaseCreator :  RelationalDatabaseCreator
                 // Log at Warning so unexpected failures are visible. Cancellation is excluded so it
                 // stops this loop immediately instead of being logged and swallowed while cleanup
                 // of the remaining sequences continues.
-                _logger.LogWarning(ex, "Failed to drop sequence {SequenceName} in scope {Scope}", sequenceName, scope);
+                _logger.LogWarning(ex, "Failed to drop sequence {SequenceName} in scope {Scope} (bucket {BucketName})",
+                    sequenceName, scope, bucketName);
             }
         }
     }

--- a/src/Couchbase.EntityFrameworkCore/ValueGeneration/CouchbaseValueGeneratorSelector.cs
+++ b/src/Couchbase.EntityFrameworkCore/ValueGeneration/CouchbaseValueGeneratorSelector.cs
@@ -1,5 +1,7 @@
 using System.Reflection;
 using Couchbase.EntityFrameworkCore.Infrastructure;
+using Couchbase.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.ValueGeneration;
 
@@ -130,7 +132,13 @@ public class CouchbaseValueGeneratorSelector : RelationalValueGeneratorSelector
     {
         var scopeOverride = property.FindAnnotation(SequenceScopeAnnotation)?.Value as string;
         var scope = scopeOverride ?? _optionsBuilder.Scope;
-        var bucket = _optionsBuilder.Bucket;
+
+        // Resolve the OWNING entity's actual bucket (mirroring CouchbaseDatabaseCreator's
+        // schema-management resolution) rather than assuming the configured bucket -- an entity
+        // mapped to a different bucket via ToCouchbaseCollection/[CouchbaseKeyspace] must generate
+        // its sequence values against that same bucket, not the context's default.
+        var tableName = (property.DeclaringType as IReadOnlyEntityType)?.GetTableName();
+        var bucket = CouchbaseKeyspace.ResolveBucket(tableName, _optionsBuilder.Bucket);
 
         return new CouchbaseSequenceValueGenerator<T>(
             sequenceName,

--- a/tests/Couchbase.EntityFrameworkCore.IntegrationTests/Tests/SequenceValueGenerationTests.cs
+++ b/tests/Couchbase.EntityFrameworkCore.IntegrationTests/Tests/SequenceValueGenerationTests.cs
@@ -476,21 +476,84 @@ public class SequenceValueGenerationTests : IAsyncLifetime
         _outputHelper.WriteLine("TEST PASSED: End-to-end auto-create sequence workflow verified");
     }
 
-    private async Task DropSequenceIfExistsAsync(string sequenceName)
+    private async Task DropSequenceIfExistsAsync(string sequenceName, string? bucketName = null, string? scopeName = null)
     {
         try
         {
-            await using var context = CreateSequenceTestDbContext();
-            var connection = context.Database.GetDbConnection();
-            await connection.OpenAsync();
-
-            using var command = connection.CreateCommand();
-            command.CommandText = $"DROP SEQUENCE IF EXISTS `{_fixture.BucketName}`.`{_fixture.ScopeName}`.`{sequenceName}`";
-            await command.ExecuteNonQueryAsync();
+            var clusterOptions = new ClusterOptions()
+                .WithConnectionString(_fixture.Host)
+                .WithCredentials(_fixture.Username, _fixture.Password);
+            using var cluster = await Cluster.ConnectAsync(clusterOptions);
+            using var result = await cluster.QueryAsync<dynamic>(
+                $"DROP SEQUENCE IF EXISTS `{bucketName ?? _fixture.BucketName}`.`{scopeName ?? _fixture.ScopeName}`.`{sequenceName}`");
+            await foreach (var _ in result.Rows)
+            {
+            }
         }
         catch (Exception ex)
         {
             _outputHelper.WriteLine($"Note: Could not drop sequence {sequenceName}: {ex.Message}");
+        }
+    }
+
+    /// <summary>
+    /// End-to-end proof of the cross-bucket sequences fix: an entity mapped to a bucket other
+    /// than the context's configured one must have its sequence created AND consumed against
+    /// that entity's actual bucket, not the configured one. Before the fix, CreateSequencesAsync
+    /// always created the sequence in the configured bucket while CouchbaseValueGeneratorSelector
+    /// always queried NEXT VALUE FOR against the configured bucket too -- so the bug was
+    /// self-consistent (never crashed), it just misplaced the sequence. This test only fails if
+    /// EITHER side of that consistency breaks -- e.g. creation resolves the entity's bucket but
+    /// runtime generation doesn't (or vice versa) -- which would make SaveChangesAsync throw a
+    /// "sequence does not exist" error instead of assigning a value.
+    /// </summary>
+    [Fact]
+    public async Task EnsureCreatedAsync_ThenSaveChanges_SequenceOnSecondaryBucketEntity_CreatesAndUsesSequenceInThatBucket()
+    {
+        const string secondaryBucketSeqName = "secondary_bucket_seq";
+
+        await DropSequenceIfExistsAsync(secondaryBucketSeqName, bucketName: "secondary", scopeName: "isolation");
+
+        var optionsBuilder = new DbContextOptionsBuilder<SecondaryBucketSequenceDbContext>();
+        optionsBuilder.UseCouchbase(
+            new ClusterOptions()
+                .WithConnectionString(_fixture.Host)
+                .WithPasswordAuthentication(_fixture.Username, _fixture.Password),
+            couchbaseDbContextOptions =>
+            {
+                // "isolation" (not the fixture's default "blogs" scope) mirrors
+                // IndexCreationTests.cs's SecondaryBucketIndexContext convention: "isolation" is
+                // the one scope pre-provisioned in BOTH "default" and "secondary" buckets. The
+                // sequence's own scope (below) has no bucket override to follow, only a scope
+                // override, so it must match the CONTEXT's configured scope here to land in the
+                // scope that actually exists on the secondary bucket.
+                couchbaseDbContextOptions.Bucket = "default";
+                couchbaseDbContextOptions.Scope = "isolation";
+            });
+        optionsBuilder.ConfigureWarnings(w => w.Ignore(CoreEventId.ManyServiceProvidersCreatedWarning));
+
+        await using var context = new SecondaryBucketSequenceDbContext(optionsBuilder.Options);
+
+        try
+        {
+            await context.Database.EnsureCreatedAsync();
+            _outputHelper.WriteLine("EnsureCreatedAsync completed");
+
+            var entity = new SecondaryBucketSequenceEntity { Name = "Cross-bucket sequence test" };
+            Assert.Equal(0, entity.Id);
+
+            context.Entities.Add(entity);
+            await context.SaveChangesAsync();
+
+            Assert.True(entity.Id > 0, $"Expected positive Id from sequence, got {entity.Id}");
+            _outputHelper.WriteLine($"Entity saved with Id = {entity.Id} using the sequence in bucket 'secondary'");
+
+            context.Entities.Remove(entity);
+            await context.SaveChangesAsync();
+        }
+        finally
+        {
+            await DropSequenceIfExistsAsync(secondaryBucketSeqName, bucketName: "secondary", scopeName: "isolation");
         }
     }
 
@@ -660,6 +723,42 @@ public class SequenceValueGenerationTests : IAsyncLifetime
                 // Default options (StartWith = 1, IncrementBy = 1)
                 entity.Property(e => e.Id).UseSequence("e2e_auto_seq");
                 entity.ToCouchbaseCollection(this, "e2e_auto_create_entities");
+            });
+
+            modelBuilder.ConfigureToCouchbase(this, true);
+        }
+    }
+
+    /// <summary>
+    /// Entity for the cross-bucket sequences test, mapped to the "secondary" bucket (pre-provisioned
+    /// by the AppHost, same bucket MultiBucketSingleContextTests/IndexCreationTests rely on) while
+    /// the context itself is configured for the default bucket.
+    /// </summary>
+    public class SecondaryBucketSequenceEntity
+    {
+        public long Id { get; set; }
+        public string Name { get; set; } = string.Empty;
+    }
+
+    public class SecondaryBucketSequenceDbContext : DbContext
+    {
+        public SecondaryBucketSequenceDbContext(DbContextOptions<SecondaryBucketSequenceDbContext> options)
+            : base(options)
+        {
+        }
+
+        public DbSet<SecondaryBucketSequenceEntity> Entities { get; set; }
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            base.OnModelCreating(modelBuilder);
+
+            modelBuilder.Entity<SecondaryBucketSequenceEntity>(entity =>
+            {
+                entity.HasKey(e => e.Id);
+                entity.Property(e => e.Id).UseSequence("secondary_bucket_seq");
+                // Mapped to the "secondary" bucket while the context is configured for the default.
+                entity.ToCouchbaseCollection("secondary", "isolation", "secondary_bucket_seq_entities");
             });
 
             modelBuilder.ConfigureToCouchbase(this, true);

--- a/tests/Couchbase.EntityFrameworkCore.UnitTests/Couchbase/EntityFrameworkCore/Metadata/KeyspaceMappingTests.cs
+++ b/tests/Couchbase.EntityFrameworkCore.UnitTests/Couchbase/EntityFrameworkCore/Metadata/KeyspaceMappingTests.cs
@@ -253,4 +253,67 @@ public class KeyspaceMappingTests
     }
 
     #endregion
+
+    #region CouchbaseKeyspace.Resolve / ResolveBucket Tests
+
+    [Fact]
+    public void Resolve_WithFullKeyspaceTableName_ReturnsParsedKeyspace_IgnoringConfiguredValues()
+    {
+        var resolved = CouchbaseKeyspace.Resolve("secondary.isolation.MyCollection", "configured-bucket", "configured-scope");
+
+        Assert.Equal("secondary", resolved.Bucket);
+        Assert.Equal("isolation", resolved.Scope);
+        Assert.Equal("MyCollection", resolved.Collection);
+    }
+
+    [Fact]
+    public void Resolve_WithBareTableName_FallsBackToConfiguredBucketAndScope()
+    {
+        var resolved = CouchbaseKeyspace.Resolve("MyCollection", "configured-bucket", "configured-scope");
+
+        Assert.Equal("configured-bucket", resolved.Bucket);
+        Assert.Equal("configured-scope", resolved.Scope);
+        Assert.Equal("MyCollection", resolved.Collection);
+    }
+
+    [Fact]
+    public void Resolve_WithNullOrEmptyTableName_Throws()
+    {
+        // A CouchbaseKeyspace always represents a genuine bucket/scope/collection triple -- there
+        // is no valid keyspace to return for an entity with no table of its own (e.g. an owned
+        // type). Callers with a possibly-null/empty table name that only need the bucket must use
+        // ResolveBucket instead, which has no such requirement.
+        Assert.ThrowsAny<ArgumentException>(() => CouchbaseKeyspace.Resolve(null!, "configured-bucket", "configured-scope"));
+        Assert.ThrowsAny<ArgumentException>(() => CouchbaseKeyspace.Resolve("", "configured-bucket", "configured-scope"));
+    }
+
+    [Fact]
+    public void ResolveBucket_WithFullKeyspaceTableName_ReturnsParsedBucket()
+    {
+        var bucket = CouchbaseKeyspace.ResolveBucket("secondary.isolation.MyCollection", "configured-bucket");
+
+        Assert.Equal("secondary", bucket);
+    }
+
+    [Fact]
+    public void ResolveBucket_WithBareTableName_FallsBackToConfiguredBucket()
+    {
+        var bucket = CouchbaseKeyspace.ResolveBucket("MyCollection", "configured-bucket");
+
+        Assert.Equal("configured-bucket", bucket);
+    }
+
+    [Fact]
+    public void ResolveBucket_WithNullOrEmptyTableName_FallsBackToConfiguredBucket_WithoutThrowing()
+    {
+        // Regression test: an owned type (or, in CouchbaseValueGeneratorSelector, a property whose
+        // DeclaringType isn't an entity type at all) has no table name of its own. ResolveBucket
+        // must gracefully fall back to the configured bucket instead of crashing -- unlike Resolve,
+        // it never constructs a CouchbaseKeyspace, so it has no non-empty-collection requirement to
+        // violate.
+        Assert.Equal("configured-bucket", CouchbaseKeyspace.ResolveBucket(null, "configured-bucket"));
+        Assert.Equal("configured-bucket", CouchbaseKeyspace.ResolveBucket("", "configured-bucket"));
+    }
+
+    #endregion
 }

--- a/tests/Couchbase.EntityFrameworkCore.UnitTests/Couchbase/EntityFrameworkCore/Storage/Internal/CouchbaseDatabaseCreatorTests.cs
+++ b/tests/Couchbase.EntityFrameworkCore.UnitTests/Couchbase/EntityFrameworkCore/Storage/Internal/CouchbaseDatabaseCreatorTests.cs
@@ -1,6 +1,7 @@
 using Couchbase.EntityFrameworkCore.Infrastructure;
 using Couchbase.EntityFrameworkCore.Storage.Internal;
 using Couchbase.EntityFrameworkCore.UnitTests.Fakes;
+using Couchbase.EntityFrameworkCore.ValueGeneration;
 using Couchbase.Extensions.DependencyInjection;
 using Couchbase.KeyValue;
 using Couchbase.Management.Buckets;
@@ -555,6 +556,144 @@ public class CouchbaseDatabaseCreatorTests
         _mockCollectionManager.Verify(
             m => m.CreateCollectionAsync("other-scope", It.IsAny<string>(), It.IsAny<CreateCollectionSettings>(), It.IsAny<CreateCollectionOptions>()),
             Times.Never);
+    }
+
+    #endregion
+
+    #region EnsureCreatedAsync Tests - Sequence Creation
+
+    private static Mock<IProperty> CreateMockSequenceProperty(IEntityType declaringEntityType, string sequenceName)
+    {
+        var mockProperty = new Mock<IProperty>();
+        var sequenceNameAnnotation = new Mock<IAnnotation>();
+        sequenceNameAnnotation.Setup(a => a.Value).Returns(sequenceName);
+        mockProperty.Setup(p => p.FindAnnotation(CouchbaseValueGeneratorSelector.SequenceNameAnnotation))
+            .Returns(sequenceNameAnnotation.Object);
+        mockProperty.Setup(p => p.DeclaringType).Returns(declaringEntityType);
+        mockProperty.Setup(p => p.Name).Returns("Id");
+        return mockProperty;
+    }
+
+    [Fact]
+    public async Task EnsureCreatedAsync_WithSequenceOnEntityMappedToDifferentBucket_CreatesSequenceInEntityMappedBucket()
+    {
+        // Arrange - the entity lives in "secondary-bucket", not the context's configured bucket
+        // ("my-bucket"). The sequence backing one of its properties must be created in
+        // "secondary-bucket" too, not the configured bucket -- this is the cross-bucket sequences
+        // fix (previously CreateSequencesAsync always used the configured bucket).
+        _mockOptions.Setup(o => o.Bucket).Returns("my-bucket");
+        _mockOptions.Setup(o => o.Scope).Returns("my-scope");
+
+        _mockBucketManager.Setup(m => m.GetBucketAsync("my-bucket", It.IsAny<GetBucketOptions>()))
+            .ReturnsAsync(new BucketSettings { Name = "my-bucket" });
+        _mockCluster.Setup(c => c.BucketAsync("my-bucket")).ReturnsAsync(_mockBucket.Object);
+        _mockCollectionManager.Setup(m => m.GetAllScopesAsync(It.IsAny<GetAllScopesOptions>()))
+            .ReturnsAsync(new List<ScopeSpec> { new ScopeSpec("my-scope") });
+
+        // Secondary bucket with its own collection manager + scope, mirroring
+        // EnsureCreatedAsync_SecondaryBucketDifferentScope_DoesNotCreateConfiguredScopeThere's setup.
+        var mockSecondaryBucket = new Mock<IBucket>();
+        var mockSecondaryCollectionManager = new Mock<ICouchbaseCollectionManager>();
+        var mockSecondaryScope = new Mock<IScope>();
+        mockSecondaryBucket.Setup(b => b.Collections).Returns(mockSecondaryCollectionManager.Object);
+        mockSecondaryBucket.Setup(b => b.ScopeAsync("my-scope")).ReturnsAsync(mockSecondaryScope.Object);
+        mockSecondaryCollectionManager.Setup(m => m.GetAllScopesAsync(It.IsAny<GetAllScopesOptions>()))
+            .ReturnsAsync(new List<ScopeSpec> { new ScopeSpec("my-scope") });
+        mockSecondaryScope.Setup(s => s.QueryAsync<dynamic>(It.IsAny<string>(), It.IsAny<QueryOptions>()))
+            .ReturnsAsync(CreateFakeQueryResult(new List<dynamic>()));
+        _mockCluster.Setup(c => c.BucketAsync("secondary-bucket")).ReturnsAsync(mockSecondaryBucket.Object);
+
+        var mockEntityType = new Mock<IEntityType>();
+        var mockTableNameAnnotation = new Mock<IAnnotation>();
+        mockTableNameAnnotation.Setup(a => a.Value).Returns("secondary-bucket.my-scope.MyCollection");
+        mockEntityType.Setup(e => e.FindAnnotation("Relational:TableName")).Returns(mockTableNameAnnotation.Object);
+        mockEntityType.Setup(e => e.ClrType).Returns(typeof(TestEntity));
+
+        var mockSequenceProperty = CreateMockSequenceProperty(mockEntityType.Object, "order_seq");
+        mockEntityType.Setup(e => e.GetProperties()).Returns(new[] { mockSequenceProperty.Object });
+        _mockModel.Setup(m => m.GetEntityTypes()).Returns(new[] { mockEntityType.Object });
+
+        var creator = CreateCreator();
+
+        // Act
+        await creator.EnsureCreatedAsync();
+
+        // Assert - the sequence is created in the entity's actual bucket...
+        mockSecondaryScope.Verify(
+            s => s.QueryAsync<dynamic>(
+                It.Is<string>(sql => sql.StartsWith("CREATE SEQUENCE IF NOT EXISTS")
+                                      && sql.Contains("`secondary-bucket`") && sql.Contains("`my-scope`")
+                                      && sql.Contains("`order_seq`")),
+                It.IsAny<QueryOptions>()),
+            Times.Once);
+
+        // ...and not in the configured bucket.
+        _mockScope.Verify(
+            s => s.QueryAsync<dynamic>(It.Is<string>(sql => sql.StartsWith("CREATE SEQUENCE")), It.IsAny<QueryOptions>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task EnsureCreatedAsync_SameSequenceNameAndScopeInDifferentBuckets_CreatesBothNotAConflict()
+    {
+        // Arrange - two entities in DIFFERENT buckets happen to use the same sequence name in the
+        // same (default) scope. A sequence's true identity is bucket.scope.name, so this must
+        // create two distinct sequences, not be treated as a name conflict.
+        _mockOptions.Setup(o => o.Bucket).Returns("my-bucket");
+        _mockOptions.Setup(o => o.Scope).Returns("my-scope");
+
+        _mockBucketManager.Setup(m => m.GetBucketAsync("my-bucket", It.IsAny<GetBucketOptions>()))
+            .ReturnsAsync(new BucketSettings { Name = "my-bucket" });
+        _mockCluster.Setup(c => c.BucketAsync("my-bucket")).ReturnsAsync(_mockBucket.Object);
+        _mockCollectionManager.Setup(m => m.GetAllScopesAsync(It.IsAny<GetAllScopesOptions>()))
+            .ReturnsAsync(new List<ScopeSpec> { new ScopeSpec("my-scope") });
+
+        var mockSecondaryBucket = new Mock<IBucket>();
+        var mockSecondaryCollectionManager = new Mock<ICouchbaseCollectionManager>();
+        var mockSecondaryScope = new Mock<IScope>();
+        mockSecondaryBucket.Setup(b => b.Collections).Returns(mockSecondaryCollectionManager.Object);
+        mockSecondaryBucket.Setup(b => b.ScopeAsync("my-scope")).ReturnsAsync(mockSecondaryScope.Object);
+        mockSecondaryCollectionManager.Setup(m => m.GetAllScopesAsync(It.IsAny<GetAllScopesOptions>()))
+            .ReturnsAsync(new List<ScopeSpec> { new ScopeSpec("my-scope") });
+        mockSecondaryScope.Setup(s => s.QueryAsync<dynamic>(It.IsAny<string>(), It.IsAny<QueryOptions>()))
+            .ReturnsAsync(CreateFakeQueryResult(new List<dynamic>()));
+        _mockCluster.Setup(c => c.BucketAsync("secondary-bucket")).ReturnsAsync(mockSecondaryBucket.Object);
+
+        var mockEntityTypeA = new Mock<IEntityType>();
+        var mockTableNameAnnotationA = new Mock<IAnnotation>();
+        mockTableNameAnnotationA.Setup(a => a.Value).Returns("CollectionA");
+        mockEntityTypeA.Setup(e => e.FindAnnotation("Relational:TableName")).Returns(mockTableNameAnnotationA.Object);
+        mockEntityTypeA.Setup(e => e.ClrType).Returns(typeof(TestEntity));
+        var mockSequencePropertyA = CreateMockSequenceProperty(mockEntityTypeA.Object, "shared_seq");
+        mockEntityTypeA.Setup(e => e.GetProperties()).Returns(new[] { mockSequencePropertyA.Object });
+
+        var mockEntityTypeB = new Mock<IEntityType>();
+        var mockTableNameAnnotationB = new Mock<IAnnotation>();
+        mockTableNameAnnotationB.Setup(a => a.Value).Returns("secondary-bucket.my-scope.CollectionB");
+        mockEntityTypeB.Setup(e => e.FindAnnotation("Relational:TableName")).Returns(mockTableNameAnnotationB.Object);
+        mockEntityTypeB.Setup(e => e.ClrType).Returns(typeof(TestDerivedEntity));
+        var mockSequencePropertyB = CreateMockSequenceProperty(mockEntityTypeB.Object, "shared_seq");
+        mockEntityTypeB.Setup(e => e.GetProperties()).Returns(new[] { mockSequencePropertyB.Object });
+
+        _mockModel.Setup(m => m.GetEntityTypes()).Returns(new[] { mockEntityTypeA.Object, mockEntityTypeB.Object });
+
+        var creator = CreateCreator();
+
+        // Act & Assert - no InvalidOperationException for a "conflict" that isn't one
+        await creator.EnsureCreatedAsync();
+
+        _mockScope.Verify(
+            s => s.QueryAsync<dynamic>(
+                It.Is<string>(sql => sql.StartsWith("CREATE SEQUENCE IF NOT EXISTS")
+                                      && sql.Contains("`my-bucket`") && sql.Contains("`shared_seq`")),
+                It.IsAny<QueryOptions>()),
+            Times.Once);
+        mockSecondaryScope.Verify(
+            s => s.QueryAsync<dynamic>(
+                It.Is<string>(sql => sql.StartsWith("CREATE SEQUENCE IF NOT EXISTS")
+                                      && sql.Contains("`secondary-bucket`") && sql.Contains("`shared_seq`")),
+                It.IsAny<QueryOptions>()),
+            Times.Once);
     }
 
     #endregion

--- a/tests/Couchbase.EntityFrameworkCore.UnitTests/Couchbase/EntityFrameworkCore/ValueGeneration/CouchbaseValueGeneratorSelectorTests.cs
+++ b/tests/Couchbase.EntityFrameworkCore.UnitTests/Couchbase/EntityFrameworkCore/ValueGeneration/CouchbaseValueGeneratorSelectorTests.cs
@@ -1,8 +1,10 @@
+using Couchbase.EntityFrameworkCore.Extensions;
 using Couchbase.EntityFrameworkCore.Infrastructure;
 using Couchbase.EntityFrameworkCore.ValueGeneration;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Storage;
 using Microsoft.EntityFrameworkCore.ValueGeneration;
 using Moq;
 using Xunit;
@@ -203,6 +205,65 @@ public class CouchbaseValueGeneratorSelectorTests
         // Act & Assert
         var exception = Assert.Throws<InvalidOperationException>(() => _selector.TrySelect(property, typeBase, out _));
         Assert.Contains("not supported", exception.Message);
+    }
+
+    #endregion
+
+    #region Cross-bucket Sequence Resolution Tests
+
+    [Fact]
+    public void Select_SequenceOnEntityMappedToDifferentBucket_ResolvesEntityMappedBucketNotConfiguredBucket()
+    {
+        // Arrange - LongEntity is mapped explicitly to a bucket other than the context's
+        // configured one ("test-bucket", from the constructor's _mockOptionsBuilder setup). The
+        // generated NEXT VALUE FOR query must target the entity's actual bucket, not the
+        // configured one -- this is the fix for the cross-bucket sequences gap.
+        var modelBuilder = new ModelBuilder();
+        modelBuilder.Entity<LongEntity>(b =>
+        {
+            b.ToCouchbaseCollection("secondary-bucket", "myscope", "mycollection");
+            b.Property(e => e.Id).HasAnnotation(CouchbaseValueGeneratorSelector.SequenceNameAnnotation, "order_seq");
+        });
+
+        var model = modelBuilder.FinalizeModel();
+        var entityType = model.FindEntityType(typeof(LongEntity))!;
+        var property = entityType.FindProperty(nameof(LongEntity.Id))!;
+
+        // Act
+        Assert.True(_selector.TrySelect(property, entityType, out var generator));
+        var sequenceGenerator = Assert.IsType<CouchbaseSequenceValueGenerator<long>>(generator);
+        var sql = sequenceGenerator.BuildSequenceQuery(CreateSqlGenerationHelper());
+
+        // Assert
+        Assert.Contains("`secondary-bucket`", sql);
+        Assert.DoesNotContain("`test-bucket`", sql);
+    }
+
+    [Fact]
+    public void Select_SequenceOnEntityWithNoExplicitBucketMapping_UsesConfiguredBucket()
+    {
+        // Arrange - regression guard for the common case: an entity with no explicit
+        // ToCouchbaseCollection/[CouchbaseKeyspace] bucket override must still resolve to the
+        // context's configured bucket.
+        var (property, typeBase) = CreatePropertyWithAnnotation<LongEntity>(
+            nameof(LongEntity.Id),
+            CouchbaseValueGeneratorSelector.SequenceNameAnnotation,
+            "order_seq");
+
+        // Act
+        Assert.True(_selector.TrySelect(property, typeBase, out var generator));
+        var sequenceGenerator = Assert.IsType<CouchbaseSequenceValueGenerator<long>>(generator);
+        var sql = sequenceGenerator.BuildSequenceQuery(CreateSqlGenerationHelper());
+
+        // Assert
+        Assert.Contains("`test-bucket`", sql);
+    }
+
+    private static ISqlGenerationHelper CreateSqlGenerationHelper()
+    {
+        var mock = new Mock<ISqlGenerationHelper>();
+        mock.Setup(h => h.DelimitIdentifier(It.IsAny<string>())).Returns<string>(s => $"`{s}`");
+        return mock.Object;
     }
 
     #endregion


### PR DESCRIPTION
… the entity's actual bucket

CreateSequencesAsync/DropSequencesAsync and CouchbaseValueGeneratorSelector's runtime NEXT VALUE FOR generator always used the context's configured bucket, even when the sequence-owning entity was mapped to a different bucket via ToCouchbaseCollection/[CouchbaseKeyspace]. Added a shared CouchbaseKeyspace.Resolve helper (mirroring how collections/indexes already resolve per-entity) so sequence creation and runtime generation both follow the entity's actual bucket. Sequences are now keyed by (bucket, scope, name) so the same name/scope in different buckets is treated as distinct rather than a conflict.