### PR TITLE
Prepare 2.0.0-beta.3 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project aims to follow [Semantic Versioning](https://semver.org/spec/v2
 
 ## [Unreleased]
 
+## [2.0.0-beta.3] - 2026-08-10
+
 ### Added
 
 - **Per-query read-your-own-writes (`ConsistentWith`/`MutationState`).** `SaveChangesAsync` now
@@ -355,5 +357,6 @@ See [`docs/limitations.md`](docs/limitations.md). Highlights: EF Core Migrations
 supported (use `EnsureCreatedAsync`); synchronous query/save APIs are not supported;
 TPT/TPC inheritance is not supported; nested data must be modeled as owned types.
 
+[2.0.0-beta.3]: https://github.com/couchbaselabs/couchbase-efcore-provider/releases/tag/2.0.0-beta.3
 [2.0.0-beta.2]: https://github.com/couchbaselabs/couchbase-efcore-provider/releases/tag/2.0.0-beta.2
 [2.0.0-beta.1]: https://github.com/couchbaselabs/couchbase-efcore-provider/releases/tag/2.0.0-beta.1

--- a/src/Couchbase.EntityFrameworkCore/CompatibilitySuppressions.xml
+++ b/src/Couchbase.EntityFrameworkCore/CompatibilitySuppressions.xml
@@ -3,20 +3,6 @@
 <Suppressions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
   <Suppression>
     <DiagnosticId>CP0002</DiagnosticId>
-    <Target>M:Couchbase.EntityFrameworkCore.Query.Internal.CouchbaseQueryEnumerable.Create``1(Microsoft.EntityFrameworkCore.Query.RelationalQueryContext,Microsoft.EntityFrameworkCore.Query.Internal.RelationalCommandResolver,System.Collections.Generic.IReadOnlyList{Microsoft.EntityFrameworkCore.Storage.ReaderColumn},System.String[],System.Func{Microsoft.EntityFrameworkCore.Query.QueryContext,System.Data.Common.DbDataReader,Microsoft.EntityFrameworkCore.Query.Internal.ResultContext,Microsoft.EntityFrameworkCore.Query.Internal.SingleQueryResultCoordinator,``0},System.Type,System.Boolean,System.Boolean,System.Boolean,System.Boolean,Couchbase.Extensions.DependencyInjection.IBucketProvider,Couchbase.EntityFrameworkCore.Infrastructure.ICouchbaseDbContextOptionsBuilder)</Target>
-    <Left>lib/net10.0/Couchbase.EntityFrameworkCore.dll</Left>
-    <Right>lib/net10.0/Couchbase.EntityFrameworkCore.dll</Right>
-    <IsBaselineSuppression>true</IsBaselineSuppression>
-  </Suppression>
-  <Suppression>
-    <DiagnosticId>CP0002</DiagnosticId>
-    <Target>M:Couchbase.EntityFrameworkCore.Query.Internal.CouchbaseQueryEnumerable`1.#ctor(Microsoft.EntityFrameworkCore.Query.RelationalQueryContext,Microsoft.EntityFrameworkCore.Query.Internal.RelationalCommandResolver,System.Collections.Generic.IReadOnlyList{Microsoft.EntityFrameworkCore.Storage.ReaderColumn},System.String[],System.Func{Microsoft.EntityFrameworkCore.Query.QueryContext,System.Data.Common.DbDataReader,Microsoft.EntityFrameworkCore.Query.Internal.ResultContext,Microsoft.EntityFrameworkCore.Query.Internal.SingleQueryResultCoordinator,`0},System.Type,System.Boolean,System.Boolean,System.Boolean,System.Boolean,Couchbase.Extensions.DependencyInjection.IBucketProvider,Couchbase.EntityFrameworkCore.Infrastructure.ICouchbaseDbContextOptionsBuilder)</Target>
-    <Left>lib/net10.0/Couchbase.EntityFrameworkCore.dll</Left>
-    <Right>lib/net10.0/Couchbase.EntityFrameworkCore.dll</Right>
-    <IsBaselineSuppression>true</IsBaselineSuppression>
-  </Suppression>
-  <Suppression>
-    <DiagnosticId>CP0002</DiagnosticId>
     <Target>M:Couchbase.EntityFrameworkCore.Query.Internal.CouchbaseFromSqlQueryingEnumerable.Create``1(Microsoft.EntityFrameworkCore.Query.RelationalQueryContext,Microsoft.EntityFrameworkCore.Query.Internal.RelationalCommandResolver,System.Collections.Generic.IReadOnlyList{Microsoft.EntityFrameworkCore.Storage.ReaderColumn},System.Collections.Generic.IReadOnlyList{System.String},System.Func{Microsoft.EntityFrameworkCore.Query.QueryContext,System.Data.Common.DbDataReader,System.Int32[],``0},System.Type,System.Boolean,System.Boolean,System.Boolean,Couchbase.Extensions.DependencyInjection.IBucketProvider,Couchbase.EntityFrameworkCore.Infrastructure.ICouchbaseDbContextOptionsBuilder)</Target>
     <Left>lib/net10.0/Couchbase.EntityFrameworkCore.dll</Left>
     <Right>lib/net10.0/Couchbase.EntityFrameworkCore.dll</Right>
@@ -31,98 +17,91 @@
   </Suppression>
   <Suppression>
     <DiagnosticId>CP0002</DiagnosticId>
-    <Target>M:Couchbase.EntityFrameworkCore.Storage.Internal.CouchbaseClientWrapper.CreateDocument``1(System.String,System.String,``0)</Target>
+    <Target>M:Couchbase.EntityFrameworkCore.Query.Internal.CouchbaseQueryEnumerable.Create``1(Microsoft.EntityFrameworkCore.Query.RelationalQueryContext,Microsoft.EntityFrameworkCore.Query.Internal.RelationalCommandResolver,System.Collections.Generic.IReadOnlyList{Microsoft.EntityFrameworkCore.Storage.ReaderColumn},System.String[],System.String[],System.String[],System.Func{Microsoft.EntityFrameworkCore.Query.QueryContext,System.Data.Common.DbDataReader,Microsoft.EntityFrameworkCore.Query.Internal.ResultContext,Microsoft.EntityFrameworkCore.Query.Internal.SingleQueryResultCoordinator,``0},System.Type,System.Boolean,System.Boolean,System.Boolean,System.Boolean,Couchbase.Extensions.DependencyInjection.IBucketProvider,Couchbase.EntityFrameworkCore.Infrastructure.ICouchbaseDbContextOptionsBuilder)</Target>
     <Left>lib/net10.0/Couchbase.EntityFrameworkCore.dll</Left>
     <Right>lib/net10.0/Couchbase.EntityFrameworkCore.dll</Right>
     <IsBaselineSuppression>true</IsBaselineSuppression>
   </Suppression>
   <Suppression>
     <DiagnosticId>CP0002</DiagnosticId>
-    <Target>M:Couchbase.EntityFrameworkCore.Storage.Internal.CouchbaseClientWrapper.DeleteDocument(System.String,System.String)</Target>
+    <Target>M:Couchbase.EntityFrameworkCore.Query.Internal.CouchbaseQueryEnumerable`1.#ctor(Microsoft.EntityFrameworkCore.Query.RelationalQueryContext,Microsoft.EntityFrameworkCore.Query.Internal.RelationalCommandResolver,System.Collections.Generic.IReadOnlyList{Microsoft.EntityFrameworkCore.Storage.ReaderColumn},System.String[],System.String[],System.String[],System.Func{Microsoft.EntityFrameworkCore.Query.QueryContext,System.Data.Common.DbDataReader,Microsoft.EntityFrameworkCore.Query.Internal.ResultContext,Microsoft.EntityFrameworkCore.Query.Internal.SingleQueryResultCoordinator,`0},System.Type,System.Boolean,System.Boolean,System.Boolean,System.Boolean,Couchbase.Extensions.DependencyInjection.IBucketProvider,Couchbase.EntityFrameworkCore.Infrastructure.ICouchbaseDbContextOptionsBuilder)</Target>
     <Left>lib/net10.0/Couchbase.EntityFrameworkCore.dll</Left>
     <Right>lib/net10.0/Couchbase.EntityFrameworkCore.dll</Right>
     <IsBaselineSuppression>true</IsBaselineSuppression>
   </Suppression>
   <Suppression>
     <DiagnosticId>CP0002</DiagnosticId>
-    <Target>M:Couchbase.EntityFrameworkCore.Storage.Internal.CouchbaseClientWrapper.EnqueueTransactionalInsert``1(Couchbase.EntityFrameworkCore.Storage.Internal.CouchbaseDbTransaction,System.String,System.String,``0)</Target>
+    <Target>M:Couchbase.EntityFrameworkCore.Query.Internal.CouchbaseQuerySqlGenerator.#ctor(Microsoft.EntityFrameworkCore.Query.QuerySqlGeneratorDependencies)</Target>
     <Left>lib/net10.0/Couchbase.EntityFrameworkCore.dll</Left>
     <Right>lib/net10.0/Couchbase.EntityFrameworkCore.dll</Right>
     <IsBaselineSuppression>true</IsBaselineSuppression>
   </Suppression>
   <Suppression>
     <DiagnosticId>CP0002</DiagnosticId>
-    <Target>M:Couchbase.EntityFrameworkCore.Storage.Internal.CouchbaseClientWrapper.EnqueueTransactionalRemove(Couchbase.EntityFrameworkCore.Storage.Internal.CouchbaseDbTransaction,System.String,System.String)</Target>
+    <Target>M:Couchbase.EntityFrameworkCore.Query.Internal.CouchbaseQuerySqlGeneratorFactory.#ctor(Microsoft.EntityFrameworkCore.Query.QuerySqlGeneratorDependencies)</Target>
     <Left>lib/net10.0/Couchbase.EntityFrameworkCore.dll</Left>
     <Right>lib/net10.0/Couchbase.EntityFrameworkCore.dll</Right>
     <IsBaselineSuppression>true</IsBaselineSuppression>
   </Suppression>
   <Suppression>
     <DiagnosticId>CP0002</DiagnosticId>
-    <Target>M:Couchbase.EntityFrameworkCore.Storage.Internal.CouchbaseClientWrapper.EnqueueTransactionalUpsert``1(Couchbase.EntityFrameworkCore.Storage.Internal.CouchbaseDbTransaction,System.String,System.String,``0)</Target>
+    <Target>M:Couchbase.EntityFrameworkCore.Storage.Internal.CouchbaseClientWrapper.CreateDocument``1(System.String,System.String,``0,System.Threading.CancellationToken)</Target>
     <Left>lib/net10.0/Couchbase.EntityFrameworkCore.dll</Left>
     <Right>lib/net10.0/Couchbase.EntityFrameworkCore.dll</Right>
     <IsBaselineSuppression>true</IsBaselineSuppression>
   </Suppression>
   <Suppression>
     <DiagnosticId>CP0002</DiagnosticId>
-    <Target>M:Couchbase.EntityFrameworkCore.Storage.Internal.CouchbaseClientWrapper.GetCollectionAsync(System.String)</Target>
+    <Target>M:Couchbase.EntityFrameworkCore.Storage.Internal.CouchbaseClientWrapper.DeleteDocument(System.String,System.String,System.Threading.CancellationToken)</Target>
     <Left>lib/net10.0/Couchbase.EntityFrameworkCore.dll</Left>
     <Right>lib/net10.0/Couchbase.EntityFrameworkCore.dll</Right>
     <IsBaselineSuppression>true</IsBaselineSuppression>
   </Suppression>
   <Suppression>
     <DiagnosticId>CP0002</DiagnosticId>
-    <Target>M:Couchbase.EntityFrameworkCore.Storage.Internal.CouchbaseClientWrapper.UpdateDocument``1(System.String,System.String,``0)</Target>
+    <Target>M:Couchbase.EntityFrameworkCore.Storage.Internal.CouchbaseClientWrapper.UpdateDocument``1(System.String,System.String,``0,System.Threading.CancellationToken)</Target>
     <Left>lib/net10.0/Couchbase.EntityFrameworkCore.dll</Left>
     <Right>lib/net10.0/Couchbase.EntityFrameworkCore.dll</Right>
     <IsBaselineSuppression>true</IsBaselineSuppression>
   </Suppression>
   <Suppression>
     <DiagnosticId>CP0002</DiagnosticId>
-    <Target>M:Couchbase.EntityFrameworkCore.Storage.Internal.ICouchbaseClientWrapper.CreateDocument``1(System.String,System.String,``0)</Target>
+    <Target>M:Couchbase.EntityFrameworkCore.Storage.Internal.CouchbaseDatabaseCreator.#ctor(Microsoft.EntityFrameworkCore.Storage.RelationalDatabaseCreatorDependencies,Microsoft.EntityFrameworkCore.Storage.IDatabase,System.IServiceProvider,Microsoft.EntityFrameworkCore.Metadata.IDesignTimeModel,Microsoft.Extensions.Logging.ILogger{Couchbase.EntityFrameworkCore.Storage.Internal.CouchbaseDatabaseCreator},Couchbase.EntityFrameworkCore.Infrastructure.ICouchbaseDbContextOptionsBuilder,Microsoft.EntityFrameworkCore.Storage.ISqlGenerationHelper)</Target>
     <Left>lib/net10.0/Couchbase.EntityFrameworkCore.dll</Left>
     <Right>lib/net10.0/Couchbase.EntityFrameworkCore.dll</Right>
     <IsBaselineSuppression>true</IsBaselineSuppression>
   </Suppression>
   <Suppression>
     <DiagnosticId>CP0002</DiagnosticId>
-    <Target>M:Couchbase.EntityFrameworkCore.Storage.Internal.ICouchbaseClientWrapper.DeleteDocument(System.String,System.String)</Target>
+    <Target>M:Couchbase.EntityFrameworkCore.Storage.Internal.CouchbaseDatabaseWrapper.#ctor(Microsoft.EntityFrameworkCore.Storage.DatabaseDependencies,Couchbase.EntityFrameworkCore.Storage.Internal.ICouchbaseClientWrapper,Microsoft.EntityFrameworkCore.Storage.IRelationalConnection,Couchbase.EntityFrameworkCore.Infrastructure.ICouchbaseDbContextOptionsBuilder)</Target>
     <Left>lib/net10.0/Couchbase.EntityFrameworkCore.dll</Left>
     <Right>lib/net10.0/Couchbase.EntityFrameworkCore.dll</Right>
     <IsBaselineSuppression>true</IsBaselineSuppression>
   </Suppression>
   <Suppression>
     <DiagnosticId>CP0002</DiagnosticId>
-    <Target>M:Couchbase.EntityFrameworkCore.Storage.Internal.ICouchbaseClientWrapper.EnqueueTransactionalInsert``1(Couchbase.EntityFrameworkCore.Storage.Internal.CouchbaseDbTransaction,System.String,System.String,``0)</Target>
+    <Target>M:Couchbase.EntityFrameworkCore.Storage.Internal.CouchbaseTypeMappingSource.#ctor(Microsoft.EntityFrameworkCore.Storage.TypeMappingSourceDependencies,Microsoft.EntityFrameworkCore.Storage.RelationalTypeMappingSourceDependencies)</Target>
     <Left>lib/net10.0/Couchbase.EntityFrameworkCore.dll</Left>
     <Right>lib/net10.0/Couchbase.EntityFrameworkCore.dll</Right>
     <IsBaselineSuppression>true</IsBaselineSuppression>
   </Suppression>
   <Suppression>
     <DiagnosticId>CP0002</DiagnosticId>
-    <Target>M:Couchbase.EntityFrameworkCore.Storage.Internal.ICouchbaseClientWrapper.EnqueueTransactionalRemove(Couchbase.EntityFrameworkCore.Storage.Internal.CouchbaseDbTransaction,System.String,System.String)</Target>
+    <Target>M:Couchbase.EntityFrameworkCore.Storage.Internal.ICouchbaseClientWrapper.CreateDocument``1(System.String,System.String,``0,System.Threading.CancellationToken)</Target>
     <Left>lib/net10.0/Couchbase.EntityFrameworkCore.dll</Left>
     <Right>lib/net10.0/Couchbase.EntityFrameworkCore.dll</Right>
     <IsBaselineSuppression>true</IsBaselineSuppression>
   </Suppression>
   <Suppression>
     <DiagnosticId>CP0002</DiagnosticId>
-    <Target>M:Couchbase.EntityFrameworkCore.Storage.Internal.ICouchbaseClientWrapper.EnqueueTransactionalUpsert``1(Couchbase.EntityFrameworkCore.Storage.Internal.CouchbaseDbTransaction,System.String,System.String,``0)</Target>
+    <Target>M:Couchbase.EntityFrameworkCore.Storage.Internal.ICouchbaseClientWrapper.DeleteDocument(System.String,System.String,System.Threading.CancellationToken)</Target>
     <Left>lib/net10.0/Couchbase.EntityFrameworkCore.dll</Left>
     <Right>lib/net10.0/Couchbase.EntityFrameworkCore.dll</Right>
     <IsBaselineSuppression>true</IsBaselineSuppression>
   </Suppression>
   <Suppression>
     <DiagnosticId>CP0002</DiagnosticId>
-    <Target>M:Couchbase.EntityFrameworkCore.Storage.Internal.ICouchbaseClientWrapper.GetCollectionAsync(System.String)</Target>
-    <Left>lib/net10.0/Couchbase.EntityFrameworkCore.dll</Left>
-    <Right>lib/net10.0/Couchbase.EntityFrameworkCore.dll</Right>
-    <IsBaselineSuppression>true</IsBaselineSuppression>
-  </Suppression>
-  <Suppression>
-    <DiagnosticId>CP0002</DiagnosticId>
-    <Target>M:Couchbase.EntityFrameworkCore.Storage.Internal.ICouchbaseClientWrapper.UpdateDocument``1(System.String,System.String,``0)</Target>
+    <Target>M:Couchbase.EntityFrameworkCore.Storage.Internal.ICouchbaseClientWrapper.UpdateDocument``1(System.String,System.String,``0,System.Threading.CancellationToken)</Target>
     <Left>lib/net10.0/Couchbase.EntityFrameworkCore.dll</Left>
     <Right>lib/net10.0/Couchbase.EntityFrameworkCore.dll</Right>
     <IsBaselineSuppression>true</IsBaselineSuppression>
@@ -136,49 +115,42 @@
   </Suppression>
   <Suppression>
     <DiagnosticId>CP0006</DiagnosticId>
-    <Target>M:Couchbase.EntityFrameworkCore.Storage.Internal.ICouchbaseClientWrapper.DeleteDocument(System.String,System.String,System.Threading.CancellationToken)</Target>
+    <Target>M:Couchbase.EntityFrameworkCore.Storage.Internal.ICouchbaseClientWrapper.DeleteDocument(System.String,System.String,System.Nullable{System.UInt64},System.Threading.CancellationToken)</Target>
     <Left>lib/net10.0/Couchbase.EntityFrameworkCore.dll</Left>
     <Right>lib/net10.0/Couchbase.EntityFrameworkCore.dll</Right>
     <IsBaselineSuppression>true</IsBaselineSuppression>
   </Suppression>
   <Suppression>
     <DiagnosticId>CP0006</DiagnosticId>
-    <Target>M:Couchbase.EntityFrameworkCore.Storage.Internal.ICouchbaseClientWrapper.EnqueueTransactionalInsert``1(Couchbase.EntityFrameworkCore.Storage.Internal.CouchbaseDbTransaction,System.String,System.String,``0,System.Threading.CancellationToken)</Target>
+    <Target>M:Couchbase.EntityFrameworkCore.Storage.Internal.ICouchbaseClientWrapper.UpdateDocument``1(System.String,System.String,``0,System.Nullable{System.UInt64},System.Threading.CancellationToken)</Target>
     <Left>lib/net10.0/Couchbase.EntityFrameworkCore.dll</Left>
     <Right>lib/net10.0/Couchbase.EntityFrameworkCore.dll</Right>
     <IsBaselineSuppression>true</IsBaselineSuppression>
   </Suppression>
   <Suppression>
     <DiagnosticId>CP0006</DiagnosticId>
-    <Target>M:Couchbase.EntityFrameworkCore.Storage.Internal.ICouchbaseClientWrapper.EnqueueTransactionalRemove(Couchbase.EntityFrameworkCore.Storage.Internal.CouchbaseDbTransaction,System.String,System.String,System.Threading.CancellationToken)</Target>
+    <Target>P:Couchbase.EntityFrameworkCore.Infrastructure.ICouchbaseDbContextOptionsBuilder.AutoCreateIndexes</Target>
     <Left>lib/net10.0/Couchbase.EntityFrameworkCore.dll</Left>
     <Right>lib/net10.0/Couchbase.EntityFrameworkCore.dll</Right>
     <IsBaselineSuppression>true</IsBaselineSuppression>
   </Suppression>
   <Suppression>
     <DiagnosticId>CP0006</DiagnosticId>
-    <Target>M:Couchbase.EntityFrameworkCore.Storage.Internal.ICouchbaseClientWrapper.EnqueueTransactionalUpsert``1(Couchbase.EntityFrameworkCore.Storage.Internal.CouchbaseDbTransaction,System.String,System.String,``0,System.Threading.CancellationToken)</Target>
+    <Target>P:Couchbase.EntityFrameworkCore.Infrastructure.ICouchbaseDbContextOptionsBuilder.DateTimeFormat</Target>
     <Left>lib/net10.0/Couchbase.EntityFrameworkCore.dll</Left>
     <Right>lib/net10.0/Couchbase.EntityFrameworkCore.dll</Right>
     <IsBaselineSuppression>true</IsBaselineSuppression>
   </Suppression>
   <Suppression>
     <DiagnosticId>CP0006</DiagnosticId>
-    <Target>M:Couchbase.EntityFrameworkCore.Storage.Internal.ICouchbaseClientWrapper.GetCollectionAsync(System.String,System.Threading.CancellationToken)</Target>
+    <Target>P:Couchbase.EntityFrameworkCore.Infrastructure.ICouchbaseDbContextOptionsBuilder.GoDateTimeFormat</Target>
     <Left>lib/net10.0/Couchbase.EntityFrameworkCore.dll</Left>
     <Right>lib/net10.0/Couchbase.EntityFrameworkCore.dll</Right>
     <IsBaselineSuppression>true</IsBaselineSuppression>
   </Suppression>
   <Suppression>
-    <DiagnosticId>CP0006</DiagnosticId>
-    <Target>M:Couchbase.EntityFrameworkCore.Storage.Internal.ICouchbaseClientWrapper.UpdateDocument``1(System.String,System.String,``0,System.Threading.CancellationToken)</Target>
-    <Left>lib/net10.0/Couchbase.EntityFrameworkCore.dll</Left>
-    <Right>lib/net10.0/Couchbase.EntityFrameworkCore.dll</Right>
-    <IsBaselineSuppression>true</IsBaselineSuppression>
-  </Suppression>
-  <Suppression>
-    <DiagnosticId>CP0006</DiagnosticId>
-    <Target>P:Couchbase.EntityFrameworkCore.Infrastructure.ICouchbaseDbContextOptionsBuilder.ServiceKey</Target>
+    <DiagnosticId>CP0009</DiagnosticId>
+    <Target>T:Couchbase.EntityFrameworkCore.Query.Internal.Translators.CouchbaseMethodCallTranslatorProvider</Target>
     <Left>lib/net10.0/Couchbase.EntityFrameworkCore.dll</Left>
     <Right>lib/net10.0/Couchbase.EntityFrameworkCore.dll</Right>
     <IsBaselineSuppression>true</IsBaselineSuppression>

--- a/src/Couchbase.EntityFrameworkCore/Couchbase.EntityFrameworkCore.csproj
+++ b/src/Couchbase.EntityFrameworkCore/Couchbase.EntityFrameworkCore.csproj
@@ -8,7 +8,7 @@
         <!-- EF1001 flags use of EF Core internal APIs. A database provider must use these by
              design, so suppress it project-wide (keeping the warning would bury real warnings). -->
         <NoWarn>$(NoWarn);EF1001</NoWarn>
-        <Version>2.0.0-beta.2</Version>
+        <Version>2.0.0-beta.3</Version>
         <Title>EF Core Couchbase DB Provider</Title>
         <Authors>Couchbase, Inc.</Authors>
         <Copyright>Couchbase, Inc. (c) 2026</Copyright>
@@ -66,18 +66,32 @@
              - CouchbaseQueryEnumerable.Create and CouchbaseQueryEnumerable<T>'s constructor
                (2026-07-14, multi-bucket DI work) gained parameters, which shows up as CP0002 only
                (the old signature no longer exists) since it's a concrete class, not an interface.
-             ICouchbaseClientWrapper, CouchbaseClientWrapper, and CouchbaseQueryEnumerable all live
-             under a ".Storage.Internal"/".Query.Internal" namespace and are provider-plumbing, not
-             part of the supported public surface — the same spirit as the project-wide EF1001
-             suppression above.
+             - CouchbaseFromSqlQueryingEnumerable.Create and its constructor (added 2026-08-10,
+               per-query RYOW work): same CP0002 shape as CouchbaseQueryEnumerable above, gained a
+               consistentWithParameterName parameter.
+             ICouchbaseClientWrapper, CouchbaseClientWrapper, CouchbaseQueryEnumerable, and
+             CouchbaseFromSqlQueryingEnumerable all live under a ".Storage.Internal"/".Query.Internal"
+             namespace and are provider-plumbing, not part of the supported public surface — the
+             same spirit as the project-wide EF1001 suppression above.
 
              CP0003 (strong-name difference) previously needed suppressing because the release
              assembly used to be signed manually *after* compilation, so the in-build assembly
              ApiCompat saw was unsigned. Removed 2026-07-14 now that SignRelease=true signs
              in-process — verified locally that a signed build produces the same strong name as the
-             baseline, so ApiCompat sees no difference there anymore. -->
+             baseline, so ApiCompat sees no difference there anymore.
+
+             PackageValidationBaselineVersion was left at 2.0.0-beta.1 through the entire 2.0.0-beta.2
+             development cycle instead of being bumped when beta.2 shipped (2026-07-15) as this
+             comment already instructed — several features landed in that window (AutoCreateIndexes,
+             DateTimeFormat/GoDateTimeFormat, a sealed-modifier fix, and a handful of internal ctor
+             signature changes) with no corresponding suppression entries, since nobody was running
+             this check against the actual just-shipped baseline to catch them. Bumped to 2.0.0-beta.2
+             now, for the beta.3 cut, and the accumulated gap was reconciled in CompatibilitySuppressions.xml
+             at the same time (all in the ".Storage.Internal"/".Query.Internal" provider-plumbing
+             namespaces, or new interface members, matching the existing precedent above — no
+             suppression covers a change to genuinely public, user-facing API). -->
         <EnablePackageValidation Condition="'$(ValidateApiCompat)' == 'true'">true</EnablePackageValidation>
-        <PackageValidationBaselineVersion>2.0.0-beta.1</PackageValidationBaselineVersion>
+        <PackageValidationBaselineVersion>2.0.0-beta.2</PackageValidationBaselineVersion>
     </PropertyGroup>
 
     <ItemGroup>


### PR DESCRIPTION
Bump the package version and reconcile CompatibilitySuppressions.xml against a real signed build compared to the 2.0.0-beta.2 baseline, which had gone stale for the entire beta.2 cycle. Close out the CHANGELOG's [Unreleased] section into [2.0.0-beta.3], covering the 25 features that accumulated since beta.2 shipped.