### PR TITLE
Add per-query read-your-own-writes support via ConsistentWith/Mutatio…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,19 @@ and this project aims to follow [Semantic Versioning](https://semver.org/spec/v2
 
 ### Added
 
+- **Per-query read-your-own-writes (`ConsistentWith`/`MutationState`).** `SaveChangesAsync` now
+  automatically accumulates a `Couchbase.Query.MutationState` on the `DbContext` from every
+  document it writes, retrievable via `context.Database.GetMutationState()`
+  (`CouchbaseDatabaseFacadeExtensions`) and resettable via `context.Database.ClearMutationState()`.
+  A new `IQueryable<TEntity>.ConsistentWith(MutationState)` extension
+  (`CouchbaseQueryableExtensions`) scopes N1QL's `AT_PLUS` scan consistency to that specific set of
+  prior writes for a single query — narrower and cheaper than a context-wide `RequestPlus` when
+  the read-after-write need is "this write I just made," not "the whole collection." Supported
+  across all three query execution paths: LINQ (`.ConsistentWith(...)` composed last —
+  translated via a new shaper-wrapping `CouchbaseConsistentWithMarkerExpression`, since composing
+  any further LINQ operator after it throws `InvalidOperationException` rather than being silently
+  ignored), `FromSqlRaw`/`FromSql`, and raw ADO.NET (`((CouchbaseCommand)connection.CreateCommand()).ConsistentWith = mutationState`).
+  See [Read-your-own-writes](docs/concurrency.md#read-your-own-writes-consistentwith).
 - **`UseIndex`/`UseHash` query hints.** New `IQueryable<T>` extension methods
   (`Couchbase.EntityFrameworkCore.Extensions.CouchbaseQueryableExtensions`) exposing N1QL's
   per-keyspace-reference optimizer hints: `UseIndex(name, CouchbaseIndexType)` forces a specific

--- a/docs/Queries.md
+++ b/docs/Queries.md
@@ -83,6 +83,30 @@ Both are optimizer nudges, not correctness requirements — a query returns iden
 whether or not the hint is honored. Calling either method on a non-Couchbase (e.g. in-memory)
 queryable is a silent, benign no-op.
 
+## Read-your-own-writes (ConsistentWith)
+
+By default, queries use `NotBounded` scan consistency, so a document written a moment ago may not
+yet be visible to a subsequent query (see [Limitations](limitations.md#querying-and-consistency)).
+`.ConsistentWith(mutationState)` scopes a read-after-write guarantee to one query, for a specific
+prior write, instead of switching the whole context to `RequestPlus`:
+
+```
+using Couchbase.EntityFrameworkCore.Extensions;
+
+await context.SaveChangesAsync();
+var mutationState = context.Database.GetMutationState();
+
+// Must be the LAST operator in the chain -- composing anything after it throws.
+var order = await context.Orders
+    .Where(o => o.CustomerName == "Ada")
+    .ConsistentWith(mutationState)
+    .SingleOrDefaultAsync();
+```
+
+Also supported on `FromSqlRaw`/`FromSql` and raw ADO.NET commands. See
+[Read-your-own-writes](concurrency.md#read-your-own-writes-consistentwith) for the full
+explanation, including why the operator must come last.
+
 ## FirstAsync
 
 ```

--- a/docs/concurrency.md
+++ b/docs/concurrency.md
@@ -97,3 +97,68 @@ type throws `InvalidOperationException` at model-build time, and the fluent
 > `Cas`/`Id`/`Type` — only the combination with `Expiration` is affected.
 
 Not supported: `META().xattrs` (extended attributes).
+
+## Read-your-own-writes (`ConsistentWith`)
+
+By default, queries use `NotBounded` scan consistency (see [Limitations — Query scan
+consistency](limitations.md#querying-and-consistency)): a document written a moment ago may not
+yet be visible to a subsequent SQL++ query, because secondary (GSI) indexes update
+asynchronously. Setting `ScanConsistency = RequestPlus` on the options builder fixes this for
+*every* query on that context, but that's an all-or-nothing, context-wide switch — every query
+pays the extra latency of waiting for the index to catch up, even ones that don't need read-your-
+own-writes at all.
+
+`ConsistentWith` scopes that guarantee to a specific write instead: it makes one query (or one
+`FromSqlRaw`/`FromSql`/ADO.NET command) wait only until the index reflects a *specific* prior
+mutation, not the whole collection's latest state. This is EF Core's provider-level surface over
+the Couchbase SDK's own `MutationState`
+([reference](https://docs.couchbase.com/dotnet-sdk/current/concept-docs/durability-replication-failure-considerations.html#at_plus)),
+which the SDK internally represents as a set of `MutationToken`s (one per document write) and
+resolves against by forcing `AT_PLUS` scan consistency.
+
+`SaveChangesAsync` automatically accumulates a `MutationState` on the `DbContext` from every
+document it writes — there's nothing to opt into on the write side:
+
+```
+context.Add(new Order { CustomerName = "Ada" });
+await context.SaveChangesAsync();
+
+var mutationState = context.Database.GetMutationState();
+```
+
+Pass that `MutationState` to `ConsistentWith` on the read side, across any of the three query
+execution paths:
+
+```
+// LINQ -- ConsistentWith must be the LAST operator in the chain (see below).
+var order = await context.Orders
+    .Where(o => o.CustomerName == "Ada")
+    .ConsistentWith(mutationState)
+    .SingleOrDefaultAsync();
+
+// FromSqlRaw / FromSql
+var orders = await context.Orders
+    .FromSqlRaw("SELECT o.* FROM `bucket`.`scope`.`orders` AS o WHERE o.customerName = {0}", "Ada")
+    .ConsistentWith(mutationState)
+    .ToListAsync();
+
+// Raw ADO.NET
+using var command = (CouchbaseCommand)connection.CreateCommand();
+command.ConsistentWith = mutationState;
+command.CommandText = "SELECT o.* FROM `bucket`.`scope`.`orders` AS o WHERE o.customerName = $name";
+```
+
+`context.Database.ClearMutationState()` resets the accumulated state (e.g. between logically
+unrelated units of work sharing one long-lived context).
+
+> [!WARNING]
+> On the LINQ path, `ConsistentWith(...)` must be the **last** operator in the query — composing
+> any further LINQ operator after it (`.Where(...)`, `.OrderBy(...)`, another `.Select(...)`, etc.)
+> throws `InvalidOperationException` at query-translation time (a clear, immediate failure, not a
+> silently-ignored hint). Apply every other operator first, then call `.ConsistentWith(...)` last:
+> `context.Orders.Where(...).OrderBy(...).ConsistentWith(mutationState)`, not the reverse.
+
+`MutationState` only ever grows narrower guarantees than `RequestPlus` — it says "wait for *these*
+writes to be indexed," not "wait for the whole collection to be caught up" — so prefer it over a
+context-wide `RequestPlus` whenever the read-after-write need is scoped to a specific prior write
+rather than the collection as a whole.

--- a/docs/limitations.md
+++ b/docs/limitations.md
@@ -67,7 +67,10 @@ The Couchbase SDK is asynchronous, so the synchronous EF Core code paths throw `
   });
   ```
 
-  Stronger consistency increases query latency, so it is opt-in rather than the default.
+  Stronger consistency increases query latency, so it is opt-in rather than the default. For
+  read-after-write consistency scoped to a *specific* prior write rather than the whole
+  collection, use `ConsistentWith`/`GetMutationState()` instead — see
+  [Read-your-own-writes](concurrency.md#read-your-own-writes-consistentwith).
 * **Nested data must be modeled as owned types.** Nested objects and collections are
   persisted and queried only when configured as EF Core owned types (`OwnsOne` /
   `OwnsMany`) or as related entities. Plain CLR objects nested on an entity that are

--- a/src/Couchbase.EntityFrameworkCore/CompatibilitySuppressions.xml
+++ b/src/Couchbase.EntityFrameworkCore/CompatibilitySuppressions.xml
@@ -17,6 +17,20 @@
   </Suppression>
   <Suppression>
     <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:Couchbase.EntityFrameworkCore.Query.Internal.CouchbaseFromSqlQueryingEnumerable.Create``1(Microsoft.EntityFrameworkCore.Query.RelationalQueryContext,Microsoft.EntityFrameworkCore.Query.Internal.RelationalCommandResolver,System.Collections.Generic.IReadOnlyList{Microsoft.EntityFrameworkCore.Storage.ReaderColumn},System.Collections.Generic.IReadOnlyList{System.String},System.Func{Microsoft.EntityFrameworkCore.Query.QueryContext,System.Data.Common.DbDataReader,System.Int32[],``0},System.Type,System.Boolean,System.Boolean,System.Boolean,Couchbase.Extensions.DependencyInjection.IBucketProvider,Couchbase.EntityFrameworkCore.Infrastructure.ICouchbaseDbContextOptionsBuilder)</Target>
+    <Left>lib/net10.0/Couchbase.EntityFrameworkCore.dll</Left>
+    <Right>lib/net10.0/Couchbase.EntityFrameworkCore.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:Couchbase.EntityFrameworkCore.Query.Internal.CouchbaseFromSqlQueryingEnumerable`1.#ctor(Microsoft.EntityFrameworkCore.Query.RelationalQueryContext,Microsoft.EntityFrameworkCore.Query.Internal.RelationalCommandResolver,System.Collections.Generic.IReadOnlyList{Microsoft.EntityFrameworkCore.Storage.ReaderColumn},System.Collections.Generic.IReadOnlyList{System.String},System.Func{Microsoft.EntityFrameworkCore.Query.QueryContext,System.Data.Common.DbDataReader,System.Int32[],`0},System.Type,System.Boolean,System.Boolean,System.Boolean,Couchbase.Extensions.DependencyInjection.IBucketProvider,Couchbase.EntityFrameworkCore.Infrastructure.ICouchbaseDbContextOptionsBuilder)</Target>
+    <Left>lib/net10.0/Couchbase.EntityFrameworkCore.dll</Left>
+    <Right>lib/net10.0/Couchbase.EntityFrameworkCore.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
     <Target>M:Couchbase.EntityFrameworkCore.Storage.Internal.CouchbaseClientWrapper.CreateDocument``1(System.String,System.String,``0)</Target>
     <Left>lib/net10.0/Couchbase.EntityFrameworkCore.dll</Left>
     <Right>lib/net10.0/Couchbase.EntityFrameworkCore.dll</Right>

--- a/src/Couchbase.EntityFrameworkCore/Extensions/CouchbaseDatabaseFacadeExtensions.cs
+++ b/src/Couchbase.EntityFrameworkCore/Extensions/CouchbaseDatabaseFacadeExtensions.cs
@@ -2,6 +2,7 @@ using System.Data;
 using Couchbase.EntityFrameworkCore.Storage.Internal;
 using Couchbase.Extensions.DependencyInjection;
 using Couchbase.KeyValue;
+using Couchbase.Query;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Storage;
@@ -149,6 +150,29 @@ public static class CouchbaseDatabaseFacadeExtensions
             await couchbaseClient.Buckets.FlushBucketAsync(bucketName.ToString()!).ConfigureAwait(false);
         }
     }
+
+    /// <summary>
+    /// Returns a <see cref="MutationState"/> reflecting every write made through this
+    /// <see cref="DbContext"/> so far (across every <c>SaveChangesAsync</c> call, not just the most
+    /// recent one), for use with
+    /// <see cref="Couchbase.EntityFrameworkCore.Extensions.CouchbaseQueryableExtensions.ConsistentWith{TEntity}"/>
+    /// to guarantee a subsequent query sees those exact writes (read-your-own-writes / RYOW).
+    /// </summary>
+    /// <remarks>
+    /// Deleted documents do not contribute to this state -- see
+    /// <see cref="ICouchbaseClientWrapper.DeleteDocument"/>'s remarks for why (a Couchbase SDK
+    /// limitation, not a gap in this provider). Call <see cref="ClearMutationState"/> to reset
+    /// accumulation, e.g. to bound growth in a long-lived context.
+    /// </remarks>
+    public static MutationState GetMutationState(this DatabaseFacade databaseFacade)
+        => databaseFacade.GetService<CouchbaseMutationStateTracker>().GetMutationState();
+
+    /// <summary>
+    /// Discards every write recorded so far by <see cref="GetMutationState"/>, so the next call
+    /// reflects only writes made afterward.
+    /// </summary>
+    public static void ClearMutationState(this DatabaseFacade databaseFacade)
+        => databaseFacade.GetService<CouchbaseMutationStateTracker>().Clear();
 
     /// <summary>
     /// Gets the number of operations committed in a Couchbase transaction.

--- a/src/Couchbase.EntityFrameworkCore/Extensions/CouchbaseQueryableExtensions.cs
+++ b/src/Couchbase.EntityFrameworkCore/Extensions/CouchbaseQueryableExtensions.cs
@@ -1,5 +1,6 @@
 using System.Linq.Expressions;
 using System.Reflection;
+using Couchbase.Query;
 using Microsoft.EntityFrameworkCore.Query;
 using Microsoft.EntityFrameworkCore.Query.Internal;
 
@@ -108,11 +109,65 @@ public static class CouchbaseQueryableExtensions
                     Expression.Constant(type)))
             : source;
 
+    /// <summary>
+    /// Constrains this query to a snapshot at least as recent as every write recorded in
+    /// <paramref name="mutationState"/> — N1QL's <c>AtPlus</c> scan consistency, driven by a
+    /// <see cref="MutationState"/> built from prior writes' <c>MutationToken</c>s (see
+    /// <see cref="Couchbase.EntityFrameworkCore.Extensions.CouchbaseDatabaseFacadeExtensions.GetMutationState"/>
+    /// for the common case of "see my own recent writes through this <c>DbContext</c>" --
+    /// read-your-own-writes / RYOW). A <see langword="null"/> <paramref name="mutationState"/>
+    /// leaves the query's consistency at whatever the context-wide
+    /// <see cref="Couchbase.EntityFrameworkCore.Infrastructure.CouchbaseDbContextOptionsBuilder.ScanConsistency"/>
+    /// setting already provides.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Unlike <see cref="UseIndex{TEntity}"/>/<see cref="UseHash{TEntity}"/>, <paramref name="mutationState"/>
+    /// is deliberately NOT marked <see cref="NotParameterizedAttribute"/> -- it must flow through EF
+    /// Core's normal parameter extraction into a genuine query parameter, refreshed on every
+    /// execution of a cached compiled query, rather than being baked into the query's cached SQL
+    /// plan the way a <c>UseIndex</c>/<c>UseHash</c> hint safely can be. A <see cref="MutationState"/>
+    /// is inherently per-call and would silently go stale if treated as a plan-level constant.
+    /// </para>
+    /// <para>
+    /// Apply this as the LAST operator before enumeration (immediately before
+    /// <c>ToListAsync()</c>/<c>FirstOrDefaultAsync()</c>/etc.), after any <c>.Where()</c>/<c>.OrderBy()</c>/
+    /// <c>.Select()</c>. This is enforced by construction, not just convention: internally, this
+    /// method wraps the query's shaper (materialization) expression in a marker that carries the
+    /// <paramref name="mutationState"/> parameter's name forward to execution time, and composing
+    /// ANY further operator afterward that needs to re-inspect that shaper's shape --
+    /// <c>.Where()</c>, <c>.OrderBy()</c>, <c>.Select()</c>, or anything else -- fails with EF
+    /// Core's standard "could not be translated" <see cref="InvalidOperationException"/> (confirmed
+    /// by a regression test), rather than silently ignoring the hint or misapplying it. This is a
+    /// deliberately loud failure mode for what is a correctness-affecting option, not merely an
+    /// optimizer nudge the way <c>UseIndex</c>/<c>UseHash</c> are.
+    /// </para>
+    /// </remarks>
+    /// <param name="source">The query to constrain.</param>
+    /// <param name="mutationState">
+    /// The mutations this query must be consistent with, or <see langword="null"/> for no
+    /// per-query constraint.
+    /// </param>
+    public static IQueryable<TEntity> ConsistentWith<TEntity>(
+        this IQueryable<TEntity> source, MutationState? mutationState)
+        where TEntity : class
+        => source.Provider is EntityQueryProvider
+            ? source.Provider.CreateQuery<TEntity>(
+                Expression.Call(
+                    null,
+                    ConsistentWithMethodInfo.MakeGenericMethod(typeof(TEntity)),
+                    source.Expression,
+                    Expression.Constant(mutationState, typeof(MutationState))))
+            : source;
+
     internal static readonly MethodInfo UseIndexMethodInfo
         = typeof(CouchbaseQueryableExtensions).GetMethod(nameof(UseIndex))!;
 
     internal static readonly MethodInfo UseHashMethodInfo
         = typeof(CouchbaseQueryableExtensions).GetMethod(nameof(UseHash))!;
+
+    internal static readonly MethodInfo ConsistentWithMethodInfo
+        = typeof(CouchbaseQueryableExtensions).GetMethod(nameof(ConsistentWith))!;
 }
 
 /* ************************************************************

--- a/src/Couchbase.EntityFrameworkCore/Extensions/CouchbaseServiceCollectionExtensions.cs
+++ b/src/Couchbase.EntityFrameworkCore/Extensions/CouchbaseServiceCollectionExtensions.cs
@@ -98,6 +98,9 @@ public static class CouchbaseServiceCollectionExtensions
                 .TryAddScoped<IRelationalCommandBuilder, RelationalCommandBuilder>()
                 .TryAddScoped<ICouchbaseDbContextOptionsBuilder,
                     CouchbaseDbContextOptionsBuilder>(b=>optionsExtension.DbContextOptionsBuilder)
+                // Accumulates this DbContext's own write results into a MutationState for
+                // read-your-own-writes (ConsistentWith) queries -- see its own doc comments.
+                .TryAddScoped<CouchbaseMutationStateTracker, CouchbaseMutationStateTracker>()
             );
 
         builder.TryAddCoreServices();

--- a/src/Couchbase.EntityFrameworkCore/Query/Internal/CouchbaseConsistentWithMarkerExpression.cs
+++ b/src/Couchbase.EntityFrameworkCore/Query/Internal/CouchbaseConsistentWithMarkerExpression.cs
@@ -1,0 +1,69 @@
+using System.Linq.Expressions;
+
+namespace Couchbase.EntityFrameworkCore.Query.Internal;
+
+/// <summary>
+/// Wraps a <see cref="Microsoft.EntityFrameworkCore.Query.ShapedQueryExpression.ShaperExpression"/>
+/// to carry a <c>ConsistentWith</c> call's generated query-parameter name from
+/// <see cref="CouchbaseQueryableMethodTranslatingExpressionVisitor"/> (which creates it) to
+/// <see cref="CouchbaseShapedQueryCompilingExpressionVisitor"/> (which strips it back off, as the
+/// very first thing it does, before any of its own shaper-shape checks run).
+/// </summary>
+/// <remarks>
+/// Chosen over annotating the <see cref="Microsoft.EntityFrameworkCore.Query.SqlExpressions.SelectExpression"/>
+/// itself (the way <c>UseIndex</c>/<c>UseHash</c> annotate a child
+/// <see cref="Microsoft.EntityFrameworkCore.Query.SqlExpressions.TableExpression"/>) because
+/// <c>SelectExpression</c>'s own <c>WithAnnotations</c> override is unimplemented in EF Core 10 --
+/// it throws <see cref="System.Diagnostics.UnreachableException"/> unconditionally (confirmed
+/// empirically: a unit test hit this exact throw before this design was adopted). Wrapping the
+/// shaper instead needs no annotation support at all -- it only relies on
+/// <see cref="Microsoft.EntityFrameworkCore.Query.ShapedQueryExpression.UpdateShaperExpression"/>,
+/// a plain, fully-supported public API.
+/// <para>
+/// This also enforces the "apply last" requirement documented on
+/// <see cref="Extensions.CouchbaseQueryableExtensions.ConsistentWith{TEntity}"/> -- but by throwing,
+/// not by silently dropping the hint (confirmed by a regression test, correcting an earlier,
+/// untested assumption). In practice this means <c>.ConsistentWith(...)</c> must be the LAST
+/// operator applied: even operators like <c>.Where()</c>/<c>.OrderBy()</c>, which only need the
+/// <c>QueryExpression</c> conceptually, still bind their lambda parameter against the shaper's
+/// shape as part of translation -- and since this wrapper isn't a shape any base-class translation
+/// logic recognizes, that binding fails with EF Core's own "could not be translated"
+/// <see cref="InvalidOperationException"/>. There is no known operator that composes cleanly on
+/// top of this wrapper; treat <c>.ConsistentWith(...)</c> as a terminal call in the query.
+/// </para>
+/// </remarks>
+internal sealed class CouchbaseConsistentWithMarkerExpression(Expression inner, string parameterName) : Expression
+{
+    public Expression Inner { get; } = inner;
+
+    public string ParameterName { get; } = parameterName;
+
+    public override Type Type => Inner.Type;
+
+    public override ExpressionType NodeType => ExpressionType.Extension;
+
+    protected override Expression VisitChildren(ExpressionVisitor visitor)
+    {
+        var visitedInner = visitor.Visit(Inner);
+        return visitedInner == Inner ? this : new CouchbaseConsistentWithMarkerExpression(visitedInner, ParameterName);
+    }
+}
+
+/* ************************************************************
+ *
+ *    @author Couchbase <info@couchbase.com>
+ *    @copyright 2025 Couchbase, Inc.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ *
+ * ************************************************************/

--- a/src/Couchbase.EntityFrameworkCore/Query/Internal/CouchbaseFromSqlQueryingEnumerable.cs
+++ b/src/Couchbase.EntityFrameworkCore/Query/Internal/CouchbaseFromSqlQueryingEnumerable.cs
@@ -29,7 +29,8 @@ public static class CouchbaseFromSqlQueryingEnumerable
         bool detailedErrorsEnabled,
         bool threadSafetyChecksEnabled,
         IBucketProvider bucketProvider,
-        ICouchbaseDbContextOptionsBuilder couchbaseDbContextOptionsBuilder)
+        ICouchbaseDbContextOptionsBuilder couchbaseDbContextOptionsBuilder,
+        string? consistentWithParameterName)
         => new(
             relationalQueryContext,
             relationalCommandResolver,
@@ -41,7 +42,8 @@ public static class CouchbaseFromSqlQueryingEnumerable
             detailedErrorsEnabled,
             threadSafetyChecksEnabled,
             bucketProvider,
-            couchbaseDbContextOptionsBuilder);
+            couchbaseDbContextOptionsBuilder,
+            consistentWithParameterName);
 }
 
 
@@ -60,6 +62,8 @@ public class CouchbaseFromSqlQueryingEnumerable<T> : IEnumerable<T>, IAsyncEnume
     private readonly IDiagnosticsLogger<DbLoggerCategory.Query> _queryLogger;
     private readonly bool _detailedErrorsEnabled;
     private readonly bool _threadSafetyChecksEnabled;
+    // See CouchbaseQueryEnumerable<T>'s identical field for what this is.
+    private readonly string? _consistentWithParameterName;
 
     public CouchbaseFromSqlQueryingEnumerable(
         RelationalQueryContext relationalQueryContext,
@@ -72,9 +76,10 @@ public class CouchbaseFromSqlQueryingEnumerable<T> : IEnumerable<T>, IAsyncEnume
         bool detailedErrorsEnabled,
         bool threadSafetyChecksEnabled,
         IBucketProvider bucketProvider,
-        ICouchbaseDbContextOptionsBuilder couchbaseDbContextOptionsBuilder)
+        ICouchbaseDbContextOptionsBuilder couchbaseDbContextOptionsBuilder,
+        string? consistentWithParameterName)
     {
-
+        _consistentWithParameterName = consistentWithParameterName;
         _relationalQueryContext = relationalQueryContext;
         _relationalCommandResolver = relationalCommandResolver;
         _readerColumns = readerColumns;
@@ -146,13 +151,22 @@ public class CouchbaseFromSqlQueryingEnumerable<T> : IEnumerable<T>, IAsyncEnume
         }
     }
     
-    private QueryOptions GetParameters(DbCommand command)
+    internal QueryOptions GetParameters(DbCommand command)
     {
         var queryOptions = new QueryOptions();
         queryOptions.ScanConsistency(_couchbaseDbContextOptionsBuilder.ScanConsistency);
         foreach (CouchbaseParameter parameter in command.Parameters)
         {
             queryOptions.Parameter(parameter.ParameterName, parameter.Value!);
+        }
+
+        // See CouchbaseQueryEnumerable<T>.GetParameters' identical block for why this is looked up
+        // fresh here rather than baked in at compile time.
+        if (_consistentWithParameterName != null
+            && _relationalQueryContext.Parameters.TryGetValue(_consistentWithParameterName, out var consistentWithValue)
+            && consistentWithValue is MutationState mutationState)
+        {
+            queryOptions.ConsistentWith(mutationState);
         }
 
         return queryOptions;

--- a/src/Couchbase.EntityFrameworkCore/Query/Internal/CouchbaseQueryEnumerable.cs
+++ b/src/Couchbase.EntityFrameworkCore/Query/Internal/CouchbaseQueryEnumerable.cs
@@ -36,7 +36,8 @@ public static class CouchbaseQueryEnumerable
         bool detailedErrorsEnabled,
         bool threadSafetyChecksEnabled,
         IBucketProvider bucketProvider,
-        ICouchbaseDbContextOptionsBuilder couchbaseDbContextOptionsBuilder)
+        ICouchbaseDbContextOptionsBuilder couchbaseDbContextOptionsBuilder,
+        string? consistentWithParameterName)
         => new(
             relationalQueryContext,
             relationalCommandResolver,
@@ -51,7 +52,8 @@ public static class CouchbaseQueryEnumerable
             detailedErrorsEnabled,
             threadSafetyChecksEnabled,
             bucketProvider,
-            couchbaseDbContextOptionsBuilder);
+            couchbaseDbContextOptionsBuilder,
+            consistentWithParameterName);
 }
 
 public class CouchbaseQueryEnumerable<T> : IEnumerable<T>, IAsyncEnumerable<T>, IRelationalQueryingEnumerable
@@ -86,6 +88,10 @@ public class CouchbaseQueryEnumerable<T> : IEnumerable<T>, IAsyncEnumerable<T>, 
     private readonly Dictionary<string, string> _ownedNavigationAliases;
     private readonly CouchbaseOwnedCollectionMaterializer _materializer = new();
     private readonly CouchbaseCollectionSnapshot _snapshot = new();
+    // The generated query-parameter name holding a .ConsistentWith(...) MutationState, if this
+    // compiled query used it -- see CouchbaseQueryHintAnnotationNames.ConsistentWith's doc comment.
+    // Null for every query that doesn't call .ConsistentWith().
+    private readonly string? _consistentWithParameterName;
 
     public CouchbaseQueryEnumerable(
         RelationalQueryContext relationalQueryContext,
@@ -101,8 +107,10 @@ public class CouchbaseQueryEnumerable<T> : IEnumerable<T>, IAsyncEnumerable<T>, 
         bool detailedErrorsEnabled,
         bool threadSafetyChecksEnabled,
         IBucketProvider bucketProvider,
-        ICouchbaseDbContextOptionsBuilder couchbaseDbContextOptionsBuilder)
+        ICouchbaseDbContextOptionsBuilder couchbaseDbContextOptionsBuilder,
+        string? consistentWithParameterName)
     {
+        _consistentWithParameterName = consistentWithParameterName;
         _relationalQueryContext = relationalQueryContext;
         _relationalCommandResolver = relationalCommandResolver;
         _readerColumns = readerColumns;
@@ -406,13 +414,25 @@ public class CouchbaseQueryEnumerable<T> : IEnumerable<T>, IAsyncEnumerable<T>, 
                 Guid.Empty,
                 (DbCommandMethod)(-1));
 
-    private QueryOptions GetParameters(DbCommand command)
+    internal QueryOptions GetParameters(DbCommand command)
     {
         var queryOptions = new QueryOptions();
         queryOptions.ScanConsistency(_couchbaseDbContextOptionsBuilder.ScanConsistency);
         foreach (CouchbaseParameter parameter in command.Parameters)
         {
             queryOptions.Parameter(parameter.ParameterName, parameter.Value!);
+        }
+
+        // .ConsistentWith(...)'s value is looked up fresh here, from THIS execution's
+        // QueryContext.Parameters, rather than baked in at compile time -- see
+        // CouchbaseQueryHintAnnotationNames.ConsistentWith's doc comment for why. Overrides the
+        // ScanConsistency call above to AtPlus internally (the SDK's own QueryOptions.ConsistentWith
+        // behavior) only when a non-null MutationState was actually supplied.
+        if (_consistentWithParameterName != null
+            && _relationalQueryContext.Parameters.TryGetValue(_consistentWithParameterName, out var consistentWithValue)
+            && consistentWithValue is MutationState mutationState)
+        {
+            queryOptions.ConsistentWith(mutationState);
         }
 
         return queryOptions;

--- a/src/Couchbase.EntityFrameworkCore/Query/Internal/CouchbaseQueryHintAnnotationNames.cs
+++ b/src/Couchbase.EntityFrameworkCore/Query/Internal/CouchbaseQueryHintAnnotationNames.cs
@@ -6,7 +6,10 @@ namespace Couchbase.EntityFrameworkCore.Query.Internal;
 /// <see cref="CouchbaseQueryableMethodTranslatingExpressionVisitor"/> (which stashes a hint as a
 /// <see cref="Microsoft.EntityFrameworkCore.Query.SqlExpressions.TableExpressionBase"/> annotation
 /// during translation) and <see cref="CouchbaseQuerySqlGenerator"/> (which reads it back to decide
-/// what to render).
+/// what to render). <c>ConsistentWith</c> does NOT use this mechanism -- see
+/// <see cref="CouchbaseConsistentWithMarkerExpression"/> for why (this class's own
+/// <see cref="Microsoft.EntityFrameworkCore.Query.SqlExpressions.SelectExpression"/> annotation
+/// support turned out to be unimplemented in EF Core 10) and what it uses instead.
 /// </summary>
 internal static class CouchbaseQueryHintAnnotationNames
 {

--- a/src/Couchbase.EntityFrameworkCore/Query/Internal/CouchbaseQueryableMethodTranslatingExpressionVisitor.cs
+++ b/src/Couchbase.EntityFrameworkCore/Query/Internal/CouchbaseQueryableMethodTranslatingExpressionVisitor.cs
@@ -14,6 +14,7 @@ public class CouchbaseQueryableMethodTranslatingExpressionVisitor : RelationalQu
 {
     private static readonly MethodInfo UseIndexMethodInfo = CouchbaseQueryableExtensions.UseIndexMethodInfo;
     private static readonly MethodInfo UseHashMethodInfo = CouchbaseQueryableExtensions.UseHashMethodInfo;
+    private static readonly MethodInfo ConsistentWithMethodInfo = CouchbaseQueryableExtensions.ConsistentWithMethodInfo;
 
     private readonly IRelationalTypeMappingSource _typeMappingSource;
     private readonly SqlAliasManager _sqlAliasManager;
@@ -59,6 +60,11 @@ public class CouchbaseQueryableMethodTranslatingExpressionVisitor : RelationalQu
             if (genericMethod == UseHashMethodInfo)
             {
                 return TranslateUseHash(methodCallExpression);
+            }
+
+            if (genericMethod == ConsistentWithMethodInfo)
+            {
+                return TranslateConsistentWith(methodCallExpression);
             }
         }
 
@@ -112,6 +118,40 @@ public class CouchbaseQueryableMethodTranslatingExpressionVisitor : RelationalQu
             var annotatedTable = SetHintAnnotation(table, CouchbaseQueryHintAnnotationNames.UseHash, hashType);
             var newSelectExpression = (SelectExpression)new TableSwapExpressionVisitor(table, annotatedTable).Visit(selectExpression);
             return shapedQueryExpression.UpdateQueryExpression(newSelectExpression);
+        }
+
+        return source!;
+    }
+
+    /// <summary>
+    /// Wraps a <c>ConsistentWith</c> call's source shaper expression in a
+    /// <see cref="CouchbaseConsistentWithMarkerExpression"/> carrying the generated query-parameter
+    /// name, for <see cref="CouchbaseShapedQueryCompilingExpressionVisitor"/> to strip back off
+    /// (as the very first thing it does) once translation finishes, threading the name into
+    /// <see cref="CouchbaseQueryEnumerable{T}"/>'s execution-time <c>QueryOptions</c> construction.
+    /// See <see cref="CouchbaseConsistentWithMarkerExpression"/>'s own doc comments for why this
+    /// shaper-wrapping design replaced an earlier attempt to annotate the root
+    /// <see cref="SelectExpression"/> the way <see cref="TranslateUseIndex"/>/<see cref="TranslateUseHash"/>
+    /// annotate a child <see cref="TableExpression"/> -- <c>SelectExpression.WithAnnotations</c> is
+    /// unimplemented in EF Core 10 and throws unconditionally, confirmed by a failing unit test
+    /// before this design was adopted.
+    /// <para>
+    /// <paramref name="methodCallExpression"/>'s <c>MutationState</c> argument is deliberately NOT
+    /// <see cref="NotParameterizedAttribute"/> (see
+    /// <see cref="CouchbaseQueryableExtensions.ConsistentWith{TEntity}"/>'s remarks), so by this
+    /// point it has already been rewritten into a <see cref="QueryParameterExpression"/> by EF
+    /// Core's own parameter extraction -- this method only needs to capture that parameter's NAME,
+    /// never its value.
+    /// </para>
+    /// </summary>
+    private Expression TranslateConsistentWith(MethodCallExpression methodCallExpression)
+    {
+        var source = Visit(methodCallExpression.Arguments[0]);
+        if (source is ShapedQueryExpression shapedQueryExpression
+            && methodCallExpression.Arguments[1] is QueryParameterExpression { Name: var parameterName })
+        {
+            var markerShaper = new CouchbaseConsistentWithMarkerExpression(shapedQueryExpression.ShaperExpression, parameterName);
+            return shapedQueryExpression.UpdateShaperExpression(markerShaper);
         }
 
         return source!;

--- a/src/Couchbase.EntityFrameworkCore/Query/Internal/CouchbaseShapedQueryCompilingExpressionVisitor.cs
+++ b/src/Couchbase.EntityFrameworkCore/Query/Internal/CouchbaseShapedQueryCompilingExpressionVisitor.cs
@@ -122,6 +122,19 @@ public class CouchbaseShapedQueryCompilingExpressionVisitor : RelationalShapedQu
     [Experimental("EF9100")]
     protected override Expression VisitShapedQuery(ShapedQueryExpression shapedQueryExpression)
     {
+        // Strip a .ConsistentWith(...) marker off the shaper, if present, before any of the
+        // shaper-shape checks below run -- they all pattern-match specific shapes
+        // (RelationalGroupByResultExpression, IncludeExpression chains, ...) that the marker would
+        // otherwise hide. Null if .ConsistentWith(...) was never called, or was called but a later
+        // operator replaced the shaper wholesale (e.g. .Select(...)) and silently dropped it -- see
+        // CouchbaseConsistentWithMarkerExpression's own doc comments.
+        string? consistentWithParameterName = null;
+        if (shapedQueryExpression.ShaperExpression is CouchbaseConsistentWithMarkerExpression consistentWithMarker)
+        {
+            consistentWithParameterName = consistentWithMarker.ParameterName;
+            shapedQueryExpression = shapedQueryExpression.UpdateShaperExpression(consistentWithMarker.Inner);
+        }
+
         CollectNavigationIncludes(shapedQueryExpression.ShaperExpression);
 
         var selectExpression = (SelectExpression)shapedQueryExpression.QueryExpression;
@@ -195,6 +208,8 @@ public class CouchbaseShapedQueryCompilingExpressionVisitor : RelationalShapedQu
             }
 
             var readerColumnsExpression = CreateReaderColumnsExpression(readerColumns, Dependencies.LiftableConstantFactory);
+            var consistentWithParameterNameExpression = Expression.Constant(consistentWithParameterName, typeof(string));
+
             if (nonComposedFromSql)
             {
                 return Expression.Call(
@@ -221,7 +236,8 @@ public class CouchbaseShapedQueryCompilingExpressionVisitor : RelationalShapedQu
                     Expression.Constant(_detailedErrorsEnabled),
                     Expression.Constant(_threadSafetyChecksEnabled),
                     Expression.Constant(_bucketProvider),
-                    Expression.Constant(_couchbaseDbContextOptionsBuilder));
+                    Expression.Constant(_couchbaseDbContextOptionsBuilder),
+                    consistentWithParameterNameExpression);
             }
 
             // Add OwnsMany/OwnsOne navigation columns to the SELECT projection using the IR so
@@ -276,7 +292,8 @@ public class CouchbaseShapedQueryCompilingExpressionVisitor : RelationalShapedQu
                 Expression.Constant(_detailedErrorsEnabled),
                 Expression.Constant(_threadSafetyChecksEnabled),
                 Expression.Constant(_bucketProvider),
-                Expression.Constant(_couchbaseDbContextOptionsBuilder));
+                Expression.Constant(_couchbaseDbContextOptionsBuilder),
+                consistentWithParameterNameExpression);
         }
     }
 

--- a/src/Couchbase.EntityFrameworkCore/Storage/Internal/CouchbaseClientWrapper.cs
+++ b/src/Couchbase.EntityFrameworkCore/Storage/Internal/CouchbaseClientWrapper.cs
@@ -65,13 +65,12 @@ public class CouchbaseClientWrapper : ICouchbaseClientWrapper
         }
     }
 
-    public async Task<ulong> CreateDocument<TEntity>(string id, string keyspace, TEntity entity, CancellationToken cancellationToken = default)
+    public async Task<IMutationResult> CreateDocument<TEntity>(string id, string keyspace, TEntity entity, CancellationToken cancellationToken = default)
     {
         try
         {
             var collection = await GetCollection(keyspace, cancellationToken).ConfigureAwait(false);
-            var result = await collection.InsertAsync(id, entity, new InsertOptions().CancellationToken(cancellationToken)).ConfigureAwait(false);
-            return result.Cas;
+            return await collection.InsertAsync(id, entity, new InsertOptions().CancellationToken(cancellationToken)).ConfigureAwait(false);
         }
         catch (OperationCanceledException)
         {
@@ -87,7 +86,7 @@ public class CouchbaseClientWrapper : ICouchbaseClientWrapper
         }
     }
 
-    public async Task<ulong> UpdateDocument<TEntity>(string id, string keyspace, TEntity entity, ulong? cas = null, CancellationToken cancellationToken = default)
+    public async Task<IMutationResult> UpdateDocument<TEntity>(string id, string keyspace, TEntity entity, ulong? cas = null, CancellationToken cancellationToken = default)
     {
         try
         {
@@ -99,13 +98,11 @@ public class CouchbaseClientWrapper : ICouchbaseClientWrapper
             // to keep today's unconditional-upsert behavior unchanged for everyone else.
             if (cas.HasValue)
             {
-                var replaceResult = await collection.ReplaceAsync(
+                return await collection.ReplaceAsync(
                     id, entity, new ReplaceOptions().Cas(cas.Value).CancellationToken(cancellationToken)).ConfigureAwait(false);
-                return replaceResult.Cas;
             }
 
-            var upsertResult = await collection.UpsertAsync(id, entity, new UpsertOptions().CancellationToken(cancellationToken)).ConfigureAwait(false);
-            return upsertResult.Cas;
+            return await collection.UpsertAsync(id, entity, new UpsertOptions().CancellationToken(cancellationToken)).ConfigureAwait(false);
         }
         catch (OperationCanceledException)
         {

--- a/src/Couchbase.EntityFrameworkCore/Storage/Internal/CouchbaseCommand.cs
+++ b/src/Couchbase.EntityFrameworkCore/Storage/Internal/CouchbaseCommand.cs
@@ -22,6 +22,14 @@ public class CouchbaseCommand : DbCommand
     // defaults to NotBounded to match the SDK default.
     internal QueryScanConsistency ScanConsistency { get; set; } = QueryScanConsistency.NotBounded;
 
+    // Per-command read-your-own-writes constraint. Unlike the LINQ path's .ConsistentWith(...),
+    // ADO.NET has no LINQ expression tree to intercept a marker call on, so this is a plain
+    // settable property the caller sets directly on the command before executing it -- e.g.
+    // ((CouchbaseCommand)connection.CreateCommand()).ConsistentWith = context.Database.GetMutationState().
+    // Overrides ScanConsistency to AtPlus internally when non-null (the SDK's own
+    // QueryOptions.ConsistentWith behavior) -- see BuildQueryOptions.
+    public MutationState? ConsistentWith { get; set; }
+
     [AllowNull]
     public override string CommandText
     {
@@ -255,6 +263,11 @@ public class CouchbaseCommand : DbCommand
     {
         var options = new QueryOptions().CancellationToken(cancellationToken);
         options.ScanConsistency(ScanConsistency);
+
+        if (ConsistentWith != null)
+        {
+            options.ConsistentWith(ConsistentWith);
+        }
 
         if (CommandTimeout > 0)
         {

--- a/src/Couchbase.EntityFrameworkCore/Storage/Internal/CouchbaseDatabaseWrapper.cs
+++ b/src/Couchbase.EntityFrameworkCore/Storage/Internal/CouchbaseDatabaseWrapper.cs
@@ -19,17 +19,20 @@ public class CouchbaseDatabaseWrapper : Database
     private readonly ICouchbaseClientWrapper _couchbaseClient;
     private readonly IRelationalConnection _relationalConnection;
     private readonly JsonNamingPolicy? _fieldNamingPolicy;
+    private readonly CouchbaseMutationStateTracker _mutationStateTracker;
 
     public CouchbaseDatabaseWrapper(
         DatabaseDependencies dependencies,
         ICouchbaseClientWrapper couchbaseClient,
         IRelationalConnection relationalConnection,
-        ICouchbaseDbContextOptionsBuilder couchbaseDbContextOptionsBuilder)
+        ICouchbaseDbContextOptionsBuilder couchbaseDbContextOptionsBuilder,
+        CouchbaseMutationStateTracker mutationStateTracker)
         : base(dependencies)
     {
         _couchbaseClient = couchbaseClient ?? throw new ArgumentNullException(nameof(couchbaseClient));
         _relationalConnection = relationalConnection ?? throw new ArgumentNullException(nameof(relationalConnection));
         _fieldNamingPolicy = couchbaseDbContextOptionsBuilder.FieldNamingPolicy;
+        _mutationStateTracker = mutationStateTracker ?? throw new ArgumentNullException(nameof(mutationStateTracker));
     }
 
     public override int SaveChanges(IList<IUpdateEntry> entries)
@@ -298,15 +301,17 @@ public class CouchbaseDatabaseWrapper : Database
 
                         case CouchbaseWriteKind.Upsert:
                         {
-                            var newCas = await _couchbaseClient.UpdateDocument(write.Key, write.Keyspace, write.Document!, write.Cas, cancellationToken).ConfigureAwait(false);
-                            RefreshCasProperty(write, newCas);
+                            var result = await _couchbaseClient.UpdateDocument(write.Key, write.Keyspace, write.Document!, write.Cas, cancellationToken).ConfigureAwait(false);
+                            RefreshCasProperty(write, result.Cas);
+                            _mutationStateTracker.Add(result);
                             break;
                         }
 
                         case CouchbaseWriteKind.Insert:
                         {
-                            var newCas = await _couchbaseClient.CreateDocument(write.Key, write.Keyspace, write.Document!, cancellationToken).ConfigureAwait(false);
-                            RefreshCasProperty(write, newCas);
+                            var result = await _couchbaseClient.CreateDocument(write.Key, write.Keyspace, write.Document!, cancellationToken).ConfigureAwait(false);
+                            RefreshCasProperty(write, result.Cas);
+                            _mutationStateTracker.Add(result);
                             break;
                         }
                     }

--- a/src/Couchbase.EntityFrameworkCore/Storage/Internal/CouchbaseMutationStateTracker.cs
+++ b/src/Couchbase.EntityFrameworkCore/Storage/Internal/CouchbaseMutationStateTracker.cs
@@ -1,0 +1,84 @@
+using Couchbase.KeyValue;
+using Couchbase.Query;
+using Microsoft.EntityFrameworkCore;
+
+namespace Couchbase.EntityFrameworkCore.Storage.Internal;
+
+/// <summary>
+/// Accumulates <see cref="IMutationResult"/>s from a single <see cref="DbContext"/> instance's own
+/// writes into a <see cref="MutationState"/>, for read-your-own-writes (RYOW) queries via
+/// <see cref="Couchbase.EntityFrameworkCore.Extensions.CouchbaseQueryableExtensions.ConsistentWith{TEntity}"/>.
+/// Registered Scoped (one instance per <see cref="DbContext"/>, mirroring
+/// <see cref="ICouchbaseClientWrapper"/>'s own lifetime) and exposed to applications via
+/// <see cref="Couchbase.EntityFrameworkCore.Extensions.CouchbaseDatabaseFacadeExtensions.GetMutationState"/>/
+/// <c>ClearMutationState</c>.
+/// </summary>
+/// <remarks>
+/// Writes within a single <c>SaveChangesAsync</c> call run concurrently (see
+/// <see cref="CouchbaseDatabaseWrapper"/>'s bounded-parallel write dispatch), so accumulation must
+/// be thread-safe; a plain lock is more than adequate here since write batches are small and this
+/// is not a hot path in the concurrent-throughput sense. State accumulates for the lifetime of the
+/// owning <see cref="DbContext"/> (never auto-reset after a <c>SaveChangesAsync</c> call) --
+/// deliberately mirroring Linq2Couchbase's own <c>BucketContext.MutationState</c> precedent, since
+/// RYOW callers typically want every write made through the context visible, not just the most
+/// recent batch. Call <c>ClearMutationState</c> explicitly to bound growth in a long-lived context.
+/// </remarks>
+public sealed class CouchbaseMutationStateTracker
+{
+    private readonly object _lock = new();
+    private readonly List<IMutationResult> _results = new();
+
+    /// <summary>
+    /// Records a successful write's mutation result. Deletes have no <see cref="IMutationResult"/>
+    /// to record -- see <see cref="ICouchbaseClientWrapper.DeleteDocument"/>'s remarks for why.
+    /// </summary>
+    public void Add(IMutationResult result)
+    {
+        lock (_lock)
+        {
+            _results.Add(result);
+        }
+    }
+
+    /// <summary>
+    /// Builds a fresh <see cref="MutationState"/> snapshot from every write recorded so far.
+    /// </summary>
+    public MutationState GetMutationState()
+    {
+        lock (_lock)
+        {
+            return MutationState.From(_results.ToArray());
+        }
+    }
+
+    /// <summary>
+    /// Discards all recorded writes, so the next <see cref="GetMutationState"/> call reflects only
+    /// writes made afterward.
+    /// </summary>
+    public void Clear()
+    {
+        lock (_lock)
+        {
+            _results.Clear();
+        }
+    }
+}
+
+/* ************************************************************
+ *
+ *    @author Couchbase <info@couchbase.com>
+ *    @copyright 2025 Couchbase, Inc.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ *
+ * ************************************************************/

--- a/src/Couchbase.EntityFrameworkCore/Storage/Internal/ICouchbaseClientWrapper.cs
+++ b/src/Couchbase.EntityFrameworkCore/Storage/Internal/ICouchbaseClientWrapper.cs
@@ -10,21 +10,35 @@ public interface ICouchbaseClientWrapper
     /// <see cref="Couchbase.Core.Exceptions.CasMismatchException"/> if the document was modified
     /// since that CAS was read; when <see langword="null"/>, the delete is unconditional.
     /// </summary>
+    /// <remarks>
+    /// Unlike <see cref="CreateDocument{TEntity}"/>/<see cref="UpdateDocument{TEntity}"/>, this
+    /// cannot return a <see cref="Couchbase.Core.MutationToken"/>: the underlying SDK's
+    /// <c>ICouchbaseCollection.RemoveAsync</c> computes one internally but its public API never
+    /// surfaces it (confirmed against the SDK's own source -- <c>CouchbaseCollection.RemoveAsync</c>
+    /// discards <c>removeOp.MutationToken</c> after the call, unlike its <c>ReplaceAsync</c> sibling,
+    /// which wraps the equivalent value in a returned <c>IMutationResult</c>). A deleted document
+    /// therefore cannot contribute to a <see cref="Couchbase.Query.MutationState"/> for
+    /// read-your-own-writes purposes -- a real SDK limitation, not a gap in this provider.
+    /// </remarks>
     Task<bool> DeleteDocument(string id, string keyspace, ulong? cas = null, CancellationToken cancellationToken = default);
 
     /// <summary>
-    /// Inserts a new document and returns its resulting CAS.
+    /// Inserts a new document, returning the SDK's own mutation result (its <c>Cas</c> and
+    /// <c>MutationToken</c> -- the latter needed to later build a <see cref="Couchbase.Query.MutationState"/>
+    /// for read-your-own-writes).
     /// </summary>
-    Task<ulong> CreateDocument<TEntity>(string id, string keyspace, TEntity entity, CancellationToken cancellationToken = default);
+    Task<IMutationResult> CreateDocument<TEntity>(string id, string keyspace, TEntity entity, CancellationToken cancellationToken = default);
 
     /// <summary>
-    /// Writes a document and returns its resulting CAS. If <paramref name="cas"/> is supplied, this
-    /// uses a CAS-checked replace (via the SDK's <c>ReplaceOptions.Cas</c>) and throws
+    /// Writes a document, returning the SDK's own mutation result (its <c>Cas</c> and
+    /// <c>MutationToken</c> -- the latter needed to later build a <see cref="Couchbase.Query.MutationState"/>
+    /// for read-your-own-writes). If <paramref name="cas"/> is supplied, this uses a CAS-checked
+    /// replace (via the SDK's <c>ReplaceOptions.Cas</c>) and throws
     /// <see cref="Couchbase.Core.Exceptions.CasMismatchException"/> if the document was modified
     /// since that CAS was read; when <see langword="null"/>, this is an unconditional upsert
     /// (create-or-replace), matching this method's original behavior.
     /// </summary>
-    Task<ulong> UpdateDocument<TEntity>(string id, string keyspace, TEntity entity, ulong? cas = null, CancellationToken cancellationToken = default);
+    Task<IMutationResult> UpdateDocument<TEntity>(string id, string keyspace, TEntity entity, ulong? cas = null, CancellationToken cancellationToken = default);
 
     string BucketName { get; }
 

--- a/tests/Couchbase.EntityFrameworkCore.IntegrationTests/Tests/CouchbaseConsistentWithTests.cs
+++ b/tests/Couchbase.EntityFrameworkCore.IntegrationTests/Tests/CouchbaseConsistentWithTests.cs
@@ -1,0 +1,345 @@
+using Couchbase.EntityFrameworkCode.IntegrationTests.Fixtures;
+using Couchbase.EntityFrameworkCore;
+using Couchbase.EntityFrameworkCore.Extensions;
+using Couchbase.EntityFrameworkCore.Storage.Internal;
+using Couchbase.Query;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+using Xunit.Abstractions;
+
+namespace Couchbase.EntityFrameworkCode.IntegrationTests.Tests;
+
+/// <summary>
+/// Proves per-query read-your-own-writes (<see cref="CouchbaseQueryableExtensions.ConsistentWith{TEntity}"/>,
+/// <see cref="CouchbaseDatabaseFacadeExtensions.GetMutationState"/>) actually works against a real
+/// cluster, across all three query execution paths (LINQ, FromSql, raw ADO.NET). Every test uses
+/// <c>NotBounded</c> scan consistency (the SDK default) on the write context specifically so a
+/// write is NOT guaranteed visible to a fresh query without the per-query consistency constraint --
+/// the point of these tests is confirming <c>.ConsistentWith(...)</c> makes it visible anyway, not
+/// just that the generated SQL/request looks right.
+/// </summary>
+/// <remarks>
+/// Each test uses its OWN dedicated <c>DbContext</c> type (rather than sharing one generic context
+/// parameterized by collection name, the way this file's first draft did) -- EF Core caches a
+/// compiled model per <c>DbContext</c> TYPE by default, keyed independently of any custom
+/// constructor arguments, so four tests sharing one context type would silently reuse whichever
+/// one built its model first, pointing every test at the SAME collection regardless of the
+/// per-test collection name passed to each instance's constructor (confirmed by a real failure:
+/// the "Linq" test's error referenced the "AdoNet" test's collection name). One type per test
+/// avoids the collision entirely, matching the same one-type-per-test convention already used by
+/// <see cref="CouchbaseQueryHintTests"/>.
+/// </remarks>
+[Collection(CouchbaseTestingCollection.Name)]
+public class CouchbaseConsistentWithTests(BloggingFixture fixture, ITestOutputHelper outputHelper)
+{
+    [Fact]
+    public async Task Linq_WriteThenConsistentWithQuery_SeesTheWrite()
+    {
+        var collectionName = "ryowlinq" + Guid.NewGuid().ToString("N");
+        var optionsBuilder = CreateOptionsBuilder<RyowLinqDbContext>();
+
+        await using var ctx = new RyowLinqDbContext(optionsBuilder.Options, collectionName);
+        try
+        {
+            await ctx.Database.EnsureCreatedAsync();
+
+            var id = Guid.NewGuid().ToString("N");
+            ctx.Entities.Add(new RyowEntity { Id = id, Content = "hello" });
+            await ctx.SaveChangesAsync();
+
+            var mutationState = ctx.Database.GetMutationState();
+            Assert.NotEmpty(mutationState);
+
+            await using var readCtx = new RyowLinqDbContext(optionsBuilder.Options, collectionName);
+            var query = readCtx.Entities.Where(e => e.Id == id).ConsistentWith(mutationState);
+            outputHelper.WriteLine("SQL: " + query.ToQueryString());
+
+            var result = await query.SingleOrDefaultAsync();
+
+            Assert.NotNull(result);
+            Assert.Equal("hello", result!.Content);
+        }
+        finally
+        {
+            await DropCollectionAsync(collectionName);
+        }
+    }
+
+    [Fact]
+    public async Task FromSql_WriteThenConsistentWithQuery_SeesTheWrite()
+    {
+        var collectionName = "ryowsql" + Guid.NewGuid().ToString("N");
+        var optionsBuilder = CreateOptionsBuilder<RyowFromSqlDbContext>();
+
+        await using var ctx = new RyowFromSqlDbContext(optionsBuilder.Options, collectionName);
+        try
+        {
+            await ctx.Database.EnsureCreatedAsync();
+
+            var id = Guid.NewGuid().ToString("N");
+            ctx.Entities.Add(new RyowEntity { Id = id, Content = "from-sql" });
+            await ctx.SaveChangesAsync();
+
+            var mutationState = ctx.Database.GetMutationState();
+
+            await using var readCtx = new RyowFromSqlDbContext(optionsBuilder.Options, collectionName);
+            await WaitForKeyspaceReadyAsync(collectionName);
+            // The keyspace identifier can't be parameterized (it's not a bind value), but the id
+            // VALUE goes through FromSqlRaw's own {0} positional-parameter mechanism rather than
+            // raw string interpolation -- {{0}} below is an escaped literal that becomes the text
+            // "{0}" in the resulting SQL, which FromSqlRaw then recognizes and parameterizes.
+            // Each keyspace segment must be delimited SEPARATELY (`bucket`.`scope`.`collection`) --
+            // wrapping the whole dotted string in one pair of backticks makes N1QL treat it as a
+            // single identifier (a bucket literally named "bucket.scope.collection"), which is the
+            // exact "No bucket named ..." 12003 error this used to produce.
+            // Columns are referenced by their camelCase STORED field name ("id"/"content"), not
+            // the CLR property name -- this DbContext uses UseCamelCaseNamingConvention() (see
+            // CreateOptionsBuilder), and the FromSqlRaw path deserializes rows into T DIRECTLY via
+            // the Couchbase SDK's own SystemTextJsonSerializer (not this provider's own
+            // alias-based materializer), which matches JSON keys against camelCase-converted CLR
+            // property names WITHOUT a case-insensitive fallback. A raw SQL column reference that
+            // doesn't match the stored casing silently deserializes to that property's CLR default
+            // instead of throwing -- confirmed by writing "Id"/"Content" (PascalCase, unconverted)
+            // in an earlier draft of this test and observing every property come back blank.
+            var sql = $"SELECT d.id, d.content FROM {DelimitKeyspace(collectionName)} AS d WHERE d.id = {{0}}";
+            var query = readCtx.Entities
+                .FromSqlRaw(sql, id)
+                .ConsistentWith(mutationState);
+
+            var results = await query.ToListAsync();
+
+            Assert.Single(results);
+            Assert.Equal("from-sql", results[0].Content);
+        }
+        finally
+        {
+            await DropCollectionAsync(collectionName);
+        }
+    }
+
+    [Fact]
+    public async Task AdoNet_WriteThenConsistentWithCommand_SeesTheWrite()
+    {
+        var collectionName = "ryowado" + Guid.NewGuid().ToString("N");
+        var optionsBuilder = CreateOptionsBuilder<RyowAdoNetDbContext>();
+
+        await using var ctx = new RyowAdoNetDbContext(optionsBuilder.Options, collectionName);
+        try
+        {
+            await ctx.Database.EnsureCreatedAsync();
+
+            var id = Guid.NewGuid().ToString("N");
+            ctx.Entities.Add(new RyowEntity { Id = id, Content = "ado-net" });
+            await ctx.SaveChangesAsync();
+
+            var mutationState = ctx.Database.GetMutationState();
+
+            await WaitForKeyspaceReadyAsync(collectionName);
+
+            var connection = ctx.Database.GetDbConnection();
+            await connection.OpenAsync();
+
+            using var command = (CouchbaseCommand)connection.CreateCommand();
+            command.ConsistentWith = mutationState;
+            // Columns referenced by their camelCase STORED field name -- see the FromSqlRaw
+            // test's comment for why (this DbContext uses UseCamelCaseNamingConvention()).
+            command.CommandText = $"SELECT d.id, d.content FROM {DelimitKeyspace(collectionName)} AS d WHERE d.id = $id";
+            command.Parameters.AddWithValue("$id", id);
+
+            await using var reader = await command.ExecuteReaderAsync();
+            var found = await reader.ReadAsync();
+
+            Assert.True(found);
+            Assert.Equal("ado-net", reader.GetString(reader.GetOrdinal("content")));
+        }
+        finally
+        {
+            await DropCollectionAsync(collectionName);
+        }
+    }
+
+    [Fact]
+    public async Task ClearMutationState_ResetsAccumulation()
+    {
+        var collectionName = "ryowclear" + Guid.NewGuid().ToString("N");
+        var optionsBuilder = CreateOptionsBuilder<RyowClearDbContext>();
+
+        await using var ctx = new RyowClearDbContext(optionsBuilder.Options, collectionName);
+        try
+        {
+            await ctx.Database.EnsureCreatedAsync();
+
+            ctx.Entities.Add(new RyowEntity { Id = Guid.NewGuid().ToString("N"), Content = "before-clear" });
+            await ctx.SaveChangesAsync();
+            Assert.NotEmpty(ctx.Database.GetMutationState());
+
+            ctx.Database.ClearMutationState();
+
+            Assert.Empty(ctx.Database.GetMutationState());
+        }
+        finally
+        {
+            await DropCollectionAsync(collectionName);
+        }
+    }
+
+    private DbContextOptionsBuilder<TContext> CreateOptionsBuilder<TContext>()
+        where TContext : DbContext
+    {
+        var optionsBuilder = new DbContextOptionsBuilder<TContext>();
+        optionsBuilder.UseCouchbase(
+            new global::Couchbase.ClusterOptions()
+                .WithConnectionString(fixture.Host)
+                .WithPasswordAuthentication(fixture.Username, fixture.Password),
+            o =>
+            {
+                o.Bucket = fixture.BucketName;
+                o.Scope = fixture.ScopeName;
+                o.AutoCreateIndexes = true;
+                // Deliberately NotBounded (the SDK default) -- RequestPlus would make the "does
+                // ConsistentWith actually matter" question moot by making every write immediately
+                // visible on its own.
+                o.ScanConsistency = QueryScanConsistency.NotBounded;
+            });
+        // Needed so the FromSqlRaw/ADO.NET raw-SQL column references (which must match the
+        // ACTUAL stored field casing) line up with what gets written -- see the FromSqlRaw
+        // test's comment for why this matters for those two paths specifically.
+        optionsBuilder.UseCamelCaseNamingConvention();
+        optionsBuilder.ConfigureWarnings(w => w.Ignore(CoreEventId.ManyServiceProvidersCreatedWarning));
+        return optionsBuilder;
+    }
+
+    /// <summary>
+    /// Delimits each keyspace segment SEPARATELY: <c>`bucket`.`scope`.`collection`</c>. Wrapping
+    /// the whole dotted string in a single pair of backticks instead makes N1QL treat it as ONE
+    /// identifier -- a bucket literally named <c>"bucket.scope.collection"</c> -- which is the
+    /// root cause of the N1QL 12003 ("No bucket named ...") errors this file used to attribute to
+    /// a query-engine keyspace-propagation race. There was no race: that malformed reference could
+    /// never succeed, no matter how long the retry loop waited.
+    /// </summary>
+    private string DelimitKeyspace(string collectionName) =>
+        $"`{fixture.BucketName}`.`{fixture.ScopeName}`.`{collectionName}`";
+
+    /// <summary>
+    /// Polls a freshly created keyspace with a trivial raw query until the query engine actually
+    /// recognizes it, retrying on N1QL error 12003 ("Keyspace not found").
+    /// </summary>
+    private async Task WaitForKeyspaceReadyAsync(string collectionName)
+    {
+        // A fresh Cluster.ConnectAsync() call -- with a FRESH ClusterOptions object -- is made on
+        // EVERY attempt, not once before the loop. Two distinct bugs were found and fixed getting
+        // here: (1) reusing one connection across all retries retries against that SAME
+        // connection's own cached bucket/collection manifest forever, which never gets a chance to
+        // refresh mid-loop; (2) reusing one ClusterOptions instance across multiple ConnectAsync
+        // calls throws ObjectDisposedException on the second call, because ClusterOptions holds a
+        // CancellationTokenSource tied to the FIRST connected cluster's own lifecycle, which gets
+        // disposed when that cluster is disposed at the end of the first iteration.
+        var deadline = DateTime.UtcNow.AddSeconds(30);
+        while (true)
+        {
+            try
+            {
+                var clusterOptions = new global::Couchbase.ClusterOptions()
+                    .WithConnectionString(fixture.Host)
+                    .WithPasswordAuthentication(fixture.Username, fixture.Password);
+                using var cluster = await global::Couchbase.Cluster.ConnectAsync(clusterOptions);
+                var result = await cluster.QueryAsync<int>($"SELECT RAW 1 FROM {DelimitKeyspace(collectionName)} AS d LIMIT 1");
+                await foreach (var _ in result.Rows)
+                {
+                    // Draining is enough; an empty (but non-erroring) result also proves the
+                    // keyspace is recognized.
+                }
+                return;
+            }
+            catch (global::Couchbase.Core.Exceptions.IndexFailureException) when (DateTime.UtcNow < deadline)
+            {
+                outputHelper.WriteLine($"Keyspace {collectionName} not yet visible to the query engine, retrying with a fresh connection...");
+                await Task.Delay(TimeSpan.FromMilliseconds(500));
+            }
+        }
+    }
+
+    private async Task DropCollectionAsync(string collectionName)
+    {
+        var clusterOptions = new global::Couchbase.ClusterOptions()
+            .WithConnectionString(fixture.Host)
+            .WithCredentials(fixture.Username, fixture.Password);
+        using var cluster = await global::Couchbase.Cluster.ConnectAsync(clusterOptions);
+        var bucket = await cluster.BucketAsync(fixture.BucketName);
+        try
+        {
+            await bucket.Collections.DropCollectionAsync(fixture.ScopeName, collectionName);
+        }
+        catch (global::Couchbase.Management.Collections.CollectionNotFoundException)
+        {
+        }
+    }
+
+    // "Value" is a reserved N1QL word (collides with SELECT VALUE syntax) -- named Content instead
+    // to avoid needing backtick-escaping everywhere this property is referenced in raw SQL below.
+    public class RyowEntity
+    {
+        public string Id { get; set; } = string.Empty;
+        public string Content { get; set; } = string.Empty;
+    }
+
+    public class RyowLinqDbContext(DbContextOptions<RyowLinqDbContext> options, string collectionName) : DbContext(options)
+    {
+        public DbSet<RyowEntity> Entities { get; set; } = null!;
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            base.OnModelCreating(modelBuilder);
+            modelBuilder.Entity<RyowEntity>(b =>
+            {
+                b.ToCouchbaseCollection(this, collectionName);
+                b.HasKey(e => e.Id);
+            });
+        }
+    }
+
+    public class RyowFromSqlDbContext(DbContextOptions<RyowFromSqlDbContext> options, string collectionName) : DbContext(options)
+    {
+        public DbSet<RyowEntity> Entities { get; set; } = null!;
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            base.OnModelCreating(modelBuilder);
+            modelBuilder.Entity<RyowEntity>(b =>
+            {
+                b.ToCouchbaseCollection(this, collectionName);
+                b.HasKey(e => e.Id);
+            });
+        }
+    }
+
+    public class RyowAdoNetDbContext(DbContextOptions<RyowAdoNetDbContext> options, string collectionName) : DbContext(options)
+    {
+        public DbSet<RyowEntity> Entities { get; set; } = null!;
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            base.OnModelCreating(modelBuilder);
+            modelBuilder.Entity<RyowEntity>(b =>
+            {
+                b.ToCouchbaseCollection(this, collectionName);
+                b.HasKey(e => e.Id);
+            });
+        }
+    }
+
+    public class RyowClearDbContext(DbContextOptions<RyowClearDbContext> options, string collectionName) : DbContext(options)
+    {
+        public DbSet<RyowEntity> Entities { get; set; } = null!;
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            base.OnModelCreating(modelBuilder);
+            modelBuilder.Entity<RyowEntity>(b =>
+            {
+                b.ToCouchbaseCollection(this, collectionName);
+                b.HasKey(e => e.Id);
+            });
+        }
+    }
+}

--- a/tests/Couchbase.EntityFrameworkCore.UnitTests/Couchbase/EntityFrameworkCore/Query/CouchbaseConsistentWithTests.cs
+++ b/tests/Couchbase.EntityFrameworkCore.UnitTests/Couchbase/EntityFrameworkCore/Query/CouchbaseConsistentWithTests.cs
@@ -1,0 +1,200 @@
+using Couchbase.Core;
+using Couchbase.EntityFrameworkCore.Extensions;
+using Couchbase.EntityFrameworkCore.Infrastructure;
+using Couchbase.EntityFrameworkCore.Query.Internal;
+using Couchbase.EntityFrameworkCore.Storage.Internal;
+using Couchbase.KeyValue;
+using Couchbase.Query;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Query;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Couchbase.EntityFrameworkCore.UnitTests.Couchbase.EntityFrameworkCore.Query;
+
+/// <summary>
+/// Verifies <c>ConsistentWith</c>'s cross-provider safety, that it leaves generated SQL text
+/// unaffected (it's a pure execution-time option, not a SQL-generation hint like
+/// <c>UseIndex</c>/<c>UseHash</c>), and that <see cref="CouchbaseQueryEnumerable{T}.GetParameters"/>
+/// correctly applies a <see cref="MutationState"/> found in the query context's parameters at
+/// execution time.
+/// </summary>
+public class CouchbaseConsistentWithTests(ITestOutputHelper output)
+{
+    [Fact]
+    public void ConsistentWith_DoesNotAlterGeneratedSql()
+    {
+        // .ConsistentWith(...) must be applied LAST (see its own doc remarks) -- composing further
+        // operators afterward that need to re-inspect the shaper's shape (.Where/.OrderBy/.Select)
+        // fails to translate, since the shaper is wrapped in a marker node at that point. Applied
+        // last, it's purely an execution-time option and must leave the generated SQL untouched.
+        using var ctx = CreateContext();
+        var withoutHint = ctx.Posts.Where(p => p.Title == "x").ToQueryString();
+        var withHint = ctx.Posts.Where(p => p.Title == "x").ConsistentWith(new MutationState()).ToQueryString();
+
+        Assert.Equal(withoutHint, withHint);
+    }
+
+    [Fact]
+    public void ConsistentWith_ComposedBeforeWhere_ThrowsTranslationException()
+    {
+        // Locks in the actual (not merely theorized) failure mode for the documented "apply last"
+        // requirement: composing .Where(...) AFTER .ConsistentWith(...) throws a clear translation
+        // exception rather than silently dropping the hint -- arguably the safer failure mode for a
+        // correctness-affecting option, and important to pin down since it differs from
+        // UseIndex/UseHash's own "silently ignored" fallback for a shape mismatch.
+        using var ctx = CreateContext();
+
+        Assert.Throws<InvalidOperationException>(
+            () => ctx.Posts.ConsistentWith(new MutationState()).Where(p => p.Title == "x").ToQueryString());
+    }
+
+    [Fact]
+    public void ConsistentWith_WithNull_DoesNotThrowOrAlterSql()
+    {
+        using var ctx = CreateContext();
+        var withoutHint = ctx.Posts.ToQueryString();
+        var withNull = ctx.Posts.ConsistentWith(null).ToQueryString();
+
+        Assert.Equal(withoutHint, withNull);
+    }
+
+    [Fact]
+    public void ConsistentWith_OnNonEntityQueryProvider_IsNoOp()
+    {
+        // Mirrors UseIndex/UseHash's own cross-provider-safety test: a genuine non-EF-Core
+        // queryable (LINQ-to-Objects) has no translation pipeline to hook into, so the call must
+        // be a silent no-op rather than throwing.
+        IQueryable<string> source = new List<string> { "a", "b", "c" }.AsQueryable();
+        var result = source.ConsistentWith(new MutationState());
+
+        Assert.Same(source, result);
+    }
+
+    [Fact]
+    public void GetParameters_WithConsistentWithParameterPresent_AppliesAtPlusConsistency()
+    {
+        using var ctx = CreateContext();
+        var relationalQueryContext =
+            (RelationalQueryContext)ctx.GetService<IQueryContextFactory>().Create();
+
+        var token = new MutationToken("test-bucket", 0, 1, 1);
+        var mutationState = new MutationState().Add(new FakeMutationResult(token));
+        const string parameterName = "__consistentWith_0";
+        relationalQueryContext.Parameters[parameterName] = mutationState;
+
+        var enumerable = new CouchbaseQueryEnumerable<Post>(
+            relationalQueryContext,
+            _ => throw new NotSupportedException(),
+            readerColumns: null,
+            projectionAliases: null,
+            ownedNavigationKeys: null,
+            ownedNavigationAliases: null,
+            shaper: (_, _, _, _) => throw new NotSupportedException(),
+            contextType: typeof(QueryHintContext),
+            standAloneStateManager: false,
+            isTracking: false,
+            detailedErrorsEnabled: false,
+            threadSafetyChecksEnabled: false,
+            bucketProvider: null!,
+            couchbaseDbContextOptionsBuilder: ctx.GetService<ICouchbaseDbContextOptionsBuilder>(),
+            consistentWithParameterName: parameterName);
+
+        using var command = new CouchbaseCommand();
+        var queryOptions = enumerable.GetParameters(command);
+        var (scanConsistency, scanVectors) = ReadScanConsistencyState(queryOptions);
+
+        output.WriteLine("scan_consistency: " + scanConsistency);
+        Assert.Equal("AtPlus", scanConsistency);
+        Assert.NotNull(scanVectors);
+    }
+
+    [Fact]
+    public void GetParameters_WithNoConsistentWithParameter_LeavesDefaultScanConsistency()
+    {
+        using var ctx = CreateContext();
+        var relationalQueryContext =
+            (RelationalQueryContext)ctx.GetService<IQueryContextFactory>().Create();
+
+        var enumerable = new CouchbaseQueryEnumerable<Post>(
+            relationalQueryContext,
+            _ => throw new NotSupportedException(),
+            readerColumns: null,
+            projectionAliases: null,
+            ownedNavigationKeys: null,
+            ownedNavigationAliases: null,
+            shaper: (_, _, _, _) => throw new NotSupportedException(),
+            contextType: typeof(QueryHintContext),
+            standAloneStateManager: false,
+            isTracking: false,
+            detailedErrorsEnabled: false,
+            threadSafetyChecksEnabled: false,
+            bucketProvider: null!,
+            couchbaseDbContextOptionsBuilder: ctx.GetService<ICouchbaseDbContextOptionsBuilder>(),
+            consistentWithParameterName: null);
+
+        using var command = new CouchbaseCommand();
+        var queryOptions = enumerable.GetParameters(command);
+        var (scanConsistency, scanVectors) = ReadScanConsistencyState(queryOptions);
+
+        output.WriteLine("scan_consistency: " + scanConsistency);
+        Assert.Equal("NotBounded", scanConsistency);
+        Assert.Null(scanVectors);
+    }
+
+    private sealed class FakeMutationResult(MutationToken token) : IMutationResult
+    {
+        public ulong Cas => 1;
+        public MutationToken MutationToken { get; set; } = token;
+    }
+
+    /// <summary>
+    /// Reads <see cref="QueryOptions"/>'s private <c>_scanConsistency</c>/<c>_scanVectors</c>
+    /// fields directly via reflection, rather than going through the public
+    /// <c>GetFormValues()</c>/<c>CreateDto</c> path -- that path unconditionally throws
+    /// ("A statement or prepared plan must be provided") unless a N1QL statement string was also
+    /// supplied, which <see cref="CouchbaseQueryEnumerable{T}.GetParameters"/> never does (the
+    /// statement is passed separately to <c>cluster.QueryAsync(statement, queryOptions)</c>, not
+    /// stored on <see cref="QueryOptions"/> itself) -- so it's unusable here for a QueryOptions
+    /// object built the same way production code builds one. <c>_scanConsistency</c>'s declared
+    /// type (<c>QueryScanConsistencyInternal</c>) is itself an internal SDK enum, so the caller
+    /// compares the returned value's <c>ToString()</c> rather than the type directly.
+    /// </summary>
+    private static (string? ScanConsistency, object? ScanVectors) ReadScanConsistencyState(QueryOptions queryOptions)
+    {
+        var scanConsistencyField = typeof(QueryOptions).GetField("_scanConsistency", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)!;
+        var scanVectorsField = typeof(QueryOptions).GetField("_scanVectors", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)!;
+        return (scanConsistencyField.GetValue(queryOptions)?.ToString(), scanVectorsField.GetValue(queryOptions));
+    }
+
+    private static QueryHintContext CreateContext()
+    {
+        var clusterOptions = new ClusterOptions()
+            .WithConnectionString("couchbase://localhost")
+            .WithPasswordAuthentication("Administrator", "password");
+        var builder = new DbContextOptionsBuilder<QueryHintContext>();
+        builder.UseCouchbaseProvider(clusterOptions);
+        return new QueryHintContext(builder.Options);
+    }
+
+    private class Post
+    {
+        public int Id { get; set; }
+        public string Title { get; set; } = string.Empty;
+    }
+
+    private class QueryHintContext(DbContextOptions<QueryHintContext> options) : DbContext(options)
+    {
+        public DbSet<Post> Posts { get; set; } = null!;
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            modelBuilder.Entity<Post>(b =>
+            {
+                b.ToCouchbaseCollection("bucket", "scope", "consistentWithPost");
+                b.HasKey(p => p.Id);
+            });
+        }
+    }
+}


### PR DESCRIPTION
…nState

SaveChangesAsync now accumulates a MutationState per DbContext from its own writes (Database.GetMutationState()/ClearMutationState()), and a new IQueryable<T>.ConsistentWith(MutationState) extension scopes N1QL AT_PLUS scan consistency to those specific writes for a single query — a cheaper, narrower alternative to context-wide RequestPlus. Supported across LINQ, FromSqlRaw/FromSql, and raw ADO.NET (CouchbaseCommand.ConsistentWith).