### PR TITLE
Add EF.Functions support for META().flags and META().type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,18 @@ and this project aims to follow [Semantic Versioning](https://semver.org/spec/v2
 
 ### Added
 
+- **`[CouchbaseMeta(CouchbaseMetaField.Flags)]`/`[CouchbaseMeta(CouchbaseMetaField.Type)]`.**
+  Extends the existing `META()` mechanism (see [Optimistic concurrency and document
+  metadata](docs/concurrency.md)) with two more read-only fields: `Flags` (a `uint` property
+  sourced from `META(alias).flags`, the SDK's KV-layer datatype marker) and `Type` (a `string`
+  property sourced from `META(alias).type`, e.g. `"json"`). No new SQL generation or read-path
+  machinery was needed — the existing `Couchbase:MetaField` annotation/`VisitColumn` rendering is
+  fully generic over the field name. **Known limitation found during this work:** projecting
+  `META(alias).flags` together with `META(alias).expiration` in the same query makes the
+  Couchbase Server query engine itself return `0` for `flags` — confirmed as a server-side bug
+  (the wrong value is already present in the raw N1QL response, bypassing this provider's code
+  entirely), not something fixable client-side. See [Optimistic concurrency and document
+  metadata](docs/concurrency.md#reading-other-meta-fields) and [Limitations](docs/limitations.md).
 - **`EF.Functions.IsMissing`/`IsNotMissing`/`IsValued`/`IsNotValued`.** Exposes N1QL's postfix
   `IS [NOT] MISSING`/`IS [NOT] VALUED` operators, letting a query distinguish a field that's
   genuinely *missing* (absent from the JSON entirely) from one that's present with an explicit

--- a/docs/concurrency.md
+++ b/docs/concurrency.md
@@ -60,10 +60,13 @@ catch (DbUpdateConcurrencyException)
 
 ## Reading other META() fields
 
-`[CouchbaseMeta(CouchbaseMetaField.Id)]` (a `string` property) and
+`[CouchbaseMeta(CouchbaseMetaField.Id)]` (a `string` property),
 `[CouchbaseMeta(CouchbaseMetaField.Expiration)]` (a `long` property, Unix epoch seconds — `0`
-means no expiration) work the same way, but are read-only: the provider has no API for setting a
-document's key or TTL on write.
+means no expiration), `[CouchbaseMeta(CouchbaseMetaField.Flags)]` (a `uint` property — an opaque
+value the SDK's KV layer uses to record the document's datatype), and
+`[CouchbaseMeta(CouchbaseMetaField.Type)]` (a `string` property — e.g. `"json"`) all work the same
+way, but are read-only: the provider has no API for setting a document's key, TTL, flags, or type
+on write.
 
 ```
 public class Order
@@ -79,8 +82,18 @@ public class Order
 ```
 
 A `[CouchbaseMeta]` property must be the exact CLR type its field requires (`ulong` for `Cas`,
-`string` for `Id`, `long` for `Expiration`) — applying it to any other type throws
-`InvalidOperationException` at model-build time, and the fluent `HasCouchbaseMeta(...)` form
-throws the same way.
+`string` for `Id`/`Type`, `long` for `Expiration`, `uint` for `Flags`) — applying it to any other
+type throws `InvalidOperationException` at model-build time, and the fluent
+`HasCouchbaseMeta(...)` form throws the same way.
+
+> [!WARNING]
+> **Known Couchbase Server limitation:** don't put both `[CouchbaseMeta(CouchbaseMetaField.Flags)]`
+> and `[CouchbaseMeta(CouchbaseMetaField.Expiration)]` on the same queried entity. Projecting
+> `META(alias).flags` together with `META(alias).expiration` in one `SELECT` makes the Couchbase
+> Server query engine itself return `0` for `flags`, regardless of the document's real value —
+> confirmed by issuing the exact SQL directly via the SDK and observing the wrong value already
+> present in the raw N1QL response, so this is not something this provider's SQL generation or
+> materialization causes or can work around. `Flags` reads back correctly alone, or combined with
+> `Cas`/`Id`/`Type` — only the combination with `Expiration` is affected.
 
 Not supported: `META().xattrs` (extended attributes).

--- a/docs/limitations.md
+++ b/docs/limitations.md
@@ -138,8 +138,18 @@ See also [Querying](Queries.md) and [Configuration](configuration.md).
   combined with EF Core's own `.IsConcurrencyToken()` — see
   [Optimistic concurrency](concurrency.md). Without it, `SaveChangesAsync` performs an
   unconditional write (today's default, unchanged behavior).
-* **`META().id`/`META().expiration` are readable** via the same `[CouchbaseMeta]` mechanism, but
-  read-only — the provider has no API for *setting* a document's TTL/expiration on write.
+* **`META().id`/`META().expiration`/`META().flags`/`META().type` are readable** via the same
+  `[CouchbaseMeta]` mechanism, but read-only — the provider has no API for *setting* a document's
+  TTL/expiration on write.
+* **Known Couchbase Server limitation: don't combine `Flags` and `Expiration` in the same query.**
+  Projecting `META(alias).flags` together with `META(alias).expiration` in one `SELECT` — e.g. by
+  putting both `[CouchbaseMeta(CouchbaseMetaField.Flags)]` and
+  `[CouchbaseMeta(CouchbaseMetaField.Expiration)]` on the same queried entity — makes the Couchbase
+  Server query engine itself return `0` for `flags`, regardless of the document's real value. This
+  was confirmed to be a server-side query-engine bug (not something this provider's SQL generation
+  or materialization causes), by issuing the exact failing SQL directly via the SDK and observing
+  the wrong value already present in the raw N1QL response. `Flags` reads back correctly alone or
+  combined with `Cas`/`Id`/`Type` — only the combination with `Expiration` is affected.
 * **`META().xattrs` (extended attributes) are not supported.**
 
 ## Value generation and keys

--- a/src/Couchbase.EntityFrameworkCore/Metadata/CouchbaseMetaField.cs
+++ b/src/Couchbase.EntityFrameworkCore/Metadata/CouchbaseMetaField.cs
@@ -26,6 +26,30 @@ public enum CouchbaseMetaField
     /// write. Maps to a <see cref="long"/> property.
     /// </summary>
     Expiration,
+
+    /// <summary>
+    /// The document's flags (<c>META(alias).flags</c>) — an opaque 32-bit value the SDK's KV layer
+    /// uses to record the document's datatype (e.g. JSON). Read-only; this provider never sets it
+    /// itself. Maps to a <see cref="uint"/> property.
+    /// </summary>
+    /// <remarks>
+    /// <b>Known limitation:</b> do not also project <see cref="Expiration"/> in the same query as
+    /// <c>Flags</c> (e.g. both as <c>[CouchbaseMeta]</c> properties on the same queried entity).
+    /// Confirmed against a live cluster (bypassing this provider's SQL generation and reader
+    /// entirely, inspecting the raw N1QL response) that the Couchbase Server query engine itself
+    /// returns <c>0</c> for <c>flags</c> whenever <c>META(alias).flags</c> and
+    /// <c>META(alias).expiration</c> are both projected in one <c>SELECT</c> — this is a
+    /// server-side query-engine bug, not something this provider causes or can work around
+    /// client-side. Querying <c>Flags</c> alone, or alongside <c>Cas</c>/<c>Id</c>/<c>Type</c>
+    /// (any combination that excludes <c>Expiration</c>), reads back correctly.
+    /// </remarks>
+    Flags,
+
+    /// <summary>
+    /// The document's type (<c>META(alias).type</c>) — e.g. <c>"json"</c> for a JSON document.
+    /// Read-only. Maps to a <see cref="string"/> property.
+    /// </summary>
+    Type,
 }
 
 /// <summary>
@@ -40,6 +64,8 @@ internal static class CouchbaseMetaFieldClrTypes
         CouchbaseMetaField.Id => typeof(string),
         CouchbaseMetaField.Cas => typeof(ulong),
         CouchbaseMetaField.Expiration => typeof(long),
+        CouchbaseMetaField.Flags => typeof(uint),
+        CouchbaseMetaField.Type => typeof(string),
         _ => throw new ArgumentOutOfRangeException(nameof(field), field, "Unknown CouchbaseMetaField."),
     };
 
@@ -52,6 +78,8 @@ internal static class CouchbaseMetaFieldClrTypes
         CouchbaseMetaField.Id => "string",
         CouchbaseMetaField.Cas => "ulong",
         CouchbaseMetaField.Expiration => "long",
+        CouchbaseMetaField.Flags => "uint",
+        CouchbaseMetaField.Type => "string",
         _ => throw new ArgumentOutOfRangeException(nameof(field), field, "Unknown CouchbaseMetaField."),
     };
 }

--- a/tests/Couchbase.EntityFrameworkCore.IntegrationTests/Tests/CouchbaseMetaTests.cs
+++ b/tests/Couchbase.EntityFrameworkCore.IntegrationTests/Tests/CouchbaseMetaTests.cs
@@ -10,7 +10,8 @@ namespace Couchbase.EntityFrameworkCode.IntegrationTests.Tests;
 /// <summary>
 /// Proves N1QL <c>META()</c> support against a real cluster: <c>META().cas</c> as an EF Core
 /// optimistic-concurrency token (closing the previously-nonexistent concurrent-write detection
-/// gap), and read-only <c>META().id</c>/<c>META().expiration</c> access.
+/// gap), and read-only <c>META().id</c>/<c>META().expiration</c>/<c>META().flags</c>/<c>META().type</c>
+/// access.
 /// </summary>
 [Collection(CouchbaseTestingCollection.Name)]
 public class CouchbaseMetaTests(BloggingFixture fixture) : IAsyncLifetime
@@ -247,6 +248,205 @@ public class CouchbaseMetaTests(BloggingFixture fixture) : IAsyncLifetime
                 b.ToCouchbaseCollection(this, collectionName);
                 b.Property(e => e.Cas).IsConcurrencyToken();
             });
+        }
+    }
+}
+
+/// <summary>
+/// Proves N1QL <c>META().flags</c>/<c>META().type</c> support against a real cluster.
+/// </summary>
+/// <remarks>
+/// <see cref="FlagsTypeEntity"/> deliberately does NOT also carry a <c>[CouchbaseMeta(Expiration)]</c>
+/// property -- projecting <c>META(alias).flags</c> together with <c>META(alias).expiration</c> in
+/// the same SELECT was found (via an isolated live-cluster spike, bypassing this provider's reader
+/// entirely and inspecting the raw N1QL response) to make the Couchbase Server query engine itself
+/// return <c>0</c> for <c>flags</c>, regardless of the document's real flags value -- a query-engine
+/// bug, not something this provider's SQL generation or materialization causes or can work around.
+/// See the "Known limitations" note on <see cref="CouchbaseMetaField.Flags"/> and
+/// <c>docs/limitations.md</c>.
+/// </remarks>
+[Collection(CouchbaseTestingCollection.Name)]
+public class CouchbaseMetaFlagsTypeTests(BloggingFixture fixture) : IAsyncLifetime
+{
+    private static readonly string CollectionName = "metaflags" + Guid.NewGuid().ToString("N");
+
+    public Task InitializeAsync() => Task.CompletedTask;
+
+    private FlagsTypeDbContext CreateContext()
+    {
+        var optionsBuilder = new DbContextOptionsBuilder<FlagsTypeDbContext>();
+        optionsBuilder.UseCouchbase(
+            new global::Couchbase.ClusterOptions()
+                .WithConnectionString(fixture.Host)
+                .WithPasswordAuthentication(fixture.Username, fixture.Password),
+            o =>
+            {
+                o.Bucket = fixture.BucketName;
+                o.Scope = fixture.ScopeName;
+                o.AutoCreateIndexes = true;
+                o.ScanConsistency = global::Couchbase.Query.QueryScanConsistency.RequestPlus;
+            });
+        optionsBuilder.ConfigureWarnings(w => w.Ignore(CoreEventId.ManyServiceProvidersCreatedWarning));
+        return new FlagsTypeDbContext(optionsBuilder.Options, CollectionName);
+    }
+
+    [Fact]
+    public async Task Type_ForJsonDocument_ReadsAsJson()
+    {
+        await using var ctx = CreateContext();
+        await ctx.Database.EnsureCreatedAsync();
+        ctx.Entities.Add(new FlagsTypeEntity { Id = 1, Name = "typed" });
+        await ctx.SaveChangesAsync();
+
+        await using var readCtx = CreateContext();
+        var entity = await readCtx.Entities.SingleAsync(e => e.Id == 1);
+
+        Assert.Equal("json", entity.DocType);
+    }
+
+    [Fact]
+    public async Task Flags_ForJsonDocument_ReadsAsNonZeroValue()
+    {
+        await using var ctx = CreateContext();
+        await ctx.Database.EnsureCreatedAsync();
+        ctx.Entities.Add(new FlagsTypeEntity { Id = 2, Name = "flagged" });
+        await ctx.SaveChangesAsync();
+
+        await using var readCtx = CreateContext();
+        var entity = await readCtx.Entities.SingleAsync(e => e.Id == 2);
+
+        // The exact bit pattern is an SDK/serializer implementation detail (it encodes datatype
+        // hints, not anything this provider controls) -- assert only that a real value comes back,
+        // not a specific constant.
+        Assert.NotEqual(0u, entity.DocFlags);
+    }
+
+    public async Task DisposeAsync()
+    {
+        try
+        {
+            var clusterOptions = new global::Couchbase.ClusterOptions()
+                .WithConnectionString(fixture.Host)
+                .WithCredentials(fixture.Username, fixture.Password);
+            using var cluster = await global::Couchbase.Cluster.ConnectAsync(clusterOptions);
+            var bucket = await cluster.BucketAsync(fixture.BucketName);
+            await bucket.Collections.DropCollectionAsync(fixture.ScopeName, CollectionName);
+        }
+        catch (global::Couchbase.Management.Collections.CollectionNotFoundException)
+        {
+        }
+    }
+
+    public class FlagsTypeEntity
+    {
+        public int Id { get; set; }
+        public string Name { get; set; } = string.Empty;
+
+        [CouchbaseMeta(CouchbaseMetaField.Flags)]
+        public uint DocFlags { get; set; }
+
+        [CouchbaseMeta(CouchbaseMetaField.Type)]
+        public string DocType { get; set; } = string.Empty;
+    }
+
+    public class FlagsTypeDbContext(DbContextOptions<FlagsTypeDbContext> options, string collectionName)
+        : DbContext(options)
+    {
+        public DbSet<FlagsTypeEntity> Entities { get; set; } = null!;
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            base.OnModelCreating(modelBuilder);
+            modelBuilder.Entity<FlagsTypeEntity>(b => b.ToCouchbaseCollection(this, collectionName));
+        }
+    }
+}
+
+/// <summary>
+/// Documents a confirmed Couchbase Server N1QL query-engine limitation (not a bug in this
+/// provider): projecting <c>META(alias).flags</c> together with <c>META(alias).expiration</c> in
+/// the same SELECT makes the server return <c>0</c> for <c>flags</c> regardless of the document's
+/// real value. Confirmed via a raw <c>QueryAsync&lt;JsonElement&gt;</c> call bypassing this
+/// provider's SQL generation and reader entirely -- the wrong value is already present in the raw
+/// N1QL response, so there is nothing to fix client-side. If a future Couchbase Server release
+/// fixes this, this test starts failing and should be treated as a signal to relax the "avoid
+/// combining Flags with Expiration" guidance in <c>docs/limitations.md</c> and on
+/// <see cref="CouchbaseMetaField.Flags"/>'s XML doc comment.
+/// </summary>
+[Collection(CouchbaseTestingCollection.Name)]
+public class CouchbaseMetaFlagsExpirationKnownLimitationTests(BloggingFixture fixture) : IAsyncLifetime
+{
+    private static readonly string CollectionName = "metaflagsexp" + Guid.NewGuid().ToString("N");
+
+    public Task InitializeAsync() => Task.CompletedTask;
+
+    [Fact]
+    public async Task Flags_CombinedWithExpirationInSameQuery_ServerReturnsZeroInsteadOfRealValue()
+    {
+        var optionsBuilder = new DbContextOptionsBuilder<CombinedDbContext>();
+        optionsBuilder.UseCouchbase(
+            new global::Couchbase.ClusterOptions()
+                .WithConnectionString(fixture.Host)
+                .WithPasswordAuthentication(fixture.Username, fixture.Password),
+            o =>
+            {
+                o.Bucket = fixture.BucketName;
+                o.Scope = fixture.ScopeName;
+                o.AutoCreateIndexes = true;
+                o.ScanConsistency = global::Couchbase.Query.QueryScanConsistency.RequestPlus;
+            });
+        optionsBuilder.ConfigureWarnings(w => w.Ignore(CoreEventId.ManyServiceProvidersCreatedWarning));
+
+        await using var ctx = new CombinedDbContext(optionsBuilder.Options, CollectionName);
+        await ctx.Database.EnsureCreatedAsync();
+        ctx.Entities.Add(new CombinedEntity { Id = 1 });
+        await ctx.SaveChangesAsync();
+
+        await using var readCtx = new CombinedDbContext(optionsBuilder.Options, CollectionName);
+        var entity = await readCtx.Entities.SingleAsync(e => e.Id == 1);
+
+        // This asserts the CURRENT, CONFIRMED-BUGGY server behavior -- Flags reads back as 0 here
+        // even though the document's real flags value is nonzero (proven separately in
+        // CouchbaseMetaFlagsTypeTests, which never combines Flags with Expiration in one query).
+        Assert.Equal(0u, entity.DocFlags);
+    }
+
+    public async Task DisposeAsync()
+    {
+        try
+        {
+            var clusterOptions = new global::Couchbase.ClusterOptions()
+                .WithConnectionString(fixture.Host)
+                .WithCredentials(fixture.Username, fixture.Password);
+            using var cluster = await global::Couchbase.Cluster.ConnectAsync(clusterOptions);
+            var bucket = await cluster.BucketAsync(fixture.BucketName);
+            await bucket.Collections.DropCollectionAsync(fixture.ScopeName, CollectionName);
+        }
+        catch (global::Couchbase.Management.Collections.CollectionNotFoundException)
+        {
+        }
+    }
+
+    public class CombinedEntity
+    {
+        public int Id { get; set; }
+
+        [CouchbaseMeta(CouchbaseMetaField.Flags)]
+        public uint DocFlags { get; set; }
+
+        [CouchbaseMeta(CouchbaseMetaField.Expiration)]
+        public long Expiration { get; set; }
+    }
+
+    public class CombinedDbContext(DbContextOptions<CombinedDbContext> options, string collectionName)
+        : DbContext(options)
+    {
+        public DbSet<CombinedEntity> Entities { get; set; } = null!;
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            base.OnModelCreating(modelBuilder);
+            modelBuilder.Entity<CombinedEntity>(b => b.ToCouchbaseCollection(this, collectionName));
         }
     }
 }

--- a/tests/Couchbase.EntityFrameworkCore.IntegrationTests/Tests/MetaFlagsTypeSpikeTests.cs
+++ b/tests/Couchbase.EntityFrameworkCore.IntegrationTests/Tests/MetaFlagsTypeSpikeTests.cs
@@ -1,0 +1,115 @@
+using Couchbase.EntityFrameworkCode.IntegrationTests.Fixtures;
+using Xunit.Abstractions;
+
+namespace Couchbase.EntityFrameworkCode.IntegrationTests.Tests;
+
+/// <summary>
+/// Phase-0 empirical spike for extending <c>[CouchbaseMeta]</c> to cover
+/// <c>META(alias).flags</c>/<c>.type</c>: before choosing CLR types for the new
+/// <see cref="global::Couchbase.EntityFrameworkCore.Metadata.CouchbaseMetaField"/> values, observe
+/// the actual JSON shape N1QL returns for both fields against a real document written by this
+/// SDK's default (System.Text.Json) serializer -- bypassing EF Core and this provider entirely,
+/// mirroring the established "observe real behavior first" discipline used for the original META
+/// work and the DateTime-format spike.
+/// </summary>
+[Collection(CouchbaseTestingCollection.Name)]
+public class MetaFlagsTypeSpikeTests(BloggingFixture fixture, ITestOutputHelper outputHelper)
+{
+    [Fact]
+    public async Task MetaFlagsAndType_ForJsonDocument_ObserveActualShape()
+    {
+        var collectionName = "metaspike" + Guid.NewGuid().ToString("N");
+        var bucketId = fixture.BucketName;
+        var scopeId = fixture.ScopeName;
+
+        var clusterOptions = new global::Couchbase.ClusterOptions()
+            .WithConnectionString(fixture.Host)
+            .WithPasswordAuthentication(fixture.Username, fixture.Password)
+            .WithSerializer(global::Couchbase.Core.IO.Serializers.SystemTextJsonSerializer.Create());
+        using var cluster = await global::Couchbase.Cluster.ConnectAsync(clusterOptions);
+        var bucket = await cluster.BucketAsync(fixture.BucketName);
+        var scope = await bucket.ScopeAsync(fixture.ScopeName);
+
+        try
+        {
+            await bucket.Collections.CreateCollectionAsync(
+                new global::Couchbase.Management.Collections.CollectionSpec(fixture.ScopeName, collectionName));
+            var collection = scope.Collection(collectionName);
+
+            await collection.InsertAsync("1", new Dictionary<string, object> { ["Id"] = 1, ["Name"] = "spike" });
+
+            var createIndexSql = $"CREATE PRIMARY INDEX IF NOT EXISTS ON `{bucketId}`.`{scopeId}`.`{collectionName}`";
+            var createIndexDeadline = DateTime.UtcNow.AddSeconds(30);
+            while (true)
+            {
+                try
+                {
+                    using var createIndexResult = await cluster.QueryAsync<dynamic>(createIndexSql);
+                    await foreach (var _ in createIndexResult.Rows) { }
+                    break;
+                }
+                catch (global::Couchbase.Core.Exceptions.IndexFailureException) when (DateTime.UtcNow < createIndexDeadline)
+                {
+                    await Task.Delay(500);
+                }
+            }
+
+            var deadline = DateTime.UtcNow.AddSeconds(60);
+            var indexOnline = false;
+            while (DateTime.UtcNow < deadline)
+            {
+                using var countResult = await cluster.QueryAsync<long>(
+                    "SELECT RAW COUNT(*) FROM system:indexes WHERE is_primary = true AND state = 'online' " +
+                    $"AND bucket_id = '{bucketId}' AND scope_id = '{scopeId}' AND keyspace_id = '{collectionName}'");
+                long count = 0;
+                await foreach (var row in countResult.Rows) { count = row; }
+                if (count > 0)
+                {
+                    indexOnline = true;
+                    break;
+                }
+
+                await Task.Delay(500);
+            }
+
+            Assert.True(indexOnline, $"Primary index on `{collectionName}` did not come online within the deadline.");
+
+            var sql = $"SELECT RAW META(d) FROM `{bucketId}`.`{scopeId}`.`{collectionName}` AS d WHERE META(d).id = '1'";
+
+            using var result = await cluster.QueryAsync<System.Text.Json.JsonElement>(
+                sql,
+                new global::Couchbase.Query.QueryOptions().ScanConsistency(global::Couchbase.Query.QueryScanConsistency.RequestPlus));
+
+            var rowCount = 0;
+            await foreach (var row in result.Rows)
+            {
+                rowCount++;
+                var flags = row.GetProperty("flags");
+                var type = row.GetProperty("type");
+                outputHelper.WriteLine($"META(d) = {row}");
+                outputHelper.WriteLine($"flags: ValueKind={flags.ValueKind}, value={flags}");
+                outputHelper.WriteLine($"type: ValueKind={type.ValueKind}, value={type}");
+
+                // The observed shape that CouchbaseMetaField.Flags/Type are designed around: flags
+                // is a non-negative JSON number well within uint32 range (Couchbase's document
+                // flags are a 32-bit value), and type is always a plain JSON string.
+                Assert.Equal(System.Text.Json.JsonValueKind.Number, flags.ValueKind);
+                Assert.True(flags.TryGetUInt32(out _), "flags should fit in a uint32.");
+                Assert.Equal(System.Text.Json.JsonValueKind.String, type.ValueKind);
+                Assert.Equal("json", type.GetString());
+            }
+
+            Assert.Equal(1, rowCount);
+        }
+        finally
+        {
+            try
+            {
+                await bucket.Collections.DropCollectionAsync(fixture.ScopeName, collectionName);
+            }
+            catch (global::Couchbase.Management.Collections.CollectionNotFoundException)
+            {
+            }
+        }
+    }
+}

--- a/tests/Couchbase.EntityFrameworkCore.UnitTests/Couchbase/EntityFrameworkCore/Extensions/CouchbasePropertyBuilderExtensionsTests.cs
+++ b/tests/Couchbase.EntityFrameworkCore.UnitTests/Couchbase/EntityFrameworkCore/Extensions/CouchbasePropertyBuilderExtensionsTests.cs
@@ -827,6 +827,56 @@ public class CouchbasePropertyBuilderExtensionsTests
         Assert.Contains("ulong", exception.Message);
     }
 
+    [Fact]
+    public void HasCouchbaseMeta_FlagsOnUintProperty_SetsAnnotation()
+    {
+        var modelBuilder = new ModelBuilder();
+        var entityBuilder = modelBuilder.Entity<MetaEntity>();
+
+        entityBuilder.Property(e => e.DocFlags).HasCouchbaseMeta(CouchbaseMetaField.Flags);
+
+        var property = modelBuilder.Model.FindEntityType(typeof(MetaEntity))!.FindProperty(nameof(MetaEntity.DocFlags));
+        Assert.Equal("Flags", property!.FindAnnotation(CouchbaseMetaAnnotationNames.MetaField)?.Value);
+    }
+
+    [Fact]
+    public void HasCouchbaseMeta_TypeOnStringProperty_SetsAnnotation()
+    {
+        var modelBuilder = new ModelBuilder();
+        var entityBuilder = modelBuilder.Entity<MetaEntity>();
+
+        entityBuilder.Property(e => e.DocType).HasCouchbaseMeta(CouchbaseMetaField.Type);
+
+        var property = modelBuilder.Model.FindEntityType(typeof(MetaEntity))!.FindProperty(nameof(MetaEntity.DocType));
+        Assert.Equal("Type", property!.FindAnnotation(CouchbaseMetaAnnotationNames.MetaField)?.Value);
+    }
+
+    [Fact]
+    public void HasCouchbaseMeta_FlagsOnNonUintProperty_ThrowsInvalidOperationException()
+    {
+        var modelBuilder = new ModelBuilder();
+        var entityBuilder = modelBuilder.Entity<MetaEntity>();
+
+        var exception = Assert.Throws<InvalidOperationException>(() =>
+            entityBuilder.Property(e => e.Id).HasCouchbaseMeta(CouchbaseMetaField.Flags));
+
+        Assert.Contains("HasCouchbaseMeta(Flags)", exception.Message);
+        Assert.Contains("uint", exception.Message);
+    }
+
+    [Fact]
+    public void HasCouchbaseMeta_TypeOnNonStringProperty_ThrowsInvalidOperationException()
+    {
+        var modelBuilder = new ModelBuilder();
+        var entityBuilder = modelBuilder.Entity<MetaEntity>();
+
+        var exception = Assert.Throws<InvalidOperationException>(() =>
+            entityBuilder.Property(e => e.Id).HasCouchbaseMeta(CouchbaseMetaField.Type));
+
+        Assert.Contains("HasCouchbaseMeta(Type)", exception.Message);
+        Assert.Contains("string", exception.Message);
+    }
+
     #endregion
 
     private class DateTimeEntity
@@ -841,6 +891,8 @@ public class CouchbasePropertyBuilderExtensionsTests
         public long Id { get; set; }
         public ulong Cas { get; set; }
         public string DocId { get; set; } = string.Empty;
+        public uint DocFlags { get; set; }
+        public string DocType { get; set; } = string.Empty;
     }
 
     private class TestEntity

--- a/tests/Couchbase.EntityFrameworkCore.UnitTests/Couchbase/EntityFrameworkCore/Metadata/Conventions/CouchbaseMetaConventionTests.cs
+++ b/tests/Couchbase.EntityFrameworkCore.UnitTests/Couchbase/EntityFrameworkCore/Metadata/Conventions/CouchbaseMetaConventionTests.cs
@@ -36,6 +36,26 @@ public class CouchbaseMetaConventionTests
         Assert.Contains("ulong", exception.Message);
     }
 
+    [Fact]
+    public void FlagsAttribute_OnUintProperty_SetsAnnotation()
+    {
+        using var ctx = CreateContext();
+
+        var property = ctx.Model.FindEntityType(typeof(ValidEntity))!.FindProperty(nameof(ValidEntity.Flags))!;
+
+        Assert.Equal("Flags", property.FindAnnotation(CouchbaseMetaAnnotationNames.MetaField)?.Value);
+    }
+
+    [Fact]
+    public void TypeAttribute_OnStringProperty_SetsAnnotation()
+    {
+        using var ctx = CreateContext();
+
+        var property = ctx.Model.FindEntityType(typeof(ValidEntity))!.FindProperty(nameof(ValidEntity.DocType))!;
+
+        Assert.Equal("Type", property.FindAnnotation(CouchbaseMetaAnnotationNames.MetaField)?.Value);
+    }
+
     private static ValidContext CreateContext()
     {
         var clusterOptions = new ClusterOptions()
@@ -62,6 +82,12 @@ public class CouchbaseMetaConventionTests
 
         [CouchbaseMeta(CouchbaseMetaField.Cas)]
         public ulong Cas { get; set; }
+
+        [CouchbaseMeta(CouchbaseMetaField.Flags)]
+        public uint Flags { get; set; }
+
+        [CouchbaseMeta(CouchbaseMetaField.Type)]
+        public string DocType { get; set; } = string.Empty;
     }
 
     private class ValidContext(DbContextOptions<ValidContext> options) : DbContext(options)

--- a/tests/Couchbase.EntityFrameworkCore.UnitTests/Couchbase/EntityFrameworkCore/Query/CouchbaseMetaSqlGenerationTests.cs
+++ b/tests/Couchbase.EntityFrameworkCore.UnitTests/Couchbase/EntityFrameworkCore/Query/CouchbaseMetaSqlGenerationTests.cs
@@ -64,6 +64,28 @@ public class CouchbaseMetaSqlGenerationTests(ITestOutputHelper output)
         Assert.Contains(").cas", sql, StringComparison.OrdinalIgnoreCase);
     }
 
+    [Fact]
+    public void Select_FlagsProperty_ProjectsAsMetaFlagsWithExplicitAlias()
+    {
+        using var ctx = CreateContext();
+        var sql = ctx.Entities.Select(e => new { e.Id, e.DocFlags }).ToQueryString();
+        output.WriteLine("SQL: " + sql);
+
+        Assert.Contains("META(", sql);
+        Assert.Matches(@"META\([^)]+\)\.flags\s+AS\s+`DocFlags`", sql);
+    }
+
+    [Fact]
+    public void Select_TypeProperty_ProjectsAsMetaTypeWithExplicitAlias()
+    {
+        using var ctx = CreateContext();
+        var sql = ctx.Entities.Select(e => new { e.Id, e.DocType }).ToQueryString();
+        output.WriteLine("SQL: " + sql);
+
+        Assert.Contains("META(", sql);
+        Assert.Matches(@"META\([^)]+\)\.type\s+AS\s+`DocType`", sql);
+    }
+
     private static MetaContext CreateContext()
     {
         var clusterOptions = new ClusterOptions()
@@ -83,6 +105,12 @@ public class CouchbaseMetaSqlGenerationTests(ITestOutputHelper output)
 
         [CouchbaseMeta(CouchbaseMetaField.Id)]
         public string DocumentKey { get; set; } = string.Empty;
+
+        [CouchbaseMeta(CouchbaseMetaField.Flags)]
+        public uint DocFlags { get; set; }
+
+        [CouchbaseMeta(CouchbaseMetaField.Type)]
+        public string DocType { get; set; } = string.Empty;
     }
 
     private class MetaContext(DbContextOptions<MetaContext> options) : DbContext(options)


### PR DESCRIPTION
Extends [CouchbaseMeta] with two more read-only document-metadata fields, Flags and Type, reusing the existing generic META() annotation and rendering mechanism -- no new SQL generation was needed.

Also documents a confirmed Couchbase Server N1QL query-engine bug found while testing: projecting META(alias).flags together with META(alias).expiration in the same query makes the server return 0 for flags regardless of the document's real value. This is not fixable client-side; a regression test locks in the current behavior so a future server fix surfaces as a test failure.