### PR TITLE
Add EF.Functions.IsMissing/IsNotMissing/IsValued/IsNotValued support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ and this project aims to follow [Semantic Versioning](https://semver.org/spec/v2
 
 ### Added
 
+- **`EF.Functions.IsMissing`/`IsNotMissing`/`IsValued`/`IsNotValued`.** Exposes N1QL's postfix
+  `IS [NOT] MISSING`/`IS [NOT] VALUED` operators, letting a query distinguish a field that's
+  genuinely *missing* (absent from the JSON entirely) from one that's present with an explicit
+  JSON `null` — a distinction ordinary `== null`/`??` cannot make, since both already treat missing
+  and JSON-null the same way. New generic `CouchbaseDbFunctionsExtensions` marker methods (mirroring
+  EF Core's own `Greatest<T>`/`Least<T>` pattern) translated by a new
+  `CouchbaseMissingValuedMethodTranslator`, rendered via a marker `SqlFunctionExpression` that
+  `CouchbaseQuerySqlGenerator` rewrites to postfix syntax — there's no valid "function-call"
+  rendering for these, since N1QL's IS MISSING family is a postfix operator on an operand, not a
+  callable function. See [Supported functions](docs/Queries.md#supported-functions).
 - **`HasIndex()` secondary-index auto-creation.** `EnsureCreatedAsync` (with `AutoCreateIndexes =
   true`) now creates a N1QL `CREATE INDEX` for every `HasIndex()` declared on the model, in
   addition to the existing primary-index creation, and waits for each to come online before

--- a/docs/Queries.md
+++ b/docs/Queries.md
@@ -146,11 +146,27 @@ SQL++ so they run server-side instead of throwing or falling back to client eval
 | `Guid.NewGuid()`                       | `UUID()`                            |
 | `a ?? b`                               | `IFMISSINGORNULL(a, b)`             |
 | `string.Compare(a, b)` / `a.CompareTo(b)` | `CASE WHEN a = b THEN 0 WHEN a > b THEN 1 WHEN a < b THEN -1 END` |
+| `EF.Functions.IsMissing(x)` / `IsNotMissing(x)` | `(x) IS MISSING` / `(x) IS NOT MISSING` |
+| `EF.Functions.IsValued(x)` / `IsNotValued(x)` | `(x) IS VALUED` / `(x) IS NOT VALUED` |
 
 C#'s `??` translates to N1QL's `IFMISSINGORNULL`, not a generic `COALESCE` (which N1QL doesn't
 have) — this is also the semantically correct choice, not just a renaming: a Couchbase document
 field can be genuinely *missing* (absent from the JSON entirely), not just JSON `null`, and
 `IFMISSINGORNULL` is the only N1QL null-handling function that treats both the way `??` does.
+
+`EF.Functions.IsMissing`/`IsNotMissing`/`IsValued`/`IsNotValued` let a query distinguish those same
+two cases explicitly, rather than folding them together the way `??`/`== null` do. `x == null`
+matches a field that's present with a JSON `null` *and* (per the same missing-is-falsy N1QL
+semantics `??` relies on) a field that's genuinely missing — if you need to tell those two apart,
+or you specifically want "field is present with a real, non-null value," use these instead:
+
+```csharp
+var missing = await context.Posts.Where(p => EF.Functions.IsMissing(p.Title)).ToListAsync();
+var hasRealValue = await context.Posts.Where(p => EF.Functions.IsValued(p.Title)).ToListAsync();
+```
+
+These have no client-side (in-memory) implementation — they can only be used inside a LINQ query
+that gets translated to SQL++; calling one directly throws `InvalidOperationException`.
 
 `string.Compare`/`.CompareTo` only produce the `CASE WHEN` shown above when the raw `int` result
 is actually used (e.g. projected in a `Select`). The common `string.Compare(a, b) > 0` /

--- a/src/Couchbase.EntityFrameworkCore/Extensions/CouchbaseDbFunctionsExtensions.cs
+++ b/src/Couchbase.EntityFrameworkCore/Extensions/CouchbaseDbFunctionsExtensions.cs
@@ -1,0 +1,94 @@
+using Microsoft.EntityFrameworkCore;
+
+namespace Couchbase.EntityFrameworkCore.Extensions;
+
+/// <summary>
+/// Couchbase-specific functions usable inside a LINQ query via <see cref="EF.Functions"/>, mirroring
+/// how EF Core's own <c>DbFunctions</c>-based methods (e.g. <c>Like</c>, <c>Greatest</c>) expose
+/// provider/relational-specific SQL through the same marker-object pattern.
+/// </summary>
+/// <remarks>
+/// N1QL documents can have a field that is genuinely <c>MISSING</c> (absent from the JSON
+/// entirely), which is a distinct concept from the field being present with a JSON <c>null</c>
+/// value — something ordinary <c>== null</c>/<c>.HasValue</c> LINQ cannot express, since EF Core's
+/// own null-semantics treat a missing column read as a CLR default/null indistinguishably from an
+/// actual stored null. These four methods expose N1QL's own <c>IS [NOT] MISSING</c>/
+/// <c>IS [NOT] VALUED</c> postfix operators to make that distinction queryable.
+/// </remarks>
+public static class CouchbaseDbFunctionsExtensions
+{
+    /// <summary>
+    /// Translates to N1QL's <c>IS MISSING</c>: <see langword="true"/> when the JSON field backing
+    /// <paramref name="value"/> is absent from the document entirely, as distinct from being
+    /// present with a JSON <c>null</c> (which ordinary <c>value == null</c> already covers).
+    /// </summary>
+    /// <remarks>
+    /// This method has no client-side (in-memory) implementation — it can only be used inside a
+    /// LINQ query that gets translated to SQL++; calling it directly throws
+    /// <see cref="InvalidOperationException"/>.
+    /// </remarks>
+    public static bool IsMissing<T>(this DbFunctions _, T value)
+        => throw new InvalidOperationException(ClientEvalMessage(nameof(IsMissing)));
+
+    /// <summary>
+    /// Translates to N1QL's <c>IS NOT MISSING</c>: <see langword="true"/> when the JSON field
+    /// backing <paramref name="value"/> is present in the document, whether its value is JSON
+    /// <c>null</c> or a real value.
+    /// </summary>
+    /// <remarks>
+    /// This method has no client-side (in-memory) implementation — it can only be used inside a
+    /// LINQ query that gets translated to SQL++; calling it directly throws
+    /// <see cref="InvalidOperationException"/>.
+    /// </remarks>
+    public static bool IsNotMissing<T>(this DbFunctions _, T value)
+        => throw new InvalidOperationException(ClientEvalMessage(nameof(IsNotMissing)));
+
+    /// <summary>
+    /// Translates to N1QL's <c>IS VALUED</c>: <see langword="true"/> when the JSON field backing
+    /// <paramref name="value"/> is present in the document AND is not JSON <c>null</c> — i.e. it
+    /// holds a real value.
+    /// </summary>
+    /// <remarks>
+    /// This method has no client-side (in-memory) implementation — it can only be used inside a
+    /// LINQ query that gets translated to SQL++; calling it directly throws
+    /// <see cref="InvalidOperationException"/>.
+    /// </remarks>
+    public static bool IsValued<T>(this DbFunctions _, T value)
+        => throw new InvalidOperationException(ClientEvalMessage(nameof(IsValued)));
+
+    /// <summary>
+    /// Translates to N1QL's <c>IS NOT VALUED</c>: <see langword="true"/> when the JSON field
+    /// backing <paramref name="value"/> is either absent from the document entirely or present
+    /// with a JSON <c>null</c> value.
+    /// </summary>
+    /// <remarks>
+    /// This method has no client-side (in-memory) implementation — it can only be used inside a
+    /// LINQ query that gets translated to SQL++; calling it directly throws
+    /// <see cref="InvalidOperationException"/>.
+    /// </remarks>
+    public static bool IsNotValued<T>(this DbFunctions _, T value)
+        => throw new InvalidOperationException(ClientEvalMessage(nameof(IsNotValued)));
+
+    private static string ClientEvalMessage(string methodName)
+        => $"'{methodName}' can only be translated to SQL++ within a LINQ query against a Couchbase " +
+           "collection; it has no client-side (in-memory) implementation.";
+}
+
+/* ************************************************************
+ *
+ *    @author Couchbase <info@couchbase.com>
+ *    @copyright 2025 Couchbase, Inc.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ *
+ * ************************************************************/

--- a/src/Couchbase.EntityFrameworkCore/Query/Internal/CouchbaseQuerySqlGenerator.cs
+++ b/src/Couchbase.EntityFrameworkCore/Query/Internal/CouchbaseQuerySqlGenerator.cs
@@ -9,6 +9,7 @@ using System.Reflection.Metadata;
 using System.Text;
 using Couchbase.EntityFrameworkCore.Infrastructure;
 using Couchbase.EntityFrameworkCore.Metadata;
+using Couchbase.EntityFrameworkCore.Query.Internal.Translators;
 using Couchbase.EntityFrameworkCore.Storage.Internal;
 using Couchbase.EntityFrameworkCore.Utils;
 using Couchbase.Extensions.DependencyInjection;
@@ -1461,6 +1462,19 @@ public class CouchbaseQuerySqlGenerator : QuerySqlGenerator
             return sqlFunctionExpression;
         }
 
+        // CouchbaseMissingValuedMethodTranslator carries EF.Functions.IsMissing/IsNotMissing/
+        // IsValued/IsNotValued as a marker SqlFunctionExpression, since there's no valid
+        // "function-call" rendering for N1QL's IS [NOT] MISSING/VALUED family -- they're postfix
+        // operators on an operand, not callable functions taking parenthesized arguments.
+        if (sqlFunctionExpression.Arguments is { Count: 1 } postfixArguments
+            && PostfixOperatorText.TryGetValue(sqlFunctionExpression.Name, out var postfixOperatorText))
+        {
+            Sql.Append("(");
+            Visit(postfixArguments[0]);
+            Sql.Append(") ").Append(postfixOperatorText);
+            return sqlFunctionExpression;
+        }
+
         if (sqlFunctionExpression.IsBuiltIn)
         {
             if (sqlFunctionExpression.Instance != null)
@@ -1558,6 +1572,18 @@ public class CouchbaseQuerySqlGenerator : QuerySqlGenerator
             generationAction(items[i]);
         }
     }
+
+    /// <summary>
+    /// Maps <see cref="CouchbaseMissingValuedMethodTranslator"/>'s internal marker function names
+    /// to the N1QL postfix operator text <see cref="VisitSqlFunction"/> substitutes for them.
+    /// </summary>
+    private static readonly Dictionary<string, string> PostfixOperatorText = new()
+    {
+        [CouchbaseMissingValuedMethodTranslator.IsMissingFunctionName] = "IS MISSING",
+        [CouchbaseMissingValuedMethodTranslator.IsNotMissingFunctionName] = "IS NOT MISSING",
+        [CouchbaseMissingValuedMethodTranslator.IsValuedFunctionName] = "IS VALUED",
+        [CouchbaseMissingValuedMethodTranslator.IsNotValuedFunctionName] = "IS NOT VALUED",
+    };
 
     /// <summary>
     /// Returns <c>true</c> for CLR types that <see cref="VisitSqlUnary"/> maps to

--- a/src/Couchbase.EntityFrameworkCore/Query/Internal/Translators/CouchbaseMethodCallTranslatorProvider.cs
+++ b/src/Couchbase.EntityFrameworkCore/Query/Internal/Translators/CouchbaseMethodCallTranslatorProvider.cs
@@ -2,33 +2,20 @@ using Microsoft.EntityFrameworkCore.Query;
 
 namespace Couchbase.EntityFrameworkCore.Query.Internal.Translators;
 
-public class CouchbaseMethodCallTranslatorProvider : RelationalMethodCallTranslatorProvider
+public sealed class CouchbaseMethodCallTranslatorProvider : RelationalMethodCallTranslatorProvider
 {
-    /*From https://github.com/dotnet/efcore/blob/73db4f0f5b5e599435a7e8cfda4a4066b8ada420/src/EFCore.Sqlite.Core/Query/Internal/SqliteMethodCallTranslatorProvider.cs*/
-    
     public CouchbaseMethodCallTranslatorProvider(RelationalMethodCallTranslatorProviderDependencies dependencies) : base(dependencies)
     {
-        var sqlExpressionFactory =/* (SqliteSqlExpressionFactory)*/dependencies.SqlExpressionFactory;
+        var sqlExpressionFactory = dependencies.SqlExpressionFactory;
 
         AddTranslators(
-            new IMethodCallTranslator[]
-            {
-                /*new SqliteByteArrayMethodTranslator(sqlExpressionFactory),
-                new SqliteCharMethodTranslator(sqlExpressionFactory),
-                new SqliteDateOnlyMethodTranslator(sqlExpressionFactory),
-                new SqliteDateTimeMethodTranslator(sqlExpressionFactory),
-                new SqliteGlobMethodTranslator(sqlExpressionFactory),
-                new SqliteHexMethodTranslator(sqlExpressionFactory),
-                new SqliteMathTranslator(sqlExpressionFactory),
-                new SqliteObjectToStringTranslator(sqlExpressionFactory),
-                new SqliteRandomTranslator(sqlExpressionFactory),
-                new SqliteRegexMethodTranslator(sqlExpressionFactory),*/
-                new CouchbaseStringMethodTranslator(sqlExpressionFactory),
+        [
+            new CouchbaseStringMethodTranslator(sqlExpressionFactory),
                 new CouchbaseMathMethodTranslator(sqlExpressionFactory),
                 new CouchbaseGuidMethodTranslator(sqlExpressionFactory),
                 new CouchbaseDateTimeMethodTranslator(sqlExpressionFactory),
-               // new SqliteSubstrMethodTranslator(sqlExpressionFactory)
-            });
+                new CouchbaseMissingValuedMethodTranslator(sqlExpressionFactory)
+        ]);
     }
 }
 

--- a/src/Couchbase.EntityFrameworkCore/Query/Internal/Translators/CouchbaseMissingValuedMethodTranslator.cs
+++ b/src/Couchbase.EntityFrameworkCore/Query/Internal/Translators/CouchbaseMissingValuedMethodTranslator.cs
@@ -1,0 +1,108 @@
+using System.Reflection;
+using Couchbase.EntityFrameworkCore.Extensions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+using Microsoft.EntityFrameworkCore.Query;
+using Microsoft.EntityFrameworkCore.Query.SqlExpressions;
+
+namespace Couchbase.EntityFrameworkCore.Query.Internal.Translators;
+
+/// <summary>
+/// Translates <see cref="CouchbaseDbFunctionsExtensions"/>'s <c>IsMissing</c>/<c>IsNotMissing</c>/
+/// <c>IsValued</c>/<c>IsNotValued</c> into a marker <see cref="SqlFunctionExpression"/> that
+/// <see cref="Query.Internal.CouchbaseQuerySqlGenerator"/> rewrites into N1QL's postfix
+/// <c>IS [NOT] MISSING</c>/<c>IS [NOT] VALUED</c> operators.
+/// </summary>
+/// <remarks>
+/// A regular <see cref="SqlFunctionExpression"/> is used purely as a carrier — there is no valid
+/// "function-call" rendering for these (N1QL's IS MISSING family is a postfix operator on an
+/// operand, not a callable function taking parenthesized arguments), so
+/// <see cref="Query.Internal.CouchbaseQuerySqlGenerator"/> recognizes the four internal function
+/// names below and substitutes postfix syntax instead — the same "detect a specific builtin name,
+/// substitute custom rendering" pattern already used there for <c>COALESCE</c> -&gt;
+/// <c>IFMISSINGORNULL</c>. Reusing <see cref="SqlFunctionExpression"/> (rather than a new
+/// <see cref="SqlExpression"/> subtype) means the base <c>SqlNullabilityProcessor</c> already knows
+/// how to process it generically — no new nullability-processor handling is needed.
+/// </remarks>
+public class CouchbaseMissingValuedMethodTranslator : IMethodCallTranslator
+{
+    internal const string IsMissingFunctionName = "COUCHBASE_IS_MISSING";
+    internal const string IsNotMissingFunctionName = "COUCHBASE_IS_NOT_MISSING";
+    internal const string IsValuedFunctionName = "COUCHBASE_IS_VALUED";
+    internal const string IsNotValuedFunctionName = "COUCHBASE_IS_NOT_VALUED";
+
+    private static readonly MethodInfo IsMissingMethodInfo = GetOpenMethod(nameof(CouchbaseDbFunctionsExtensions.IsMissing));
+    private static readonly MethodInfo IsNotMissingMethodInfo = GetOpenMethod(nameof(CouchbaseDbFunctionsExtensions.IsNotMissing));
+    private static readonly MethodInfo IsValuedMethodInfo = GetOpenMethod(nameof(CouchbaseDbFunctionsExtensions.IsValued));
+    private static readonly MethodInfo IsNotValuedMethodInfo = GetOpenMethod(nameof(CouchbaseDbFunctionsExtensions.IsNotValued));
+
+    private readonly ISqlExpressionFactory _sqlExpressionFactory;
+
+    public CouchbaseMissingValuedMethodTranslator(ISqlExpressionFactory sqlExpressionFactory)
+    {
+        _sqlExpressionFactory = sqlExpressionFactory;
+    }
+
+    public virtual SqlExpression? Translate(
+        SqlExpression? instance,
+        MethodInfo method,
+        IReadOnlyList<SqlExpression> arguments,
+        IDiagnosticsLogger<DbLoggerCategory.Query> logger)
+    {
+        // IsMissing/etc. are generic (T value) -- like EF Core's own Greatest<T>/Least<T> -- so
+        // `method` here is a closed generic method instance and must be compared against its own
+        // generic method definition, not via MethodInfo.Equals directly.
+        if (!method.IsGenericMethod)
+        {
+            return null;
+        }
+
+        var genericMethodDefinition = method.GetGenericMethodDefinition();
+        var functionName = genericMethodDefinition == IsMissingMethodInfo ? IsMissingFunctionName
+            : genericMethodDefinition == IsNotMissingMethodInfo ? IsNotMissingFunctionName
+            : genericMethodDefinition == IsValuedMethodInfo ? IsValuedFunctionName
+            : genericMethodDefinition == IsNotValuedMethodInfo ? IsNotValuedFunctionName
+            : null;
+
+        if (functionName is null)
+        {
+            return null;
+        }
+
+        // arguments[0] is the EF.Functions marker itself (translated to a placeholder by EF
+        // Core's own visitor); the real operand is arguments[1] -- matches how EF Core's own
+        // LikeTranslator reads arguments[1]/[2] for DbFunctionsExtensions.Like's matchExpression/
+        // pattern past its own DbFunctions receiver.
+        var function = _sqlExpressionFactory.Function(
+            functionName,
+            new[] { arguments[1] },
+            nullable: false,
+            argumentsPropagateNullability: new[] { false },
+            typeof(bool));
+
+        return _sqlExpressionFactory.ApplyDefaultTypeMapping(function);
+    }
+
+    private static MethodInfo GetOpenMethod(string name)
+        => typeof(CouchbaseDbFunctionsExtensions).GetMethods(BindingFlags.Public | BindingFlags.Static)
+            .Single(m => m.Name == name);
+}
+
+/* ************************************************************
+ *
+ *    @author Couchbase <info@couchbase.com>
+ *    @copyright 2025 Couchbase, Inc.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ *
+ * ************************************************************/

--- a/tests/Couchbase.EntityFrameworkCore.IntegrationTests/Tests/CouchbaseMissingValuedTests.cs
+++ b/tests/Couchbase.EntityFrameworkCore.IntegrationTests/Tests/CouchbaseMissingValuedTests.cs
@@ -1,0 +1,155 @@
+using Couchbase.EntityFrameworkCode.IntegrationTests.Fixtures;
+using Couchbase.EntityFrameworkCore;
+using Couchbase.EntityFrameworkCore.Extensions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+
+namespace Couchbase.EntityFrameworkCode.IntegrationTests.Tests;
+
+/// <summary>
+/// Proves <c>EF.Functions.IsMissing</c>/<c>IsNotMissing</c>/<c>IsValued</c>/<c>IsNotValued</c>
+/// translate to N1QL's postfix <c>IS [NOT] MISSING</c>/<c>IS [NOT] VALUED</c> operators and
+/// correctly distinguish the three ways a field can appear in a Couchbase document: genuinely
+/// MISSING (the JSON key doesn't exist at all), present with an explicit JSON <c>null</c>, and
+/// present with a real value -- the whole point of this feature, so it needs live proof against a
+/// real query engine, not just SQL-text assertions. Mirrors <c>CouchbaseCoalesceTests.cs</c>'s
+/// established raw-KV-write pattern for producing a genuinely missing field (SaveChangesAsync
+/// always writes every mapped property, so it can never produce one).
+/// </summary>
+[Collection(CouchbaseTestingCollection.Name)]
+public class CouchbaseMissingValuedTests(BloggingFixture fixture) : IAsyncLifetime
+{
+    private static readonly string CollectionName = "missingvalued" + Guid.NewGuid().ToString("N");
+
+    private MissingValuedDbContext _context = null!;
+
+    public async Task InitializeAsync()
+    {
+        var optionsBuilder = new DbContextOptionsBuilder<MissingValuedDbContext>();
+        optionsBuilder.UseCouchbase(
+            new global::Couchbase.ClusterOptions()
+                .WithConnectionString(fixture.Host)
+                .WithPasswordAuthentication(fixture.Username, fixture.Password),
+            o =>
+            {
+                o.Bucket = fixture.BucketName;
+                o.Scope = fixture.ScopeName;
+                o.AutoCreateIndexes = true;
+                o.ScanConsistency = global::Couchbase.Query.QueryScanConsistency.RequestPlus;
+            });
+        optionsBuilder.ConfigureWarnings(w => w.Ignore(CoreEventId.ManyServiceProvidersCreatedWarning));
+
+        _context = new MissingValuedDbContext(optionsBuilder.Options, CollectionName);
+        await _context.Database.EnsureCreatedAsync();
+
+        var clusterOptions = new global::Couchbase.ClusterOptions()
+            .WithConnectionString(fixture.Host)
+            .WithPasswordAuthentication(fixture.Username, fixture.Password)
+            .WithSerializer(global::Couchbase.Core.IO.Serializers.SystemTextJsonSerializer.Create());
+        using var cluster = await global::Couchbase.Cluster.ConnectAsync(clusterOptions);
+        var bucket = await cluster.BucketAsync(fixture.BucketName);
+        var scope = await bucket.ScopeAsync(fixture.ScopeName);
+        var collection = scope.Collection(CollectionName);
+
+        // Id=1: Title field is genuinely MISSING (key omitted entirely).
+        await collection.InsertAsync("1", new Dictionary<string, object> { ["Id"] = 1 });
+        // Id=2: Title field is present but an explicit JSON null.
+        await collection.InsertAsync("2", new Dictionary<string, object?> { ["Id"] = 2, ["Title"] = null });
+        // Id=3: Title field is present with a real value.
+        await collection.InsertAsync("3", new Dictionary<string, object> { ["Id"] = 3, ["Title"] = "real value" });
+    }
+
+    [Fact]
+    public async Task IsMissing_MatchesOnlyTheGenuinelyMissingField()
+    {
+        var results = await _context.Entities
+            .Where(e => EF.Functions.IsMissing(e.Title))
+            .ToListAsync();
+
+        Assert.Single(results);
+        Assert.Equal(1, results[0].Id);
+    }
+
+    [Fact]
+    public async Task IsNotMissing_MatchesExplicitNullAndRealValue_NotGenuinelyMissing()
+    {
+        var results = await _context.Entities
+            .Where(e => EF.Functions.IsNotMissing(e.Title))
+            .ToListAsync();
+
+        Assert.Equal(2, results.Count);
+        Assert.Contains(results, e => e.Id == 2);
+        Assert.Contains(results, e => e.Id == 3);
+    }
+
+    [Fact]
+    public async Task IsValued_MatchesOnlyTheRealValue()
+    {
+        var results = await _context.Entities
+            .Where(e => EF.Functions.IsValued(e.Title))
+            .ToListAsync();
+
+        Assert.Single(results);
+        Assert.Equal(3, results[0].Id);
+    }
+
+    [Fact]
+    public async Task IsNotValued_MatchesGenuinelyMissingAndExplicitNull_NotRealValue()
+    {
+        var results = await _context.Entities
+            .Where(e => EF.Functions.IsNotValued(e.Title))
+            .ToListAsync();
+
+        Assert.Equal(2, results.Count);
+        Assert.Contains(results, e => e.Id == 1);
+        Assert.Contains(results, e => e.Id == 2);
+    }
+
+    [Fact]
+    public async Task IsMissing_Negated_BehavesLikeIsNotMissing()
+    {
+        var results = await _context.Entities
+            .Where(e => !EF.Functions.IsMissing(e.Title))
+            .ToListAsync();
+
+        Assert.Equal(2, results.Count);
+        Assert.Contains(results, e => e.Id == 2);
+        Assert.Contains(results, e => e.Id == 3);
+    }
+
+    public async Task DisposeAsync()
+    {
+        await _context.DisposeAsync();
+
+        try
+        {
+            var clusterOptions = new global::Couchbase.ClusterOptions()
+                .WithConnectionString(fixture.Host)
+                .WithCredentials(fixture.Username, fixture.Password);
+            using var cluster = await global::Couchbase.Cluster.ConnectAsync(clusterOptions);
+            var bucket = await cluster.BucketAsync(fixture.BucketName);
+            await bucket.Collections.DropCollectionAsync(fixture.ScopeName, CollectionName);
+        }
+        catch (global::Couchbase.Management.Collections.CollectionNotFoundException)
+        {
+        }
+    }
+
+    public class MissingValuedEntity
+    {
+        public int Id { get; set; }
+        public string? Title { get; set; }
+    }
+
+    public class MissingValuedDbContext(DbContextOptions<MissingValuedDbContext> options, string collectionName)
+        : DbContext(options)
+    {
+        public DbSet<MissingValuedEntity> Entities { get; set; } = null!;
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            base.OnModelCreating(modelBuilder);
+            modelBuilder.Entity<MissingValuedEntity>().ToCouchbaseCollection(this, collectionName);
+        }
+    }
+}

--- a/tests/Couchbase.EntityFrameworkCore.UnitTests/Couchbase/EntityFrameworkCore/Query/CouchbaseMissingValuedSqlGenerationTests.cs
+++ b/tests/Couchbase.EntityFrameworkCore.UnitTests/Couchbase/EntityFrameworkCore/Query/CouchbaseMissingValuedSqlGenerationTests.cs
@@ -1,0 +1,108 @@
+using Couchbase.EntityFrameworkCore.Extensions;
+using Microsoft.EntityFrameworkCore;
+using Xunit;
+
+namespace Couchbase.EntityFrameworkCore.UnitTests.Couchbase.EntityFrameworkCore.Query;
+
+/// <summary>
+/// Verifies <see cref="CouchbaseDbFunctionsExtensions"/>'s IsMissing/IsNotMissing/IsValued/
+/// IsNotValued translate to N1QL's postfix <c>IS [NOT] MISSING</c>/<c>IS [NOT] VALUED</c>
+/// operators via <c>CouchbaseMissingValuedMethodTranslator</c>.
+/// </summary>
+public class CouchbaseMissingValuedSqlGenerationTests
+{
+    [Fact]
+    public void IsMissing_TranslatesToIsMissingPostfix()
+    {
+        using var ctx = CreateContext();
+        var query = ctx.Posts.Where(p => EF.Functions.IsMissing(p.Score));
+
+        var sql = query.ToQueryString();
+        Assert.Contains("(`b`.`Score`) IS MISSING", sql, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void IsNotMissing_TranslatesToIsNotMissingPostfix()
+    {
+        using var ctx = CreateContext();
+        var query = ctx.Posts.Where(p => EF.Functions.IsNotMissing(p.Score));
+
+        var sql = query.ToQueryString();
+        Assert.Contains("(`b`.`Score`) IS NOT MISSING", sql, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void IsValued_TranslatesToIsValuedPostfix()
+    {
+        using var ctx = CreateContext();
+        var query = ctx.Posts.Where(p => EF.Functions.IsValued(p.Score));
+
+        var sql = query.ToQueryString();
+        Assert.Contains("(`b`.`Score`) IS VALUED", sql, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void IsNotValued_TranslatesToIsNotValuedPostfix()
+    {
+        using var ctx = CreateContext();
+        var query = ctx.Posts.Where(p => EF.Functions.IsNotValued(p.Score));
+
+        var sql = query.ToQueryString();
+        Assert.Contains("(`b`.`Score`) IS NOT VALUED", sql, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void IsMissing_OnStringProperty_TranslatesCorrectly()
+    {
+        // Confirm the generic method works for a reference-typed property too, not just value
+        // types -- exercises a different closed generic instantiation of IsMissing<T>.
+        using var ctx = CreateContext();
+        var query = ctx.Posts.Where(p => EF.Functions.IsMissing(p.Title));
+
+        var sql = query.ToQueryString();
+        Assert.Contains("(`b`.`Title`) IS MISSING", sql, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void IsMissing_Negated_TranslatesToNotWrappingPostfixExpression()
+    {
+        using var ctx = CreateContext();
+        var query = ctx.Posts.Where(p => !EF.Functions.IsMissing(p.Score));
+
+        var sql = query.ToQueryString();
+        Assert.Contains("IS MISSING", sql, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("IS NOT MISSING", sql, StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static PostContext CreateContext()
+    {
+        var clusterOptions = new ClusterOptions()
+            .WithConnectionString("couchbase://localhost")
+            .WithPasswordAuthentication("Administrator", "password");
+
+        var builder = new DbContextOptionsBuilder<PostContext>();
+        builder.UseCouchbaseProvider(clusterOptions);
+        return new PostContext(builder.Options);
+    }
+
+    private class Post
+    {
+        public int PostId { get; set; }
+        public double Score { get; set; }
+        public string? Title { get; set; }
+    }
+
+    private class PostContext(DbContextOptions<PostContext> options) : DbContext(options)
+    {
+        public DbSet<Post> Posts { get; set; } = null!;
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            modelBuilder.Entity<Post>(b =>
+            {
+                b.ToCouchbaseCollection("bucket", "scope", "post");
+                b.HasKey(p => p.PostId);
+            });
+        }
+    }
+}


### PR DESCRIPTION
Adds Couchbase-specific DbFunctions translating to N1QL's IS MISSING, IS NOT MISSING, IS VALUED, and IS NOT VALUED postfix operators, letting queries distinguish a genuinely absent JSON field from one present with an explicit null value -- a distinction ordinary null-coalescing and equality checks against null cannot express.