### PR TITLE
Add EF.Functions-style UseIndex/UseHash query hints (USE INDEX/USE HASH)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ and this project aims to follow [Semantic Versioning](https://semver.org/spec/v2
 
 ### Added
 
+- **`UseIndex`/`UseHash` query hints.** New `IQueryable<T>` extension methods
+  (`Couchbase.EntityFrameworkCore.Extensions.CouchbaseQueryableExtensions`) exposing N1QL's
+  per-keyspace-reference optimizer hints: `UseIndex(name, CouchbaseIndexType)` forces a specific
+  secondary index (GSI or FTS) on the query's root keyspace instead of letting the planner choose,
+  and `UseHash(CouchbaseHashHintType)` forces a hash-join strategy (picking the BUILD/PROBE side)
+  for a specific join's inner sequence instead of the default nested-loop join. Implemented via a
+  new `VisitMethodCall` override in `CouchbaseQueryableMethodTranslatingExpressionVisitor` that
+  stashes the hint as a query-tree annotation on the relevant `TableExpression`, and a matching
+  render step in `CouchbaseQuerySqlGenerator`. See [Query hints](docs/Queries.md#query-hints-use-index--use-hash).
 - **`[CouchbaseMeta(CouchbaseMetaField.Flags)]`/`[CouchbaseMeta(CouchbaseMetaField.Type)]`.**
   Extends the existing `META()` mechanism (see [Optimistic concurrency and document
   metadata](docs/concurrency.md)) with two more read-only fields: `Flags` (a `uint` property

--- a/docs/Queries.md
+++ b/docs/Queries.md
@@ -38,6 +38,51 @@ FROM `Blogging`.`MyBlog`.`PersonPhoto` AS `p`
 INNER JOIN `Blogging`.`MyBlog`.`Person` AS `p0` ON `p`.`PersonPhotoId` = `p0`.`PhotoId`
 ```
 
+## Query hints (USE INDEX / USE HASH)
+
+N1QL lets a query nudge the optimizer per keyspace reference — force a specific secondary index
+instead of letting the planner choose (`USE INDEX`), or force a hash-join strategy for a specific
+join and pick which side builds the hash table vs. probes it (`USE HASH`), instead of the default
+nested-loop join
+([reference](https://docs.couchbase.com/server/current/n1ql/n1ql-language-reference/hints.html)).
+Both are exposed as `IQueryable<T>` extension methods, mirroring N1QL's own per-FROM-term
+placement:
+
+```
+using Couchbase.EntityFrameworkCore.Extensions;
+
+// USE INDEX -- only valid on the root (primary) keyspace of a query, not after a join.
+var highScores = await context.Posts
+    .UseIndex("post_score_idx")
+    .Where(p => p.Score >= 20)
+    .ToListAsync();
+
+// A null name broadens the hint to "any index of the given type" (USE INDEX(USING GSI) with no name).
+var anyGsi = await context.Posts.UseIndex(null).ToListAsync();
+
+// USE HASH -- apply to the inner (right-hand) sequence of a join, before the join itself.
+var query = context.Posts.Join(
+    context.Authors.UseHash(CouchbaseHashHintType.Build),
+    p => p.AuthorId,
+    a => a.Id,
+    (p, a) => new { p.Title, a.Name });
+```
+
+This generates:
+
+```
+SELECT `p`.`Title`, `a`.`Name`
+FROM `Blogging`.`MyBlog`.`Post` AS `p`
+INNER JOIN `Blogging`.`MyBlog`.`Author` AS `a` USE HASH(BUILD) ON `p`.`AuthorId` = `a`.`Id`
+```
+
+`UseIndex`'s second parameter is a `CouchbaseIndexType` (`Gsi` — the default — or `Fts`), and
+`UseHash`'s parameter is a `CouchbaseHashHintType` (`Build` or `Probe`).
+
+Both are optimizer nudges, not correctness requirements — a query returns identical results
+whether or not the hint is honored. Calling either method on a non-Couchbase (e.g. in-memory)
+queryable is a silent, benign no-op.
+
 ## FirstAsync
 
 ```

--- a/src/Couchbase.EntityFrameworkCore/Extensions/CouchbaseQueryableExtensions.cs
+++ b/src/Couchbase.EntityFrameworkCore/Extensions/CouchbaseQueryableExtensions.cs
@@ -1,0 +1,135 @@
+using System.Linq.Expressions;
+using System.Reflection;
+using Microsoft.EntityFrameworkCore.Query;
+using Microsoft.EntityFrameworkCore.Query.Internal;
+
+namespace Couchbase.EntityFrameworkCore.Extensions;
+
+/// <summary>
+/// The N1QL index type a <see cref="CouchbaseQueryableExtensions.UseIndex{TEntity}"/> hint targets.
+/// </summary>
+public enum CouchbaseIndexType
+{
+    /// <summary>A Global Secondary Index (N1QL's <c>USING GSI</c>) — the default.</summary>
+    Gsi,
+
+    /// <summary>A Full Text Search index (N1QL's <c>USING FTS</c>).</summary>
+    Fts,
+}
+
+/// <summary>
+/// Which side of a hash join a <see cref="CouchbaseQueryableExtensions.UseHash{TEntity}"/> hint
+/// builds vs. probes.
+/// </summary>
+public enum CouchbaseHashHintType
+{
+    /// <summary>This side builds the in-memory hash table (N1QL's <c>USE HASH(BUILD)</c>).</summary>
+    Build,
+
+    /// <summary>This side probes the hash table built by the other side (N1QL's <c>USE HASH(PROBE)</c>).</summary>
+    Probe,
+}
+
+/// <summary>
+/// Per-query N1QL optimizer hints — <c>USE INDEX</c> and <c>USE HASH</c> — attached to a specific
+/// keyspace reference in a LINQ query, mirroring N1QL's own per-FROM-term placement
+/// (<see href="https://docs.couchbase.com/server/current/n1ql/n1ql-language-reference/from.html"/>,
+/// <see href="https://docs.couchbase.com/server/current/n1ql/n1ql-language-reference/hints.html"/>).
+/// </summary>
+/// <remarks>
+/// <para>
+/// <see cref="EntityQueryProvider"/> is EF Core's single, shared query-provider implementation used
+/// by every relational and non-relational EF Core provider alike (SQL Server, SQLite, the in-memory
+/// provider, Couchbase, ...) — it is not a Couchbase-specific marker, so the <c>source.Provider is
+/// EntityQueryProvider</c> check below only distinguishes "this is an EF Core queryable that will go
+/// through query translation" from "this is a genuine non-EF-Core queryable" (e.g. LINQ-to-Objects'
+/// own provider, produced by <c>List&lt;T&gt;.AsQueryable()</c>) — the latter has no translation
+/// pipeline for either method to hook into at all, so it's a silent, benign no-op there: it returns
+/// <paramref name="source"/> unchanged, since these are optimizer nudges, not correctness
+/// requirements, and a query behaves identically whether or not a hint is honored.
+/// </para>
+/// <para>
+/// Calling either method against an EF Core queryable backed by a provider OTHER than Couchbase
+/// (SQL Server, SQLite, in-memory, ...) is <em>not</em> a no-op: the call is embedded in the query's
+/// expression tree same as for Couchbase, but that other provider's translation pipeline has no
+/// registered handling for <see cref="CouchbaseQueryableExtensions"/>'s methods, so it throws EF
+/// Core's standard "translation failed" <see cref="InvalidOperationException"/> once the query is
+/// executed — the same behavior any other provider-specific query extension exhibits when used
+/// against the wrong provider (e.g. a SQL-Server-only <c>EF.Functions</c> method used with SQLite).
+/// </para>
+/// </remarks>
+public static class CouchbaseQueryableExtensions
+{
+    /// <summary>
+    /// Forces the query planner to use the named secondary index for this keyspace reference,
+    /// instead of letting it choose — N1QL's <c>USE INDEX(name USING GSI|FTS)</c>. Only valid on
+    /// the primary (root) keyspace of a query, not on the right-hand side of a join — use
+    /// <see cref="UseHash{TEntity}"/> for join hints.
+    /// </summary>
+    /// <param name="source">The root queryable for the entity whose keyspace reference is hinted.</param>
+    /// <param name="indexName">
+    /// The index name, or <see langword="null"/> to broaden the hint to "any index of the given
+    /// <paramref name="type"/>" (N1QL's own <c>USE INDEX(USING GSI)</c> form with no name).
+    /// </param>
+    /// <param name="type">The index type — <see cref="CouchbaseIndexType.Gsi"/> by default.</param>
+    public static IQueryable<TEntity> UseIndex<TEntity>(
+        this IQueryable<TEntity> source,
+        [NotParameterized] string? indexName,
+        [NotParameterized] CouchbaseIndexType type = CouchbaseIndexType.Gsi)
+        where TEntity : class
+        => source.Provider is EntityQueryProvider
+            ? source.Provider.CreateQuery<TEntity>(
+                Expression.Call(
+                    null,
+                    UseIndexMethodInfo.MakeGenericMethod(typeof(TEntity)),
+                    source.Expression,
+                    Expression.Constant(indexName, typeof(string)),
+                    Expression.Constant(type)))
+            : source;
+
+    /// <summary>
+    /// Forces a hash-join strategy for this keyspace reference as the right-hand side of a join,
+    /// instead of the default nested-loop join, and picks which side builds the hash table vs.
+    /// probes it — N1QL's <c>USE HASH(BUILD)</c>/<c>USE HASH(PROBE)</c>. Apply this to the inner
+    /// (right-hand) sequence passed to <c>Join</c>/<c>GroupJoin</c>, before the join itself:
+    /// <c>outer.Join(inner.UseHash(CouchbaseHashHintType.Build), ...)</c>.
+    /// </summary>
+    /// <param name="source">The inner (right-hand) queryable of the join being hinted.</param>
+    /// <param name="type">Which side of the hash join this sequence plays.</param>
+    public static IQueryable<TEntity> UseHash<TEntity>(
+        this IQueryable<TEntity> source, [NotParameterized] CouchbaseHashHintType type)
+        where TEntity : class
+        => source.Provider is EntityQueryProvider
+            ? source.Provider.CreateQuery<TEntity>(
+                Expression.Call(
+                    null,
+                    UseHashMethodInfo.MakeGenericMethod(typeof(TEntity)),
+                    source.Expression,
+                    Expression.Constant(type)))
+            : source;
+
+    internal static readonly MethodInfo UseIndexMethodInfo
+        = typeof(CouchbaseQueryableExtensions).GetMethod(nameof(UseIndex))!;
+
+    internal static readonly MethodInfo UseHashMethodInfo
+        = typeof(CouchbaseQueryableExtensions).GetMethod(nameof(UseHash))!;
+}
+
+/* ************************************************************
+ *
+ *    @author Couchbase <info@couchbase.com>
+ *    @copyright 2025 Couchbase, Inc.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ *
+ * ************************************************************/

--- a/src/Couchbase.EntityFrameworkCore/Query/Internal/CouchbaseQueryHintAnnotationNames.cs
+++ b/src/Couchbase.EntityFrameworkCore/Query/Internal/CouchbaseQueryHintAnnotationNames.cs
@@ -1,0 +1,24 @@
+namespace Couchbase.EntityFrameworkCore.Query.Internal;
+
+/// <summary>
+/// Query-tree annotation names used by the <c>UseIndex</c>/<c>UseHash</c> per-query N1QL hint
+/// mechanism (<see cref="Extensions.CouchbaseQueryableExtensions"/>). Shared between
+/// <see cref="CouchbaseQueryableMethodTranslatingExpressionVisitor"/> (which stashes a hint as a
+/// <see cref="Microsoft.EntityFrameworkCore.Query.SqlExpressions.TableExpressionBase"/> annotation
+/// during translation) and <see cref="CouchbaseQuerySqlGenerator"/> (which reads it back to decide
+/// what to render).
+/// </summary>
+internal static class CouchbaseQueryHintAnnotationNames
+{
+    /// <summary>
+    /// A <c>(string? IndexName, Extensions.CouchbaseIndexType Type)</c> tuple recording a
+    /// <c>UseIndex</c> hint for the annotated table.
+    /// </summary>
+    public const string UseIndex = "Couchbase:UseIndex";
+
+    /// <summary>
+    /// A <see cref="Extensions.CouchbaseHashHintType"/> recording a <c>UseHash</c> hint for the
+    /// annotated table.
+    /// </summary>
+    public const string UseHash = "Couchbase:UseHash";
+}

--- a/src/Couchbase.EntityFrameworkCore/Query/Internal/CouchbaseQuerySqlGenerator.cs
+++ b/src/Couchbase.EntityFrameworkCore/Query/Internal/CouchbaseQuerySqlGenerator.cs
@@ -7,6 +7,7 @@ using System.Reflection;
 using System.Reflection.Emit;
 using System.Reflection.Metadata;
 using System.Text;
+using Couchbase.EntityFrameworkCore.Extensions;
 using Couchbase.EntityFrameworkCore.Infrastructure;
 using Couchbase.EntityFrameworkCore.Metadata;
 using Couchbase.EntityFrameworkCore.Query.Internal.Translators;
@@ -1248,7 +1249,69 @@ public class CouchbaseQuerySqlGenerator : QuerySqlGenerator
             .Append(AliasSeparator)
             .Append(Dependencies.SqlGenerationHelper.DelimitIdentifier(tableExpression.Alias));
 
+        AppendUseIndexHint(tableExpression);
+        AppendUseHashHint(tableExpression);
+
         return tableExpression;
+    }
+
+    /// <summary>
+    /// Renders a <c>UseIndex</c> hint (see <see cref="CouchbaseQueryHintAnnotationNames.UseIndex"/>)
+    /// stashed on <paramref name="table"/> as N1QL's <c>USE INDEX(name USING GSI|FTS)</c>, right
+    /// after the table's alias -- the exact placement N1QL requires
+    /// (<see href="https://docs.couchbase.com/server/current/n1ql/n1ql-language-reference/from.html"/>).
+    /// No-op if the table carries no such annotation.
+    /// </summary>
+    private void AppendUseIndexHint(TableExpressionBase table)
+    {
+        // A type pattern like "string indexName" never matches a null first element, so a
+        // no-name hint (legitimate -- broadens to "any index of the given type") would silently
+        // fail to match here and never render. "var" always matches regardless of nullness.
+        if (table.FindAnnotation(CouchbaseQueryHintAnnotationNames.UseIndex)?.Value is not
+            (var indexNameObj, CouchbaseIndexType indexType))
+        {
+            return;
+        }
+
+        var indexName = (string?)indexNameObj;
+        var indexTypeText = indexType switch
+        {
+            CouchbaseIndexType.Gsi => "GSI",
+            CouchbaseIndexType.Fts => "FTS",
+            _ => throw new ArgumentOutOfRangeException(
+                nameof(indexType), indexType, $"Unsupported {nameof(CouchbaseIndexType)} value."),
+        };
+
+        Sql.Append(" USE INDEX(");
+        if (indexName != null)
+        {
+            Sql.Append(Dependencies.SqlGenerationHelper.DelimitIdentifier(indexName)).Append(" ");
+        }
+
+        Sql.Append("USING ").Append(indexTypeText).Append(")");
+    }
+
+    /// <summary>
+    /// Renders a <c>UseHash</c> hint (see <see cref="CouchbaseQueryHintAnnotationNames.UseHash"/>)
+    /// stashed on <paramref name="table"/> as N1QL's <c>USE HASH(BUILD|PROBE)</c>, right after the
+    /// joined table's alias, before the join's <c>ON</c> clause.
+    /// </summary>
+    private void AppendUseHashHint(TableExpressionBase table)
+    {
+        if (table.FindAnnotation(CouchbaseQueryHintAnnotationNames.UseHash)?.Value is not CouchbaseHashHintType hashType)
+        {
+            return;
+        }
+
+        var hashTypeText = hashType switch
+        {
+            CouchbaseHashHintType.Build => "BUILD",
+            CouchbaseHashHintType.Probe => "PROBE",
+            _ => throw new ArgumentOutOfRangeException(
+                nameof(hashType), hashType, $"Unsupported {nameof(CouchbaseHashHintType)} value."),
+        };
+
+        Sql.Append(" USE HASH(").Append(hashTypeText).Append(")");
     }
 
     private static readonly HashSet<string> DateTimeStrFunctionNames =

--- a/src/Couchbase.EntityFrameworkCore/Query/Internal/CouchbaseQueryableMethodTranslatingExpressionVisitor.cs
+++ b/src/Couchbase.EntityFrameworkCore/Query/Internal/CouchbaseQueryableMethodTranslatingExpressionVisitor.cs
@@ -1,4 +1,8 @@
+using System.Diagnostics.CodeAnalysis;
 using System.Linq.Expressions;
+using System.Reflection;
+using Couchbase.EntityFrameworkCore.Extensions;
+using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Query;
 using Microsoft.EntityFrameworkCore.Query.SqlExpressions;
@@ -8,6 +12,9 @@ namespace Couchbase.EntityFrameworkCore.Query.Internal;
 
 public class CouchbaseQueryableMethodTranslatingExpressionVisitor : RelationalQueryableMethodTranslatingExpressionVisitor
 {
+    private static readonly MethodInfo UseIndexMethodInfo = CouchbaseQueryableExtensions.UseIndexMethodInfo;
+    private static readonly MethodInfo UseHashMethodInfo = CouchbaseQueryableExtensions.UseHashMethodInfo;
+
     private readonly IRelationalTypeMappingSource _typeMappingSource;
     private readonly SqlAliasManager _sqlAliasManager;
 
@@ -31,6 +38,174 @@ public class CouchbaseQueryableMethodTranslatingExpressionVisitor : RelationalQu
 
     protected override QueryableMethodTranslatingExpressionVisitor CreateSubqueryVisitor()
         => new CouchbaseQueryableMethodTranslatingExpressionVisitor(this);
+
+    /// <summary>
+    /// Intercepts <see cref="CouchbaseQueryableExtensions.UseIndex{TEntity}"/>/
+    /// <see cref="CouchbaseQueryableExtensions.UseHash{TEntity}"/> calls -- neither is a real LINQ
+    /// operator the base class knows about, so without this override the base implementation would
+    /// throw "translation failed" for any query using them.
+    /// </summary>
+    protected override Expression VisitMethodCall(MethodCallExpression methodCallExpression)
+    {
+        var method = methodCallExpression.Method;
+        if (method.IsGenericMethod && method.DeclaringType == typeof(CouchbaseQueryableExtensions))
+        {
+            var genericMethod = method.GetGenericMethodDefinition();
+            if (genericMethod == UseIndexMethodInfo)
+            {
+                return TranslateUseIndex(methodCallExpression);
+            }
+
+            if (genericMethod == UseHashMethodInfo)
+            {
+                return TranslateUseHash(methodCallExpression);
+            }
+        }
+
+        return base.VisitMethodCall(methodCallExpression);
+    }
+
+    /// <summary>
+    /// Stashes a <c>UseIndex</c> hint as a <see cref="CouchbaseQueryHintAnnotationNames.UseIndex"/>
+    /// annotation on the sole <see cref="TableExpression"/> of the visited source, for
+    /// <see cref="CouchbaseQuerySqlGenerator"/> to render as N1QL's <c>USE INDEX(...)</c>. Only the
+    /// simple "root queryable, nothing composed yet" shape <c>UseIndex</c> is documented to require
+    /// is recognized (see <see cref="IsUnpushedDownTable"/>); anything else silently ignores the
+    /// hint (an optimizer nudge, not a correctness requirement) rather than failing the whole query
+    /// or -- the bug this guard specifically prevents -- silently annotating a table that a later
+    /// pushdown buries inside a subquery, rendering the hint on the wrong FROM term. Chaining
+    /// <c>.UseIndex(...)</c> more than once on the same queryable is last-call-wins -- see
+    /// <see cref="SetHintAnnotation"/>.
+    /// </summary>
+    private Expression TranslateUseIndex(MethodCallExpression methodCallExpression)
+    {
+        var source = Visit(methodCallExpression.Arguments[0]);
+        if (source is ShapedQueryExpression { QueryExpression: SelectExpression selectExpression } shapedQueryExpression
+            && IsUnpushedDownTable(selectExpression, out var table))
+        {
+            var indexName = (string?)((ConstantExpression)methodCallExpression.Arguments[1]).Value;
+            var indexType = (CouchbaseIndexType)((ConstantExpression)methodCallExpression.Arguments[2]).Value!;
+            var annotatedTable = SetHintAnnotation(table, CouchbaseQueryHintAnnotationNames.UseIndex, (indexName, indexType));
+            var newSelectExpression = (SelectExpression)new TableSwapExpressionVisitor(table, annotatedTable).Visit(selectExpression);
+            return shapedQueryExpression.UpdateQueryExpression(newSelectExpression);
+        }
+
+        return source!;
+    }
+
+    /// <summary>
+    /// Stashes a <c>UseHash</c> hint as a <see cref="CouchbaseQueryHintAnnotationNames.UseHash"/>
+    /// annotation on the sole <see cref="TableExpression"/> of the visited source (the join's inner
+    /// sequence, per <c>UseHash</c>'s documented usage), for <see cref="CouchbaseQuerySqlGenerator"/>
+    /// to render as N1QL's <c>USE HASH(BUILD|PROBE)</c> once the base class wraps this table in the
+    /// actual join expression. Same "ignore the hint if the shape doesn't match" fallback (see
+    /// <see cref="IsUnpushedDownTable"/>), and same last-call-wins repeat semantics, as
+    /// <see cref="TranslateUseIndex"/>.
+    /// </summary>
+    private Expression TranslateUseHash(MethodCallExpression methodCallExpression)
+    {
+        var source = Visit(methodCallExpression.Arguments[0]);
+        if (source is ShapedQueryExpression { QueryExpression: SelectExpression selectExpression } shapedQueryExpression
+            && IsUnpushedDownTable(selectExpression, out var table))
+        {
+            var hashType = (CouchbaseHashHintType)((ConstantExpression)methodCallExpression.Arguments[1]).Value!;
+            var annotatedTable = SetHintAnnotation(table, CouchbaseQueryHintAnnotationNames.UseHash, hashType);
+            var newSelectExpression = (SelectExpression)new TableSwapExpressionVisitor(table, annotatedTable).Visit(selectExpression);
+            return shapedQueryExpression.UpdateQueryExpression(newSelectExpression);
+        }
+
+        return source!;
+    }
+
+    /// <summary>
+    /// True if <paramref name="selectExpression"/> is still exactly its bare, single, un-composed
+    /// table -- i.e. annotating that <paramref name="table"/> now is guaranteed to still be
+    /// annotating it once query generation finishes, because nothing about this
+    /// <paramref name="selectExpression"/> will force EF Core to bury it inside a pushed-down
+    /// subquery later. Mirrors, property-for-property, the exact pushdown condition EF Core's own
+    /// <c>SelectExpression.AddJoin</c> uses (<c>innerSelect.Limit != null || innerSelect.Offset !=
+    /// null || innerSelect.IsDistinct || innerSelect.Predicate != null || innerSelect.Tables.Count
+    /// &gt; 1 || innerSelect.GroupBy.Count > 0</c>) when deciding whether a join's inner sequence
+    /// needs subquery pushdown -- not a guess at what "simple" means. Without this check, a hint
+    /// applied to e.g. <c>inner.Where(...).UseHash(...)</c> or <c>inner.Take(1).UseHash(...)</c>
+    /// used as a join's inner sequence would still match a looser "single <see cref="TableExpression"/>"
+    /// pattern and get annotated, but <c>AddJoin</c> then pushes that exact table down into a new
+    /// subquery wrapping it -- leaving the annotation on the table now nested INSIDE that subquery,
+    /// so <see cref="CouchbaseQuerySqlGenerator.VisitTable"/> renders <c>USE HASH(...)</c> on the
+    /// subquery's own inner <c>FROM</c> term instead of on the outer join's keyspace reference,
+    /// producing a misplaced (and likely invalid) hint instead of silently doing nothing.
+    /// </summary>
+    private static bool IsUnpushedDownTable(SelectExpression selectExpression, [NotNullWhen(true)] out TableExpression? table)
+    {
+        if (selectExpression is
+            {
+                Tables: [TableExpression singleTable],
+                Predicate: null,
+                Limit: null,
+                Offset: null,
+                IsDistinct: false,
+                GroupBy.Count: 0,
+            })
+        {
+            table = singleTable;
+            return true;
+        }
+
+        table = null;
+        return false;
+    }
+
+    /// <summary>
+    /// Sets a hint annotation on <paramref name="table"/>, replacing (last-call-wins) whatever value
+    /// it may already carry under <paramref name="name"/>, instead of the
+    /// <see cref="InvalidOperationException"/> (EF Core's internal "duplicate annotation" guard)
+    /// that <see cref="TableExpressionBase.AddAnnotation"/> throws when asked to add a second,
+    /// different value under a name that's already set -- reachable simply by chaining
+    /// <c>.UseIndex("a").UseIndex("b")</c> (or <c>.UseHash(...)</c> twice) on the same queryable.
+    /// A single N1QL keyspace reference can carry only one <c>USE INDEX</c>/<c>USE HASH</c> clause,
+    /// so "the last hint applied wins" is the only sensible repeat semantics -- matching how e.g.
+    /// chaining <c>.OrderBy(...)</c> twice replaces the earlier ordering rather than erroring.
+    /// </summary>
+    private static TableExpression SetHintAnnotation(TableExpression table, string name, object? value)
+    {
+        var existing = table.FindAnnotation(name);
+        if (existing is null || Equals(existing.Value, value))
+        {
+            // AddAnnotation itself already no-ops (returns an equal table) for a repeated,
+            // identical value -- only a genuinely different value needs the rebuild below.
+            return (TableExpression)table.AddAnnotation(name, value);
+        }
+
+        var annotations = new SortedDictionary<string, IAnnotation>(StringComparer.Ordinal);
+        foreach (var annotation in table.GetAnnotations())
+        {
+            if (annotation.Name != name)
+            {
+                annotations[annotation.Name] = annotation;
+            }
+        }
+
+        annotations[name] = new Annotation(name, value);
+
+#pragma warning disable EF1001 // TableExpression's (alias, table, annotations) constructor is an internal API.
+        return new TableExpression(table.Alias, table.Table, annotations);
+#pragma warning restore EF1001
+    }
+
+    /// <summary>
+    /// Replaces a single <see cref="TableExpressionBase"/> reference (by-reference, not by value
+    /// equality) throughout an expression tree. Relies on <see cref="SelectExpression"/>'s own
+    /// <c>VisitChildren</c> to correctly propagate the swap through its <c>Tables</c> list (mutating
+    /// in place while the select is still in its pre-projection-finalization mutable state) -- the
+    /// same mechanism EF Core's own internal rewrite passes (e.g. the nullability processor) use for
+    /// tree-local node replacement, needing no EF1001-marked internal API.
+    /// </summary>
+    private sealed class TableSwapExpressionVisitor(TableExpressionBase oldTable, TableExpressionBase newTable) : ExpressionVisitor
+    {
+        [return: NotNullIfNotNull(nameof(node))]
+        public override Expression? Visit(Expression? node)
+            => ReferenceEquals(node, oldTable) ? newTable : base.Visit(node);
+    }
 
     /// <summary>
     /// Expands a scalar "primitive collection" property (e.g. <c>List&lt;string&gt; Tags</c>

--- a/tests/Couchbase.EntityFrameworkCore.IntegrationTests/Tests/CouchbaseQueryHintTests.cs
+++ b/tests/Couchbase.EntityFrameworkCore.IntegrationTests/Tests/CouchbaseQueryHintTests.cs
@@ -1,0 +1,178 @@
+using Couchbase.EntityFrameworkCode.IntegrationTests.Fixtures;
+using Couchbase.EntityFrameworkCore;
+using Couchbase.EntityFrameworkCore.Extensions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+using Xunit.Abstractions;
+
+namespace Couchbase.EntityFrameworkCode.IntegrationTests.Tests;
+
+/// <summary>
+/// Proves N1QL <c>USE INDEX</c>/<c>USE HASH</c> query hints (<see cref="CouchbaseQueryableExtensions"/>)
+/// actually execute correctly against a real cluster -- these are optimizer nudges that must not
+/// change query results, so the point of these tests is confirming the hint text doesn't break
+/// execution (a N1QL syntax error) and results stay correct, not that the planner honored the hint.
+/// </summary>
+[Collection(CouchbaseTestingCollection.Name)]
+public class CouchbaseQueryHintTests(BloggingFixture fixture, ITestOutputHelper outputHelper)
+{
+    [Fact]
+    public async Task UseIndex_WithRealSecondaryIndex_ExecutesAndReturnsCorrectResults()
+    {
+        var collectionName = "hintidx" + Guid.NewGuid().ToString("N");
+        var optionsBuilder = new DbContextOptionsBuilder<HintIndexDbContext>();
+        optionsBuilder.UseCouchbase(
+            new global::Couchbase.ClusterOptions()
+                .WithConnectionString(fixture.Host)
+                .WithPasswordAuthentication(fixture.Username, fixture.Password),
+            o =>
+            {
+                o.Bucket = fixture.BucketName;
+                o.Scope = fixture.ScopeName;
+                o.AutoCreateIndexes = true;
+                o.ScanConsistency = global::Couchbase.Query.QueryScanConsistency.RequestPlus;
+            });
+        optionsBuilder.ConfigureWarnings(w => w.Ignore(CoreEventId.ManyServiceProvidersCreatedWarning));
+
+        await using var ctx = new HintIndexDbContext(optionsBuilder.Options, collectionName);
+        try
+        {
+            await ctx.Database.EnsureCreatedAsync();
+            ctx.Entities.AddRange(
+                new HintIndexEntity { Id = 1, Score = 10 },
+                new HintIndexEntity { Id = 2, Score = 20 },
+                new HintIndexEntity { Id = 3, Score = 30 });
+            await ctx.SaveChangesAsync();
+
+            await using var readCtx = new HintIndexDbContext(optionsBuilder.Options, collectionName);
+            var sql = readCtx.Entities.UseIndex("ix_hint_score").Where(e => e.Score >= 20).ToQueryString();
+            outputHelper.WriteLine("SQL: " + sql);
+
+            var results = await readCtx.Entities.UseIndex("ix_hint_score").Where(e => e.Score >= 20).OrderBy(e => e.Score).ToListAsync();
+
+            Assert.Equal(2, results.Count);
+            Assert.Equal(20, results[0].Score);
+            Assert.Equal(30, results[1].Score);
+        }
+        finally
+        {
+            await DropCollectionAsync(collectionName);
+        }
+    }
+
+    [Fact]
+    public async Task UseHash_OnJoinInnerSequence_ExecutesAndReturnsCorrectResults()
+    {
+        var collectionName = "hinthash" + Guid.NewGuid().ToString("N");
+        var optionsBuilder = new DbContextOptionsBuilder<HintJoinDbContext>();
+        optionsBuilder.UseCouchbase(
+            new global::Couchbase.ClusterOptions()
+                .WithConnectionString(fixture.Host)
+                .WithPasswordAuthentication(fixture.Username, fixture.Password),
+            o =>
+            {
+                o.Bucket = fixture.BucketName;
+                o.Scope = fixture.ScopeName;
+                o.AutoCreateIndexes = true;
+                o.ScanConsistency = global::Couchbase.Query.QueryScanConsistency.RequestPlus;
+            });
+        optionsBuilder.ConfigureWarnings(w => w.Ignore(CoreEventId.ManyServiceProvidersCreatedWarning));
+
+        await using var ctx = new HintJoinDbContext(optionsBuilder.Options, collectionName);
+        try
+        {
+            await ctx.Database.EnsureCreatedAsync();
+            ctx.Authors.Add(new HintAuthor { Id = 1, Name = "Ada" });
+            ctx.Posts.Add(new HintPost { Id = 1, AuthorId = 1, Title = "Hello" });
+            await ctx.SaveChangesAsync();
+
+            await using var readCtx = new HintJoinDbContext(optionsBuilder.Options, collectionName);
+            var query = readCtx.Posts.Join(
+                readCtx.Authors.UseHash(CouchbaseHashHintType.Build),
+                p => p.AuthorId,
+                a => a.Id,
+                (p, a) => new { p.Title, a.Name });
+
+            outputHelper.WriteLine("SQL: " + query.ToQueryString());
+
+            var results = await query.ToListAsync();
+
+            Assert.Single(results);
+            Assert.Equal("Hello", results[0].Title);
+            Assert.Equal("Ada", results[0].Name);
+        }
+        finally
+        {
+            await DropCollectionAsync(collectionName, collectionName2: "hintauthor" + collectionName);
+        }
+    }
+
+    private async Task DropCollectionAsync(string collectionName, string? collectionName2 = null)
+    {
+        var clusterOptions = new global::Couchbase.ClusterOptions()
+            .WithConnectionString(fixture.Host)
+            .WithCredentials(fixture.Username, fixture.Password);
+        using var cluster = await global::Couchbase.Cluster.ConnectAsync(clusterOptions);
+        var bucket = await cluster.BucketAsync(fixture.BucketName);
+        foreach (var name in new[] { collectionName, collectionName2 })
+        {
+            if (name == null) continue;
+            try
+            {
+                await bucket.Collections.DropCollectionAsync(fixture.ScopeName, name);
+            }
+            catch (global::Couchbase.Management.Collections.CollectionNotFoundException)
+            {
+            }
+        }
+    }
+
+    public class HintIndexEntity
+    {
+        public long Id { get; set; }
+        public double Score { get; set; }
+    }
+
+    public class HintIndexDbContext(DbContextOptions<HintIndexDbContext> options, string collectionName)
+        : DbContext(options)
+    {
+        public DbSet<HintIndexEntity> Entities { get; set; } = null!;
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            base.OnModelCreating(modelBuilder);
+            modelBuilder.Entity<HintIndexEntity>(b =>
+            {
+                b.ToCouchbaseCollection(this, collectionName);
+                b.HasIndex(e => e.Score).HasDatabaseName("ix_hint_score");
+            });
+        }
+    }
+
+    public class HintPost
+    {
+        public long Id { get; set; }
+        public string Title { get; set; } = string.Empty;
+        public long AuthorId { get; set; }
+    }
+
+    public class HintAuthor
+    {
+        public long Id { get; set; }
+        public string Name { get; set; } = string.Empty;
+    }
+
+    public class HintJoinDbContext(DbContextOptions<HintJoinDbContext> options, string collectionName)
+        : DbContext(options)
+    {
+        public DbSet<HintPost> Posts { get; set; } = null!;
+        public DbSet<HintAuthor> Authors { get; set; } = null!;
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            base.OnModelCreating(modelBuilder);
+            modelBuilder.Entity<HintPost>(b => b.ToCouchbaseCollection(this, collectionName));
+            modelBuilder.Entity<HintAuthor>(b => b.ToCouchbaseCollection(this, "hintauthor" + collectionName));
+        }
+    }
+}

--- a/tests/Couchbase.EntityFrameworkCore.UnitTests/Couchbase/EntityFrameworkCore/Query/CouchbaseQueryHintSqlGenerationTests.cs
+++ b/tests/Couchbase.EntityFrameworkCore.UnitTests/Couchbase/EntityFrameworkCore/Query/CouchbaseQueryHintSqlGenerationTests.cs
@@ -1,0 +1,236 @@
+using Couchbase.EntityFrameworkCore.Extensions;
+using Microsoft.EntityFrameworkCore;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Couchbase.EntityFrameworkCore.UnitTests.Couchbase.EntityFrameworkCore.Query;
+
+/// <summary>
+/// Verifies <c>UseIndex</c>/<c>UseHash</c> render as N1QL's <c>USE INDEX(...)</c>/<c>USE HASH(...)</c>
+/// query hints in generated SQL++.
+/// </summary>
+public class CouchbaseQueryHintSqlGenerationTests(ITestOutputHelper output)
+{
+    [Fact]
+    public void UseIndex_WithName_RendersUseIndexUsingGsi()
+    {
+        using var ctx = CreateContext();
+        var sql = ctx.Posts.UseIndex("post_title_idx").ToQueryString();
+        output.WriteLine("SQL: " + sql);
+
+        Assert.Contains("USE INDEX(`post_title_idx` USING GSI)", sql);
+    }
+
+    [Fact]
+    public void UseIndex_WithFtsType_RendersUsingFts()
+    {
+        using var ctx = CreateContext();
+        var sql = ctx.Posts.UseIndex("post_fts_idx", CouchbaseIndexType.Fts).ToQueryString();
+        output.WriteLine("SQL: " + sql);
+
+        Assert.Contains("USE INDEX(`post_fts_idx` USING FTS)", sql);
+    }
+
+    [Fact]
+    public void UseIndex_WithNullName_RendersUsingGsiWithNoName()
+    {
+        using var ctx = CreateContext();
+        var sql = ctx.Posts.UseIndex(null).ToQueryString();
+        output.WriteLine("SQL: " + sql);
+
+        Assert.Contains("USE INDEX(USING GSI)", sql);
+    }
+
+    [Fact]
+    public void UseIndex_ComposedWithWhere_StillRendersHint()
+    {
+        using var ctx = CreateContext();
+        var sql = ctx.Posts.UseIndex("post_title_idx").Where(p => p.Title == "x").ToQueryString();
+        output.WriteLine("SQL: " + sql);
+
+        Assert.Contains("USE INDEX(`post_title_idx` USING GSI)", sql);
+        Assert.Contains("WHERE", sql);
+    }
+
+    [Fact]
+    public void NoHint_DoesNotRenderUseIndex()
+    {
+        using var ctx = CreateContext();
+        var sql = ctx.Posts.ToQueryString();
+
+        Assert.DoesNotContain("USE INDEX", sql);
+    }
+
+    [Fact]
+    public void UseIndex_ChainedWithDifferentValue_LastCallWinsWithoutThrowing()
+    {
+        using var ctx = CreateContext();
+        var sql = ctx.Posts.UseIndex("first_idx").UseIndex("second_idx", CouchbaseIndexType.Fts).ToQueryString();
+        output.WriteLine("SQL: " + sql);
+
+        Assert.Contains("USE INDEX(`second_idx` USING FTS)", sql);
+        Assert.DoesNotContain("first_idx", sql);
+        // Only one USE INDEX clause should appear -- not one per call.
+        Assert.Equal(1, CountOccurrences(sql, "USE INDEX"));
+    }
+
+    [Fact]
+    public void UseIndex_ChainedWithSameValue_DoesNotThrow()
+    {
+        using var ctx = CreateContext();
+        var sql = ctx.Posts.UseIndex("post_title_idx").UseIndex("post_title_idx").ToQueryString();
+        output.WriteLine("SQL: " + sql);
+
+        Assert.Contains("USE INDEX(`post_title_idx` USING GSI)", sql);
+        Assert.Equal(1, CountOccurrences(sql, "USE INDEX"));
+    }
+
+    [Fact]
+    public void UseHash_OnJoinInnerSequence_RendersUseHashBuild()
+    {
+        using var ctx = CreateContext();
+        var query = ctx.Posts.Join(
+            ctx.Authors.UseHash(CouchbaseHashHintType.Build),
+            p => p.AuthorId,
+            a => a.Id,
+            (p, a) => new { p.Title, a.Name });
+        var sql = query.ToQueryString();
+        output.WriteLine("SQL: " + sql);
+
+        Assert.Contains("USE HASH(BUILD)", sql);
+    }
+
+    [Fact]
+    public void UseHash_WithProbe_RendersUseHashProbe()
+    {
+        using var ctx = CreateContext();
+        var query = ctx.Posts.Join(
+            ctx.Authors.UseHash(CouchbaseHashHintType.Probe),
+            p => p.AuthorId,
+            a => a.Id,
+            (p, a) => new { p.Title, a.Name });
+        var sql = query.ToQueryString();
+        output.WriteLine("SQL: " + sql);
+
+        Assert.Contains("USE HASH(PROBE)", sql);
+    }
+
+    [Fact]
+    public void NoHint_JoinDoesNotRenderUseHash()
+    {
+        using var ctx = CreateContext();
+        var query = ctx.Posts.Join(ctx.Authors, p => p.AuthorId, a => a.Id, (p, a) => new { p.Title, a.Name });
+        var sql = query.ToQueryString();
+
+        Assert.DoesNotContain("USE HASH", sql);
+    }
+
+    [Fact]
+    public void UseHash_OnJoinInnerSequenceWithPriorWhere_IgnoresHintRatherThanMisplacingIt()
+    {
+        // A .Where(...) before .UseHash(...) forces EF Core's AddJoin to push the inner sequence's
+        // table down into a subquery once it's used as this join's inner side -- if this were
+        // annotated anyway, the hint would end up rendered on that subquery's own inner FROM term
+        // instead of the outer join's keyspace reference. Confirm it's silently ignored instead.
+        using var ctx = CreateContext();
+        var query = ctx.Posts.Join(
+            ctx.Authors.Where(a => a.Name != "").UseHash(CouchbaseHashHintType.Build),
+            p => p.AuthorId,
+            a => a.Id,
+            (p, a) => new { p.Title, a.Name });
+        var sql = query.ToQueryString();
+        output.WriteLine("SQL: " + sql);
+
+        Assert.DoesNotContain("USE HASH", sql);
+    }
+
+    [Fact]
+    public void UseHash_OnJoinInnerSequenceWithPriorTake_IgnoresHintRatherThanMisplacingIt()
+    {
+        // Same pushdown hazard as the .Where(...) case above, triggered by .Take(...) instead
+        // (EF Core's AddJoin pushes down on Limit/Offset/Distinct/Predicate/GroupBy alike).
+        using var ctx = CreateContext();
+        var query = ctx.Posts.Join(
+            ctx.Authors.Take(1).UseHash(CouchbaseHashHintType.Build),
+            p => p.AuthorId,
+            a => a.Id,
+            (p, a) => new { p.Title, a.Name });
+        var sql = query.ToQueryString();
+        output.WriteLine("SQL: " + sql);
+
+        Assert.DoesNotContain("USE HASH", sql);
+    }
+
+    [Fact]
+    public void UseHash_ChainedWithDifferentValue_LastCallWinsWithoutThrowing()
+    {
+        using var ctx = CreateContext();
+        var query = ctx.Posts.Join(
+            ctx.Authors.UseHash(CouchbaseHashHintType.Build).UseHash(CouchbaseHashHintType.Probe),
+            p => p.AuthorId,
+            a => a.Id,
+            (p, a) => new { p.Title, a.Name });
+        var sql = query.ToQueryString();
+        output.WriteLine("SQL: " + sql);
+
+        Assert.Contains("USE HASH(PROBE)", sql);
+        Assert.DoesNotContain("USE HASH(BUILD)", sql);
+        Assert.Equal(1, CountOccurrences(sql, "USE HASH"));
+    }
+
+    private static int CountOccurrences(string haystack, string needle)
+    {
+        var count = 0;
+        var index = 0;
+        while ((index = haystack.IndexOf(needle, index, StringComparison.Ordinal)) != -1)
+        {
+            count++;
+            index += needle.Length;
+        }
+
+        return count;
+    }
+
+    private static QueryHintContext CreateContext()
+    {
+        var clusterOptions = new ClusterOptions()
+            .WithConnectionString("couchbase://localhost")
+            .WithPasswordAuthentication("Administrator", "password");
+        var builder = new DbContextOptionsBuilder<QueryHintContext>();
+        builder.UseCouchbaseProvider(clusterOptions);
+        return new QueryHintContext(builder.Options);
+    }
+
+    private class Post
+    {
+        public int Id { get; set; }
+        public string Title { get; set; } = string.Empty;
+        public int AuthorId { get; set; }
+    }
+
+    private class Author
+    {
+        public int Id { get; set; }
+        public string Name { get; set; } = string.Empty;
+    }
+
+    private class QueryHintContext(DbContextOptions<QueryHintContext> options) : DbContext(options)
+    {
+        public DbSet<Post> Posts { get; set; } = null!;
+        public DbSet<Author> Authors { get; set; } = null!;
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            modelBuilder.Entity<Post>(b =>
+            {
+                b.ToCouchbaseCollection("bucket", "scope", "hintPost");
+                b.HasKey(p => p.Id);
+            });
+            modelBuilder.Entity<Author>(b =>
+            {
+                b.ToCouchbaseCollection("bucket", "scope", "hintAuthor");
+                b.HasKey(a => a.Id);
+            });
+        }
+    }
+}


### PR DESCRIPTION
Lets callers steer the N1QL query planner via .UseIndex(name, type) and .UseHash(type) on IQueryable<T>, translated through a new VisitMethodCall interception and rendered by the SQL generator on the target table/join.