### PR TITLE
Add TimeProvider support to CouchbaseDatabaseCreator for testable dea…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -195,6 +195,19 @@ and this project aims to follow [Semantic Versioning](https://semver.org/spec/v2
   `AutoCreateIndexes` under concurrent load; fixed by including all of these in both methods, and
   `SerializerOptions` via reference equality.
 
+### Changed
+
+- **`CouchbaseDatabaseCreator`'s retry/online-wait deadlines and delays now run on an injectable
+  `TimeProvider`** instead of raw `DateTime.UtcNow`/`Task.Delay`. Purely an internal testability
+  improvement — behavior is unchanged (defaults to `TimeProvider.System` when nothing is injected,
+  which nothing needs to register explicitly: an unregistered `TimeProvider` falls back to the
+  constructor's optional-parameter default via the standard DI resolution rules). Lets the 60-second
+  primary/secondary index online-wait deadlines and the 10-attempt DDL/bucket-retrieval retry delays
+  be exercised deterministically in unit tests (via `Microsoft.Extensions.TimeProvider.Testing`'s
+  `FakeTimeProvider`, advancing simulated time instead of waiting in real time) — closing a
+  previously undocumented gap where the timeout-wrapping fixes from the `AutoCreateIndexes` work had
+  no automated regression coverage at all.
+
 ## [2.0.0-beta.2] - 2026-07-15
 
 ### Added

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -29,6 +29,7 @@
     <PackageVersion Include="Microsoft.EntityFrameworkCore.Specification.Tests" Version="10.0.5" />
     <PackageVersion Include="Microsoft.Extensions.Logging.Console" Version="10.0.8" />
     <PackageVersion Include="Microsoft.Extensions.Logging.Debug" Version="10.0.5" />
+    <PackageVersion Include="Microsoft.Extensions.TimeProvider.Testing" Version="10.2.0" />
     <PackageVersion Include="Serilog.Extensions.Logging.File" Version="3.0.0" />
     <PackageVersion Include="xunit.assert" Version="2.9.3" />
     <PackageVersion Include="xunit.core" Version="2.9.3" />

--- a/src/Couchbase.EntityFrameworkCore/Storage/Internal/CouchbaseDatabaseCreator.cs
+++ b/src/Couchbase.EntityFrameworkCore/Storage/Internal/CouchbaseDatabaseCreator.cs
@@ -23,17 +23,26 @@ public class CouchbaseDatabaseCreator :  RelationalDatabaseCreator
     private readonly IServiceProvider _serviceProvider;
     private readonly ICouchbaseDbContextOptionsBuilder _couchbaseDbContextOptionsBuilder;
     private readonly ISqlGenerationHelper _sqlGenerationHelper;
+    private readonly TimeProvider _timeProvider;
     // Lazily initialized by InitializeAsync before any use; null-forgiving avoids cascading
     // nullable warnings at the (guaranteed-initialized) deref sites.
     private ICluster _cluster = null!;
 
+    /// <param name="timeProvider">
+    /// Source of time for the retry/online-wait deadlines and delays below. Optional and defaults
+    /// to <see cref="TimeProvider.System"/> — nothing needs to register <see cref="TimeProvider"/>
+    /// in DI for normal use; tests can pass a <c>FakeTimeProvider</c> (from
+    /// <c>Microsoft.Extensions.TimeProvider.Testing</c>) directly to make the 60s/1s/500ms
+    /// constants advance deterministically instead of requiring a real wait.
+    /// </param>
     public CouchbaseDatabaseCreator(RelationalDatabaseCreatorDependencies dependencies,
         IDatabase database,
         IServiceProvider serviceProvider,
         IDesignTimeModel designTimeModel,
         ILogger<CouchbaseDatabaseCreator> logger,
         ICouchbaseDbContextOptionsBuilder couchbaseDbContextOptionsBuilder,
-        ISqlGenerationHelper sqlGenerationHelper) : base(dependencies)
+        ISqlGenerationHelper sqlGenerationHelper,
+        TimeProvider? timeProvider = null) : base(dependencies)
     {
         _database = database;
         _designTimeModel = designTimeModel;
@@ -41,6 +50,7 @@ public class CouchbaseDatabaseCreator :  RelationalDatabaseCreator
         _serviceProvider = serviceProvider;
         _couchbaseDbContextOptionsBuilder = couchbaseDbContextOptionsBuilder;
         _sqlGenerationHelper = sqlGenerationHelper;
+        _timeProvider = timeProvider ?? TimeProvider.System;
     }
 
     private async Task InitializeAsync(CancellationToken cancellationToken = default)
@@ -60,7 +70,7 @@ public class CouchbaseDatabaseCreator :  RelationalDatabaseCreator
     private async Task<IBucket> GetBucketAsync(string bucketName, CancellationToken cancellationToken = default)
     {
         const int maxRetries = 10;
-        const int delayMs = 500;
+        var delay = TimeSpan.FromMilliseconds(500);
 
         for (var attempt = 1; attempt <= maxRetries; attempt++)
         {
@@ -82,7 +92,7 @@ public class CouchbaseDatabaseCreator :  RelationalDatabaseCreator
                 _logger.LogWarning(e, "Couchbase bucket '{BucketName}' could not be retrieved (attempt {Attempt}/{MaxRetries}). Retrying...",
                     bucketName, attempt, maxRetries);
 
-                await Task.Delay(delayMs, cancellationToken);
+                await Task.Delay(delay, _timeProvider, cancellationToken);
             }
         }
 
@@ -603,7 +613,7 @@ public class CouchbaseDatabaseCreator :  RelationalDatabaseCreator
                 _logger.LogDebug(ex,
                     "DDL execution for {Keyspace} failed (attempt {Attempt}/{MaxAttempts}); retrying...",
                     keyspace.ToSqlString(), attempt, maxAttempts);
-                await Task.Delay(TimeSpan.FromSeconds(1), cancellationToken);
+                await Task.Delay(TimeSpan.FromSeconds(1), _timeProvider, cancellationToken);
             }
         }
     }
@@ -612,7 +622,7 @@ public class CouchbaseDatabaseCreator :  RelationalDatabaseCreator
     {
         // Per-keyspace deadline: a shared deadline would let time spent waiting on earlier
         // keyspaces eat into the budget for later ones, causing spurious timeouts.
-        var onlineDeadline = DateTime.UtcNow + TimeSpan.FromSeconds(60);
+        var onlineDeadline = _timeProvider.GetUtcNow() + TimeSpan.FromSeconds(60);
         Exception? lastError = null;
 
         while (true)
@@ -652,19 +662,19 @@ public class CouchbaseDatabaseCreator :  RelationalDatabaseCreator
                 return;
             }
 
-            if (DateTime.UtcNow > onlineDeadline)
+            if (_timeProvider.GetUtcNow() > onlineDeadline)
             {
                 throw new TimeoutException(
                     $"Primary index for {keyspace.ToSqlString()} did not come online within 60 seconds.", lastError);
             }
 
-            await Task.Delay(TimeSpan.FromSeconds(1), cancellationToken);
+            await Task.Delay(TimeSpan.FromSeconds(1), _timeProvider, cancellationToken);
         }
     }
 
     private async Task WaitForSecondaryIndexOnlineAsync(CouchbaseKeyspace keyspace, string indexName, CancellationToken cancellationToken)
     {
-        var onlineDeadline = DateTime.UtcNow + TimeSpan.FromSeconds(60);
+        var onlineDeadline = _timeProvider.GetUtcNow() + TimeSpan.FromSeconds(60);
         Exception? lastError = null;
 
         while (true)
@@ -706,14 +716,14 @@ public class CouchbaseDatabaseCreator :  RelationalDatabaseCreator
                 return;
             }
 
-            if (DateTime.UtcNow > onlineDeadline)
+            if (_timeProvider.GetUtcNow() > onlineDeadline)
             {
                 throw new TimeoutException(
                     $"Secondary index '{indexName}' for {keyspace.ToSqlString()} did not come online within 60 seconds.",
                     lastError);
             }
 
-            await Task.Delay(TimeSpan.FromSeconds(1), cancellationToken);
+            await Task.Delay(TimeSpan.FromSeconds(1), _timeProvider, cancellationToken);
         }
     }
 

--- a/tests/Couchbase.EntityFrameworkCore.UnitTests/Couchbase.EntityFrameworkCore.UnitTests.csproj
+++ b/tests/Couchbase.EntityFrameworkCore.UnitTests/Couchbase.EntityFrameworkCore.UnitTests.csproj
@@ -12,6 +12,7 @@
 
     <ItemGroup>
         <PackageReference Include="coverlet.collector" PrivateAssets="all" />
+        <PackageReference Include="Microsoft.Extensions.TimeProvider.Testing" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" />
         <PackageReference Include="Moq" />
         <PackageReference Include="xunit" />

--- a/tests/Couchbase.EntityFrameworkCore.UnitTests/Couchbase/EntityFrameworkCore/Storage/Internal/CouchbaseDatabaseCreatorTests.cs
+++ b/tests/Couchbase.EntityFrameworkCore.UnitTests/Couchbase/EntityFrameworkCore/Storage/Internal/CouchbaseDatabaseCreatorTests.cs
@@ -14,6 +14,7 @@ using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Time.Testing;
 using Moq;
 using Xunit;
 
@@ -78,7 +79,7 @@ public class CouchbaseDatabaseCreatorTests
             .Returns<string>(s => $"`{s}`");
     }
 
-    private CouchbaseDatabaseCreator CreateCreator()
+    private CouchbaseDatabaseCreator CreateCreator(TimeProvider? timeProvider = null)
     {
         // Create minimal dependencies - we'll use reflection or make methods testable
         var dependencies = CreateMockDependencies();
@@ -89,7 +90,8 @@ public class CouchbaseDatabaseCreatorTests
             _mockDesignTimeModel.Object,
             _mockLogger.Object,
             _mockOptions.Object,
-            _mockSqlGenerationHelper.Object);
+            _mockSqlGenerationHelper.Object,
+            timeProvider);
     }
 
     private static IQueryResult<T> CreateFakeQueryResult<T>(List<T> rows)
@@ -1306,6 +1308,164 @@ public class CouchbaseDatabaseCreatorTests
                 It.Is<string>(sql => sql.StartsWith("CREATE INDEX `ix_shared_score` IF NOT EXISTS")),
                 It.IsAny<QueryOptions>()),
             Times.Once);
+    }
+
+    #endregion
+
+    #region EnsureCreatedAsync Tests - TimeProvider-driven Deadlines and Retries
+
+    /// <summary>
+    /// Repeatedly advances <paramref name="fakeTime"/> by <paramref name="step"/>, yielding after
+    /// each advance so any woken continuation gets a chance to run, until <paramref name="task"/>
+    /// completes. Lets a test exercise a 60-second deadline or a multi-attempt retry-with-delay
+    /// loop without an equivalent real-time wait -- <see cref="FakeTimeProvider.Advance"/> only
+    /// wakes timers that are due relative to whatever the simulated clock already is at the moment
+    /// it's called, so a single large jump can't skip over a chain of sequential delays; each one
+    /// needs its own advance.
+    /// </summary>
+    private static async Task AdvanceUntilCompleteAsync(FakeTimeProvider fakeTime, Task task, TimeSpan step, int maxIterations = 500)
+    {
+        for (var i = 0; i < maxIterations && !task.IsCompleted; i++)
+        {
+            fakeTime.Advance(step);
+            await Task.Yield();
+        }
+    }
+
+    [Fact]
+    public async Task EnsureCreatedAsync_WithAutoCreateIndexesEnabled_PrimaryIndexNeverComesOnline_ThrowsTimeoutExceptionWithoutRealWait()
+    {
+        // Arrange
+        _mockOptions.Setup(o => o.Bucket).Returns("my-bucket");
+        _mockOptions.Setup(o => o.Scope).Returns("my-scope");
+        _mockOptions.Setup(o => o.AutoCreateIndexes).Returns(true);
+
+        _mockBucketManager.Setup(m => m.GetBucketAsync("my-bucket", It.IsAny<GetBucketOptions>()))
+            .ReturnsAsync(new BucketSettings { Name = "my-bucket" });
+        _mockCluster.Setup(c => c.BucketAsync("my-bucket")).ReturnsAsync(_mockBucket.Object);
+        _mockCollectionManager.Setup(m => m.GetAllScopesAsync(It.IsAny<GetAllScopesOptions>()))
+            .ReturnsAsync(new List<ScopeSpec> { new ScopeSpec("my-scope") });
+
+        // Override the constructor's default (always online) so the primary index never reports online.
+        _mockCluster.Setup(c => c.QueryAsync<int>(It.IsAny<string>(), It.IsAny<QueryOptions>()))
+            .ReturnsAsync(CreateFakeQueryResult(new List<int> { 0 }));
+
+        var mockEntityType = new Mock<IEntityType>();
+        var mockTableNameAnnotation = new Mock<IAnnotation>();
+        mockTableNameAnnotation.Setup(a => a.Value).Returns("TestCollection");
+        mockEntityType.Setup(e => e.FindAnnotation("Relational:TableName")).Returns(mockTableNameAnnotation.Object);
+        mockEntityType.Setup(e => e.ClrType).Returns(typeof(TestEntity));
+        mockEntityType.Setup(e => e.GetProperties()).Returns(Array.Empty<IProperty>());
+        _mockModel.Setup(m => m.GetEntityTypes()).Returns(new[] { mockEntityType.Object });
+
+        var fakeTime = new FakeTimeProvider();
+        var creator = CreateCreator(fakeTime);
+
+        // Act - advancing the simulated clock past the 60-second deadline, not waiting for real
+        // wall-clock time to pass.
+        var task = creator.EnsureCreatedAsync();
+        await AdvanceUntilCompleteAsync(fakeTime, task, TimeSpan.FromSeconds(5));
+
+        // Assert
+        var ex = await Assert.ThrowsAsync<TimeoutException>(() => task);
+        Assert.Contains("Primary index", ex.Message);
+        Assert.Contains("did not come online within 60 seconds", ex.Message);
+    }
+
+    [Fact]
+    public async Task EnsureCreatedAsync_WithAutoCreateIndexesEnabled_SecondaryIndexNeverComesOnline_ThrowsTimeoutExceptionWithoutRealWait()
+    {
+        // Arrange
+        _mockOptions.Setup(o => o.Bucket).Returns("my-bucket");
+        _mockOptions.Setup(o => o.Scope).Returns("my-scope");
+        _mockOptions.Setup(o => o.AutoCreateIndexes).Returns(true);
+
+        _mockBucketManager.Setup(m => m.GetBucketAsync("my-bucket", It.IsAny<GetBucketOptions>()))
+            .ReturnsAsync(new BucketSettings { Name = "my-bucket" });
+        _mockCluster.Setup(c => c.BucketAsync("my-bucket")).ReturnsAsync(_mockBucket.Object);
+        _mockCollectionManager.Setup(m => m.GetAllScopesAsync(It.IsAny<GetAllScopesOptions>()))
+            .ReturnsAsync(new List<ScopeSpec> { new ScopeSpec("my-scope") });
+
+        // Primary index: online immediately (the constructor's default -- any QueryAsync<int> call
+        // returns count=1 -- covers both the online-check and ConfirmQueryableAsync's trial query).
+        // Secondary index: never reports online -- overridden specifically for its name-scoped query
+        // shape, which is more specific than the constructor's blanket setup and so takes precedence
+        // for matching calls.
+        _mockCluster.Setup(c => c.QueryAsync<int>(
+                It.Is<string>(sql => sql.Contains("AND name = $name")), It.IsAny<QueryOptions>()))
+            .ReturnsAsync(CreateFakeQueryResult(new List<int> { 0 }));
+
+        var mockEntityType = new Mock<IEntityType>();
+        var mockTableNameAnnotation = new Mock<IAnnotation>();
+        mockTableNameAnnotation.Setup(a => a.Value).Returns("TestCollection");
+        mockEntityType.Setup(e => e.FindAnnotation("Relational:TableName")).Returns(mockTableNameAnnotation.Object);
+        mockEntityType.Setup(e => e.ClrType).Returns(typeof(TestEntity));
+        mockEntityType.Setup(e => e.GetProperties()).Returns(Array.Empty<IProperty>());
+
+        var mockScoreProperty = CreateMockProperty("Score", mockEntityType.Object);
+        var mockIndex = CreateMockIndex(mockEntityType.Object, new[] { mockScoreProperty.Object }, "ix_score");
+        mockEntityType.Setup(e => e.GetIndexes()).Returns(new[] { mockIndex.Object });
+
+        _mockModel.Setup(m => m.GetEntityTypes()).Returns(new[] { mockEntityType.Object });
+
+        var fakeTime = new FakeTimeProvider();
+        var creator = CreateCreator(fakeTime);
+
+        // Act
+        var task = creator.EnsureCreatedAsync();
+        await AdvanceUntilCompleteAsync(fakeTime, task, TimeSpan.FromSeconds(5));
+
+        // Assert
+        var ex = await Assert.ThrowsAsync<TimeoutException>(() => task);
+        Assert.Contains("Secondary index", ex.Message);
+        Assert.Contains("did not come online within 60 seconds", ex.Message);
+    }
+
+    [Fact]
+    public async Task EnsureCreatedAsync_WithAutoCreateIndexesEnabled_TransientDdlFailures_RetriesUsingSimulatedTimeAndSucceeds()
+    {
+        // Arrange
+        _mockOptions.Setup(o => o.Bucket).Returns("my-bucket");
+        _mockOptions.Setup(o => o.Scope).Returns("my-scope");
+        _mockOptions.Setup(o => o.AutoCreateIndexes).Returns(true);
+
+        _mockBucketManager.Setup(m => m.GetBucketAsync("my-bucket", It.IsAny<GetBucketOptions>()))
+            .ReturnsAsync(new BucketSettings { Name = "my-bucket" });
+        _mockCluster.Setup(c => c.BucketAsync("my-bucket")).ReturnsAsync(_mockBucket.Object);
+        _mockCollectionManager.Setup(m => m.GetAllScopesAsync(It.IsAny<GetAllScopesOptions>()))
+            .ReturnsAsync(new List<ScopeSpec> { new ScopeSpec("my-scope") });
+
+        // The CREATE PRIMARY INDEX statement (issued via ExecuteDdlWithRetryAsync) fails
+        // transiently on the first two attempts before succeeding on the third.
+        var attempt = 0;
+        _mockScope.Setup(s => s.QueryAsync<dynamic>(It.IsAny<string>(), It.IsAny<QueryOptions>()))
+            .Returns(() =>
+            {
+                attempt++;
+                return attempt <= 2
+                    ? Task.FromException<IQueryResult<dynamic>>(new Exception($"transient failure {attempt}"))
+                    : Task.FromResult<IQueryResult<dynamic>>(CreateFakeQueryResult(new List<dynamic>()));
+            });
+
+        var mockEntityType = new Mock<IEntityType>();
+        var mockTableNameAnnotation = new Mock<IAnnotation>();
+        mockTableNameAnnotation.Setup(a => a.Value).Returns("TestCollection");
+        mockEntityType.Setup(e => e.FindAnnotation("Relational:TableName")).Returns(mockTableNameAnnotation.Object);
+        mockEntityType.Setup(e => e.ClrType).Returns(typeof(TestEntity));
+        mockEntityType.Setup(e => e.GetProperties()).Returns(Array.Empty<IProperty>());
+        _mockModel.Setup(m => m.GetEntityTypes()).Returns(new[] { mockEntityType.Object });
+
+        var fakeTime = new FakeTimeProvider();
+        var creator = CreateCreator(fakeTime);
+
+        // Act - each of the two 1-second retry delays is advanced past using simulated time.
+        var task = creator.EnsureCreatedAsync();
+        await AdvanceUntilCompleteAsync(fakeTime, task, TimeSpan.FromSeconds(1));
+
+        // Assert - succeeds once the transient failures stop, having actually reached the 3rd
+        // attempt (proving the retry loop, not just a lucky first success).
+        await task;
+        Assert.Equal(3, attempt);
     }
 
     #endregion

--- a/tests/Couchbase.EntityFrameworkCore.UnitTests/Couchbase/EntityFrameworkCore/Storage/Internal/CouchbaseDatabaseCreatorTests.cs
+++ b/tests/Couchbase.EntityFrameworkCore.UnitTests/Couchbase/EntityFrameworkCore/Storage/Internal/CouchbaseDatabaseCreatorTests.cs
@@ -1315,21 +1315,41 @@ public class CouchbaseDatabaseCreatorTests
     #region EnsureCreatedAsync Tests - TimeProvider-driven Deadlines and Retries
 
     /// <summary>
-    /// Repeatedly advances <paramref name="fakeTime"/> by <paramref name="step"/>, yielding after
-    /// each advance so any woken continuation gets a chance to run, until <paramref name="task"/>
-    /// completes. Lets a test exercise a 60-second deadline or a multi-attempt retry-with-delay
-    /// loop without an equivalent real-time wait -- <see cref="FakeTimeProvider.Advance"/> only
-    /// wakes timers that are due relative to whatever the simulated clock already is at the moment
-    /// it's called, so a single large jump can't skip over a chain of sequential delays; each one
-    /// needs its own advance.
+    /// Repeatedly advances <paramref name="fakeTime"/> by <paramref name="step"/>, pausing briefly
+    /// after each advance so any woken continuation gets a chance to run, until
+    /// <paramref name="task"/> completes. Lets a test exercise a 60-second deadline or a
+    /// multi-attempt retry-with-delay loop without an equivalent real-time wait --
+    /// <see cref="FakeTimeProvider.Advance"/> only wakes timers that are due relative to whatever
+    /// the simulated clock already is at the moment it's called, so a single large jump can't skip
+    /// over a chain of sequential delays; each one needs its own advance.
     /// </summary>
+    /// <remarks>
+    /// The pause between advances is a genuine (if tiny) real-time <c>Task.Delay(1)</c>, not
+    /// <c>Task.Yield()</c> -- empirically, <c>Task.Yield()</c> was not reliably enough for the code
+    /// under test's next <c>Task.Delay(_, fakeTime, _)</c> continuation to actually resume and
+    /// register its own timer before this loop's next <see cref="FakeTimeProvider.Advance"/> call,
+    /// which could otherwise land before that timer existed and be missed entirely (surfaced as
+    /// this method's own fail-fast assertion below, not a silent hang, since it was added
+    /// specifically to catch this class of timing gap). A 1ms real delay costs nothing observable
+    /// against the seconds/minutes of real waiting this helper exists to avoid.
+    /// </remarks>
     private static async Task AdvanceUntilCompleteAsync(FakeTimeProvider fakeTime, Task task, TimeSpan step, int maxIterations = 500)
     {
         for (var i = 0; i < maxIterations && !task.IsCompleted; i++)
         {
             fakeTime.Advance(step);
-            await Task.Yield();
+            await Task.Delay(1);
         }
+
+        // Fail fast here instead of letting the caller's next `await task`/`Assert.ThrowsAsync`
+        // hang indefinitely: if the code under test stopped scheduling FakeTimeProvider timers (a
+        // bug, or `step`/`maxIterations` too small for how it actually waits), the task never
+        // completes no matter how long a real wait ran -- so a hang here means "genuinely broken",
+        // not "just needs more real time," and should be reported as a normal assertion failure.
+        Assert.True(task.IsCompleted,
+            $"Task did not complete after advancing the fake clock by {step} x {maxIterations} " +
+            "iterations. The code under test may have stopped scheduling timers, or maxIterations/" +
+            "step is too small for how long it actually waits.");
     }
 
     [Fact]


### PR DESCRIPTION
…dlines/retries

CouchbaseDatabaseCreator now accepts an optional TimeProvider (defaulting to TimeProvider.System) instead of using raw DateTime.UtcNow/Task.Delay directly, so the 60-second index online-wait deadlines and the DDL/bucket-retrieval retry delays can be driven deterministically in tests via FakeTimeProvider rather than requiring a real wait. Adds Microsoft.Extensions.TimeProvider.Testing and three new unit tests covering the previously-uncovered timeout and retry-then-succeed paths.